### PR TITLE
fix namespace does not comply with psr-4 autoloading standard

### DIFF
--- a/app/DTOs/Vk/VkTextMessageDto.php
+++ b/app/DTOs/Vk/VkTextMessageDto.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\DTOs\VK;
+namespace App\DTOs\Vk;
 
 use Spatie\LaravelData\Data;
 


### PR DESCRIPTION
Fix message from composer after install `Class App\DTOs\VK\VkTextMessageDto located in ./app/DTOs/Vk/VkTextMessageDto.php does not comply with psr-4 autoloading standard`
Namespace in VkTextMessageDto.php has wrong folder name