### PR TITLE
issues-132 | fix(tests): stub AiSystemPromptLoader in legacy AI job tests

### DIFF
--- a/tests/Feature/Jobs/SendAiResponseMessageJobTest.php
+++ b/tests/Feature/Jobs/SendAiResponseMessageJobTest.php
@@ -3,13 +3,14 @@
 namespace Tests\Feature\Jobs;
 
 use App\Models\BotUser;
+use App\Modules\Ai\Services\AiSystemPromptLoader;
 use App\Modules\Telegram\Jobs\SendAiResponseMessageJob;
 use App\Modules\Telegram\Jobs\SendAiTelegramMessageJob;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Queue;
-use Illuminate\Support\Facades\Storage;
+use Mockery;
 use Tests\Mocks\Tg\TelegramUpdateDtoMock;
 use Tests\TestCase;
 
@@ -29,13 +30,20 @@ class SendAiResponseMessageJobTest extends TestCase
 
         Config::set('ai.providers.gigachat.client_secret', 'test_secret');
 
-        Storage::fake('prompts');
-        Storage::disk('prompts')->put('basic.txt', 'System prompt');
+        $loader = Mockery::mock(AiSystemPromptLoader::class);
+        $loader->shouldReceive('render')->andReturn('System prompt');
+        $this->app->instance(AiSystemPromptLoader::class, $loader);
 
         $chatId = time();
         $this->botUser = BotUser::getUserByChatId($chatId, 'telegram');
 
         $this->baseProviderUrl = config('ai.providers.gigachat.base_url');
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
     }
 
     public function test_success_send_creates_message_record(): void

--- a/tests/Feature/Jobs/SendAiTelegramMessageJobTest.php
+++ b/tests/Feature/Jobs/SendAiTelegramMessageJobTest.php
@@ -5,13 +5,14 @@ namespace Tests\Feature\Jobs;
 use App\Models\BotUser;
 use App\Modules\Ai\DTOs\AiRequestDto;
 use App\Modules\Ai\Services\AiAssistantService;
+use App\Modules\Ai\Services\AiSystemPromptLoader;
 use App\Modules\Telegram\Jobs\SendAiTelegramMessageJob;
 use App\Modules\Telegram\Jobs\SendTelegramMessageJob;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Queue;
-use Illuminate\Support\Facades\Storage;
+use Mockery;
 use Tests\Mocks\Tg\TelegramUpdateDtoMock;
 use Tests\TestCase;
 
@@ -37,8 +38,9 @@ class SendAiTelegramMessageJobTest extends TestCase
 
         Config::set('ai.providers.gigachat.client_secret', 'test_secret');
 
-        Storage::fake('prompts');
-        Storage::disk('prompts')->put('basic.txt', 'System prompt');
+        $loader = Mockery::mock(AiSystemPromptLoader::class);
+        $loader->shouldReceive('render')->andReturn('System prompt');
+        $this->app->instance(AiSystemPromptLoader::class, $loader);
 
         $this->groupId = time();
         config(['traffic_source.settings.telegram.group_id' => $this->groupId]);
@@ -50,6 +52,12 @@ class SendAiTelegramMessageJobTest extends TestCase
 
         $this->provider = 'gigachat';
         $this->baseProviderUrl = config('ai.providers.gigachat.base_url');
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
     }
 
     public function test_success_send_creates_message_record(): void


### PR DESCRIPTION
## Summary

Hotfix для CI на PR #135 (`dev → main`). `SendAiResponseMessageJobTest` и `SendAiTelegramMessageJobTest` всё ещё стабали legacy-источник system prompt (`Storage::disk('prompts')->put('basic.txt', ...)`), который не используется после рефакторинга #132. После переезда на `AiSystemPromptLoader::render()` → `View::file(config('ai.system_prompt_path'))->render()` тесты пытались прочитать реальный `resources/ai/system-prompt.blade.php`, который теперь gitignore'нут (каждый environment подкладывает свой) и отсутствует в CI. `View::file` бросал `InvalidArgumentException`, `AiAssistantService::processMessage()` глушил его в catch-all и возвращал `null`, после чего:

- `SendAiResponseMessageJobTest` не дожидался диспатча `SendAiTelegramMessageJob` (срабатывал `if (empty($aiResponse)) throw` в `SendAiResponseMessageJob::handle()`).
- `SendAiTelegramMessageJobTest` падал на `$aiResponse->response` с `Attempt to read property "response" on null`.

## Решение

Заменил `Storage::fake('prompts')` + `put('basic.txt', ...)` на тот же Mockery-стаб, что уже использовали `OpenAiProviderTest`/`DeepSeekProviderTest`/`GigaChatProviderTest`:

```php
$loader = Mockery::mock(AiSystemPromptLoader::class);
$loader->shouldReceive('render')->andReturn('System prompt');
$this->app->instance(AiSystemPromptLoader::class, $loader);
```

Плюс `tearDown()` с `Mockery::close()` в обоих тестах. Никаких изменений в production-коде, никаких новых кейсов, никаких изменений в `Http::fake()`-стабах GigaChat и в assertion-блоках — это чистая замена test-double с disk-fake на service-mock.

## Closes
- Закрывает CI-блокер на #135.

## Test plan

- [x] `docker exec -it pet php artisan test --filter='SendAiResponseMessageJobTest|SendAiTelegramMessageJobTest'` — 2 теста, 11 assertions, зелёные.
- [x] `docker exec -it pet php artisan test` (full suite на pre-push) — 339 passed, 872 assertions.
- [x] PHPStan level 6 — 0 ошибок.
- [x] Pint — без изменений.
