### PR TITLE
Add a platform to ignore messages not from the thread

### DIFF
--- a/app/Http/Controllers/TelegramBotController.php
+++ b/app/Http/Controllers/TelegramBotController.php
@@ -30,8 +30,10 @@ class TelegramBotController
 
         if ($this->dataHook->typeSource === 'private') {
             $this->platform = 'telegram';
-        } else {
+        } else if (!empty($this->dataHook->messageThreadId)) {
             $this->platform = BotUser::getPlatformByTopicId($this->dataHook->messageThreadId);
+        } else {
+            $this->platform = 'ignore';
         }
     }
 
@@ -74,6 +76,9 @@ class TelegramBotController
                 case 'vk':
                     $this->controllerPlatformVk();
                     break;
+
+                case 'ignore':
+                    return;
 
                 default:
                     $this->controllerExternalPlatform();


### PR DESCRIPTION
MR to issue #45 #29 
Забивалась очередь из-за того что система отадавала ошибку и телеграм пытался повторить запрос, в нашем случае это было из-за того что в getPlatformByTopicId передавался null. Данный MR позволяет отпустить телеграм в случае если сообщение не имеет messageThreadId. 