### PR TITLE
[FEATURE] Форма сбора отзывов после закрытия обращения

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,6 +251,16 @@ public static function execute(BotUser $botUser): TelegramAnswerDto
 - Requests must be authenticated with a bearer token from `external_source_access_tokens`
 - When the team replies to an external user, a webhook is sent to `external_sources.webhook_url`
 
+### Feedback Form
+
+- When `CloseTopic::execute()` closes a conversation, `SendFeedbackForm` creates a `Feedback` record (`status='awaiting_rating'`) and sends a 5-star inline-keyboard rating form to the user on their platform (Telegram/VK/Max)
+- Telegram callback_data format: `feedback_rate_{botUserId}_{feedbackId}_{score}` (score 1..5) — handled in `TelegramBotController::checkBotQuery()`
+- VK rating callbacks arrive as `type=message_event` with `payload.command` containing `feedback_rate_*` — handled in `VkBotController`
+- Max rating callbacks arrive as `update_type=message_callback` with `callback.payload` containing `feedback_rate_*` — handled in `MaxBotController`
+- On rating click: `HandleFeedbackRating` saves `rating`, sets `status='completed_no_comment'`, edits message to thank-you text. `comment` stays NULL — no comment capture is implemented
+- Every close event creates a new `Feedback` record — history accumulates
+- Feedback records are viewable in Filament admin via `FeedbackResource` (read-only: List + View) and via `FeedbacksRelationManager` on the BotUser detail page
+
 ### Manager Interface
 
 - `MANAGER_INTERFACE=telegram_group` (default) — managers work via Telegram supergroup with forum topics

--- a/app/Models/BotUser.php
+++ b/app/Models/BotUser.php
@@ -248,6 +248,14 @@ class BotUser extends Model
     }
 
     /**
+     * @return HasMany
+     */
+    public function feedbacks(): HasMany
+    {
+        return $this->hasMany(Feedback::class);
+    }
+
+    /**
      * @return bool
      */
     public function isBanned(): bool

--- a/app/Models/Feedback.php
+++ b/app/Models/Feedback.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int         $id
+ * @property int         $bot_user_id
+ * @property int|null    $rating      1..5, null until user rates
+ * @property string|null $comment     Optional text comment (nullable, reserved for future use)
+ * @property string      $status      'awaiting_rating' | 'completed_no_comment'
+ * @property string|null $closed_at   Timestamp when the conversation was closed
+ * @property string      $created_at
+ * @property string      $updated_at
+ */
+class Feedback extends Model
+{
+    use HasFactory;
+
+    protected $table = 'feedbacks';
+
+    protected $fillable = [
+        'bot_user_id',
+        'rating',
+        'comment',
+        'status',
+        'closed_at',
+    ];
+
+    protected $casts = [
+        'rating' => 'integer',
+        'closed_at' => 'datetime',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    /**
+     * @return BelongsTo
+     */
+    public function botUser(): BelongsTo
+    {
+        return $this->belongsTo(BotUser::class);
+    }
+}

--- a/app/Modules/Admin/Filament/Resources/BotUserResource.php
+++ b/app/Modules/Admin/Filament/Resources/BotUserResource.php
@@ -4,9 +4,12 @@ namespace App\Modules\Admin\Filament\Resources;
 
 use App\Models\BotUser;
 use App\Modules\Admin\Filament\Resources\BotUserResource\Pages\ListBotUsers;
+use App\Modules\Admin\Filament\Resources\BotUserResource\Pages\ViewBotUser;
+use App\Modules\Admin\Filament\Resources\BotUserResource\RelationManagers\FeedbacksRelationManager;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables\Actions\Action;
+use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 
@@ -54,6 +57,7 @@ class BotUserResource extends Resource
             ])
             ->filters([])
             ->actions([
+                ViewAction::make(),
                 Action::make('ban')
                     ->label('Заблокировать')
                     ->icon('heroicon-o-no-symbol')
@@ -83,6 +87,17 @@ class BotUserResource extends Resource
     {
         return [
             'index' => ListBotUsers::route('/'),
+            'view' => ViewBotUser::route('/{record}'),
+        ];
+    }
+
+    /**
+     * @return array<class-string<\Filament\Resources\RelationManagers\RelationManager>>
+     */
+    public static function getRelationManagers(): array
+    {
+        return [
+            FeedbacksRelationManager::class,
         ];
     }
 }

--- a/app/Modules/Admin/Filament/Resources/BotUserResource/Pages/ViewBotUser.php
+++ b/app/Modules/Admin/Filament/Resources/BotUserResource/Pages/ViewBotUser.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Modules\Admin\Filament\Resources\BotUserResource\Pages;
+
+use App\Modules\Admin\Filament\Resources\BotUserResource;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewBotUser extends ViewRecord
+{
+    protected static string $resource = BotUserResource::class;
+}

--- a/app/Modules/Admin/Filament/Resources/BotUserResource/RelationManagers/FeedbacksRelationManager.php
+++ b/app/Modules/Admin/Filament/Resources/BotUserResource/RelationManagers/FeedbacksRelationManager.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Modules\Admin\Filament\Resources\BotUserResource\RelationManagers;
+
+use Filament\Forms\Form;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class FeedbacksRelationManager extends RelationManager
+{
+    protected static string $relationship = 'feedbacks';
+
+    protected static ?string $title = 'История отзывов';
+
+    public function form(Form $form): Form
+    {
+        return $form->schema([]);
+    }
+
+    /**
+     * @param Table $table
+     *
+     * @return Table
+     */
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('rating')
+                    ->label('Оценка')
+                    ->sortable()
+                    ->formatStateUsing(fn (?int $state): string => $state !== null ? str_repeat('⭐', $state) . " ({$state})" : '—'),
+                TextColumn::make('comment')
+                    ->label('Комментарий')
+                    ->limit(60)
+                    ->placeholder('—'),
+                TextColumn::make('status')
+                    ->label('Статус')
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        'awaiting_rating' => 'warning',
+                        'completed_no_comment' => 'success',
+                        default => 'gray',
+                    })
+                    ->formatStateUsing(fn (string $state): string => match ($state) {
+                        'awaiting_rating' => 'Ожидает оценки',
+                        'completed_no_comment' => 'Оценён',
+                        default => $state,
+                    }),
+                TextColumn::make('closed_at')
+                    ->label('Закрыто')
+                    ->dateTime('d.m.Y H:i')
+                    ->sortable(),
+                TextColumn::make('created_at')
+                    ->label('Создано')
+                    ->dateTime('d.m.Y H:i')
+                    ->sortable(),
+            ])
+            ->defaultSort('created_at', 'desc');
+    }
+
+    /**
+     * Read-only relation manager — no create or edit allowed.
+     *
+     * @return bool
+     */
+    public function canCreate(): bool
+    {
+        return false;
+    }
+}

--- a/app/Modules/Admin/Filament/Resources/FeedbackResource.php
+++ b/app/Modules/Admin/Filament/Resources/FeedbackResource.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace App\Modules\Admin\Filament\Resources;
+
+use App\Models\Feedback;
+use App\Modules\Admin\Filament\Resources\FeedbackResource\Pages\ListFeedbacks;
+use App\Modules\Admin\Filament\Resources\FeedbackResource\Pages\ViewFeedback;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+
+class FeedbackResource extends Resource
+{
+    protected static ?string $model = Feedback::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-star';
+
+    protected static ?string $navigationLabel = 'Отзывы';
+
+    protected static ?string $modelLabel = 'Отзыв';
+
+    protected static ?string $pluralModelLabel = 'Отзывы';
+
+    protected static ?int $navigationSort = 4;
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([]);
+    }
+
+    /**
+     * @param Table $table
+     *
+     * @return Table
+     */
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('botUser.chat_id')
+                    ->label('User (Chat ID)')
+                    ->sortable()
+                    ->searchable(),
+                TextColumn::make('botUser.platform')
+                    ->label('Платформа')
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        'telegram' => 'info',
+                        'vk' => 'primary',
+                        'max' => 'success',
+                        default => 'warning',
+                    }),
+                TextColumn::make('rating')
+                    ->label('Оценка')
+                    ->sortable()
+                    ->formatStateUsing(fn (?int $state): string => $state !== null ? str_repeat('⭐', $state) . " ({$state})" : '—'),
+                TextColumn::make('comment')
+                    ->label('Комментарий')
+                    ->limit(60)
+                    ->placeholder('—'),
+                TextColumn::make('closed_at')
+                    ->label('Закрыто')
+                    ->dateTime('d.m.Y H:i')
+                    ->sortable(),
+                TextColumn::make('status')
+                    ->label('Статус')
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        'awaiting_rating' => 'warning',
+                        'completed_no_comment' => 'success',
+                        default => 'gray',
+                    })
+                    ->formatStateUsing(fn (string $state): string => match ($state) {
+                        'awaiting_rating' => 'Ожидает оценки',
+                        'completed_no_comment' => 'Оценён',
+                        default => $state,
+                    }),
+            ])
+            ->filters([
+                SelectFilter::make('rating')
+                    ->label('Оценка')
+                    ->options([
+                        1 => '⭐ 1',
+                        2 => '⭐⭐ 2',
+                        3 => '⭐⭐⭐ 3',
+                        4 => '⭐⭐⭐⭐ 4',
+                        5 => '⭐⭐⭐⭐⭐ 5',
+                    ]),
+                SelectFilter::make('status')
+                    ->label('Статус')
+                    ->options([
+                        'awaiting_rating' => 'Ожидает оценки',
+                        'completed_no_comment' => 'Оценён',
+                    ]),
+                SelectFilter::make('platform')
+                    ->label('Платформа')
+                    ->relationship('botUser', 'platform')
+                    ->options([
+                        'telegram' => 'Telegram',
+                        'vk' => 'VK',
+                        'max' => 'Max',
+                    ]),
+            ])
+            ->defaultSort('created_at', 'desc');
+    }
+
+    /**
+     * @return array<string, \Filament\Resources\Pages\PageRegistration>
+     */
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListFeedbacks::route('/'),
+            'view' => ViewFeedback::route('/{record}'),
+        ];
+    }
+
+    /**
+     * Feedback records are read-only — no create, edit, or delete actions.
+     *
+     * @return bool
+     */
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+}

--- a/app/Modules/Admin/Filament/Resources/FeedbackResource/Pages/ListFeedbacks.php
+++ b/app/Modules/Admin/Filament/Resources/FeedbackResource/Pages/ListFeedbacks.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Modules\Admin\Filament\Resources\FeedbackResource\Pages;
+
+use App\Modules\Admin\Filament\Resources\FeedbackResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListFeedbacks extends ListRecords
+{
+    protected static string $resource = FeedbackResource::class;
+}

--- a/app/Modules/Admin/Filament/Resources/FeedbackResource/Pages/ViewFeedback.php
+++ b/app/Modules/Admin/Filament/Resources/FeedbackResource/Pages/ViewFeedback.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Modules\Admin\Filament\Resources\FeedbackResource\Pages;
+
+use App\Modules\Admin\Filament\Resources\FeedbackResource;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewFeedback extends ViewRecord
+{
+    protected static string $resource = FeedbackResource::class;
+}

--- a/app/Modules/Feedback/Actions/HandleFeedbackRating.php
+++ b/app/Modules/Feedback/Actions/HandleFeedbackRating.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Modules\Feedback\Actions;
+
+use App\Models\Feedback;
+use App\Modules\Telegram\DTOs\TGTextMessageDto;
+use App\Modules\Telegram\Jobs\SendTelegramSimpleQueryJob;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Handle user's rating callback for a feedback form.
+ *
+ * Parses the callback_data / payload (format: feedback_rate_{botUserId}_{feedbackId}_{score}),
+ * saves the rating on the Feedback record, sets status='completed_no_comment',
+ * and edits the original message text to a thank-you string.
+ *
+ * Called from:
+ * - TelegramBotController::checkBotQuery() for Telegram callback_query
+ * - VkBotController::bot_query() for VK message_event
+ * - MaxBotController::bot_query() for Max message_callback
+ */
+class HandleFeedbackRating
+{
+    /**
+     * Process a rating callback.
+     *
+     * @param string   $callbackData Raw callback string (feedback_rate_{botUserId}_{feedbackId}_{score})
+     * @param int|null $messageId    Message ID to edit (Telegram only; null for VK/Max)
+     * @param int|null $chatId       Chat ID for Telegram editMessageText (user's private chat)
+     *
+     * @return void
+     */
+    public function execute(string $callbackData, ?int $messageId = null, ?int $chatId = null): void
+    {
+        $parsed = $this->parseCallbackData($callbackData);
+        if ($parsed === null) {
+            Log::channel('loki')->warning('HandleFeedbackRating: invalid callback_data', [
+                'source' => 'feedback_rating_invalid',
+                'callback_data' => $callbackData,
+            ]);
+            return;
+        }
+
+        ['feedbackId' => $feedbackId, 'score' => $score] = $parsed;
+
+        $feedback = Feedback::find($feedbackId);
+        if ($feedback === null) {
+            Log::channel('loki')->warning('HandleFeedbackRating: feedback record not found', [
+                'source' => 'feedback_rating_not_found',
+                'feedback_id' => $feedbackId,
+            ]);
+            return;
+        }
+
+        $feedback->update([
+            'rating' => $score,
+            'status' => 'completed_no_comment',
+        ]);
+
+        Log::channel('loki')->info('HandleFeedbackRating: rating saved', [
+            'source' => 'feedback_rating_saved',
+            'feedback_id' => $feedbackId,
+            'rating' => $score,
+            'bot_user_id' => $feedback->bot_user_id,
+        ]);
+
+        // Edit the original feedback form message to a thank-you text if Telegram message context is available
+        if ($messageId !== null && $chatId !== null) {
+            // TODO: move text to lang/ru/messages.php when i18n infrastructure is added
+            $thankYouText = 'Спасибо за отзыв! Ваша оценка принята.';
+
+            SendTelegramSimpleQueryJob::dispatch(TGTextMessageDto::from([
+                'methodQuery' => 'editMessageText',
+                'chat_id' => $chatId,
+                'message_id' => $messageId,
+                'text' => $thankYouText,
+                'parse_mode' => 'html',
+                'reply_markup' => ['inline_keyboard' => []],
+            ]));
+        }
+    }
+
+    /**
+     * Parse callback_data string.
+     *
+     * Expected format: feedback_rate_{botUserId}_{feedbackId}_{score}
+     *
+     * @param string $callbackData
+     *
+     * @return array{botUserId: int, feedbackId: int, score: int}|null
+     */
+    public function parseCallbackData(string $callbackData): ?array
+    {
+        if (!preg_match('/^feedback_rate_(\d+)_(\d+)_([1-5])$/', $callbackData, $matches)) {
+            return null;
+        }
+
+        return [
+            'botUserId' => (int) $matches[1],
+            'feedbackId' => (int) $matches[2],
+            'score' => (int) $matches[3],
+        ];
+    }
+}

--- a/app/Modules/Feedback/Actions/SendFeedbackForm.php
+++ b/app/Modules/Feedback/Actions/SendFeedbackForm.php
@@ -1,0 +1,235 @@
+<?php
+
+namespace App\Modules\Feedback\Actions;
+
+use App\Models\BotUser;
+use App\Models\Feedback;
+use App\Modules\Max\DTOs\MaxTextMessageDto;
+use App\Modules\Max\Jobs\SendMaxMessageJob;
+use App\Modules\Telegram\DTOs\TGTextMessageDto;
+use App\Modules\Telegram\Jobs\SendTelegramSimpleQueryJob;
+use App\Modules\Vk\DTOs\VkTextMessageDto;
+use App\Modules\Vk\Jobs\SendVkSimpleMessageJob;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Send the post-close feedback form to the user on their platform.
+ *
+ * Creates a Feedback record with status='awaiting_rating' and dispatches
+ * a platform-appropriate message carrying the rating keyboard.
+ *
+ * Platform delivery:
+ * - telegram — SendTelegramSimpleQueryJob with inline_keyboard (5 star buttons)
+ * - vk       — SendVkSimpleMessageJob with VK callback keyboard (5 buttons)
+ * - max      — SendMaxMessageJob with Max inline keyboard (5 buttons)
+ *
+ * callback_data / payload format: feedback_rate_{botUserId}_{score}
+ * e.g. feedback_rate_42_3
+ */
+class SendFeedbackForm
+{
+    /**
+     * Send feedback form to the user after their conversation is closed.
+     *
+     * @param BotUser $botUser The user whose conversation was just closed.
+     *
+     * @return void
+     */
+    public function execute(BotUser $botUser): void
+    {
+        $feedback = Feedback::create([
+            'bot_user_id' => $botUser->id,
+            'status' => 'awaiting_rating',
+            'closed_at' => now(),
+        ]);
+
+        Log::channel('loki')->info('SendFeedbackForm: created feedback record', [
+            'source' => 'feedback_form_created',
+            'bot_user_id' => $botUser->id,
+            'feedback_id' => $feedback->id,
+            'platform' => $botUser->platform,
+        ]);
+
+        switch ($botUser->platform) {
+            case 'telegram':
+                $this->sendTelegram($botUser, $feedback->id);
+                break;
+
+            case 'vk':
+                $this->sendVk($botUser, $feedback->id);
+                break;
+
+            case 'max':
+                $this->sendMax($botUser, $feedback->id);
+                break;
+
+            default:
+                Log::channel('loki')->warning('SendFeedbackForm: unsupported platform, skipping delivery', [
+                    'source' => 'feedback_form_unsupported_platform',
+                    'bot_user_id' => $botUser->id,
+                    'platform' => $botUser->platform,
+                ]);
+                break;
+        }
+    }
+
+    /**
+     * Send Telegram inline keyboard with 5 star rating buttons.
+     *
+     * @param BotUser $botUser
+     * @param int     $feedbackId
+     *
+     * @return void
+     */
+    private function sendTelegram(BotUser $botUser, int $feedbackId): void
+    {
+        // TODO: move text to lang/ru/messages.php when i18n infrastructure is added
+        $text = 'Пожалуйста, оцените качество нашей поддержки:';
+
+        $keyboard = $this->buildTelegramKeyboard($botUser->id, $feedbackId);
+
+        SendTelegramSimpleQueryJob::dispatch(TGTextMessageDto::from([
+            'methodQuery' => 'sendMessage',
+            'chat_id' => $botUser->chat_id,
+            'text' => $text,
+            'parse_mode' => 'html',
+            'reply_markup' => ['inline_keyboard' => [$keyboard]],
+        ]));
+    }
+
+    /**
+     * Send VK message with inline callback keyboard (5 rating buttons).
+     *
+     * VK supports callback buttons via the `keyboard` JSON parameter on messages.send.
+     * Callback events arrive at the VK webhook as type=message_event and are routed
+     * by VkBotController to HandleFeedbackRating.
+     *
+     * @param BotUser $botUser
+     * @param int     $feedbackId
+     *
+     * @return void
+     */
+    private function sendVk(BotUser $botUser, int $feedbackId): void
+    {
+        // TODO: move text to lang/ru/messages.php when i18n infrastructure is added
+        $text = 'Пожалуйста, оцените качество нашей поддержки:';
+
+        $keyboard = $this->buildVkKeyboard($botUser->id, $feedbackId);
+
+        SendVkSimpleMessageJob::dispatch(VkTextMessageDto::from([
+            'methodQuery' => 'messages.send',
+            'peer_id' => $botUser->chat_id,
+            'message' => $text,
+            'keyboard' => json_encode($keyboard),
+        ]));
+    }
+
+    /**
+     * Send Max message with inline keyboard (5 rating buttons).
+     *
+     * Max supports inline keyboards via the keyboard array in MaxTextMessageDto.
+     * Callback events arrive as update_type=message_callback and are routed
+     * by MaxBotController to HandleFeedbackRating.
+     *
+     * @param BotUser $botUser
+     * @param int     $feedbackId
+     *
+     * @return void
+     */
+    private function sendMax(BotUser $botUser, int $feedbackId): void
+    {
+        // TODO: move text to lang/ru/messages.php when i18n infrastructure is added
+        $text = 'Пожалуйста, оцените качество нашей поддержки:';
+
+        $keyboard = $this->buildMaxKeyboard($botUser->id, $feedbackId);
+
+        SendMaxMessageJob::dispatch(
+            $botUser->id,
+            null,
+            MaxTextMessageDto::from([
+                'methodQuery' => 'sendMessage',
+                'user_id' => $botUser->chat_id,
+                'text' => $text,
+                'keyboard' => $keyboard,
+            ]),
+        );
+    }
+
+    /**
+     * Build Telegram inline keyboard row with 5 rating buttons.
+     *
+     * callback_data format: feedback_rate_{botUserId}_{feedbackId}_{score}
+     *
+     * @param int $botUserId
+     * @param int $feedbackId
+     *
+     * @return array<int, array<string, string>>
+     */
+    private function buildTelegramKeyboard(int $botUserId, int $feedbackId): array
+    {
+        $buttons = [];
+        $stars = ['⭐', '⭐⭐', '⭐⭐⭐', '⭐⭐⭐⭐', '⭐⭐⭐⭐⭐'];
+
+        for ($score = 1; $score <= 5; $score++) {
+            $buttons[] = [
+                'text' => $stars[$score - 1],
+                'callback_data' => "feedback_rate_{$botUserId}_{$feedbackId}_{$score}",
+            ];
+        }
+
+        return $buttons;
+    }
+
+    /**
+     * Build VK callback keyboard with 5 rating buttons in one row.
+     *
+     * @param int $botUserId
+     * @param int $feedbackId
+     *
+     * @return array<string, mixed>
+     */
+    private function buildVkKeyboard(int $botUserId, int $feedbackId): array
+    {
+        $buttons = [];
+        $stars = ['⭐', '⭐⭐', '⭐⭐⭐', '⭐⭐⭐⭐', '⭐⭐⭐⭐⭐'];
+
+        for ($score = 1; $score <= 5; $score++) {
+            $buttons[] = [
+                'action' => [
+                    'type' => 'callback',
+                    'label' => $stars[$score - 1],
+                    'payload' => json_encode(['command' => "feedback_rate_{$botUserId}_{$feedbackId}_{$score}"]),
+                ],
+            ];
+        }
+
+        return [
+            'inline' => true,
+            'buttons' => [$buttons],
+        ];
+    }
+
+    /**
+     * Build Max inline keyboard with 5 rating buttons in one row.
+     *
+     * @param int $botUserId
+     * @param int $feedbackId
+     *
+     * @return array<int, array<int, array<string, mixed>>>
+     */
+    private function buildMaxKeyboard(int $botUserId, int $feedbackId): array
+    {
+        $buttons = [];
+        $stars = ['⭐', '⭐⭐', '⭐⭐⭐', '⭐⭐⭐⭐', '⭐⭐⭐⭐⭐'];
+
+        for ($score = 1; $score <= 5; $score++) {
+            $buttons[] = [
+                'type' => 'callback',
+                'text' => $stars[$score - 1],
+                'payload' => "feedback_rate_{$botUserId}_{$feedbackId}_{$score}",
+            ];
+        }
+
+        return [$buttons];
+    }
+}

--- a/app/Modules/Feedback/Actions/SendFeedbackForm.php
+++ b/app/Modules/Feedback/Actions/SendFeedbackForm.php
@@ -168,11 +168,10 @@ class SendFeedbackForm
     private function buildTelegramKeyboard(int $botUserId, int $feedbackId): array
     {
         $buttons = [];
-        $stars = ['⭐', '⭐⭐', '⭐⭐⭐', '⭐⭐⭐⭐', '⭐⭐⭐⭐⭐'];
 
         for ($score = 1; $score <= 5; $score++) {
             $buttons[] = [
-                'text' => $stars[$score - 1],
+                'text' => (string) $score,
                 'callback_data' => "feedback_rate_{$botUserId}_{$feedbackId}_{$score}",
             ];
         }
@@ -191,13 +190,12 @@ class SendFeedbackForm
     private function buildVkKeyboard(int $botUserId, int $feedbackId): array
     {
         $buttons = [];
-        $stars = ['⭐', '⭐⭐', '⭐⭐⭐', '⭐⭐⭐⭐', '⭐⭐⭐⭐⭐'];
 
         for ($score = 1; $score <= 5; $score++) {
             $buttons[] = [
                 'action' => [
                     'type' => 'callback',
-                    'label' => $stars[$score - 1],
+                    'label' => (string) $score,
                     'payload' => json_encode(['command' => "feedback_rate_{$botUserId}_{$feedbackId}_{$score}"]),
                 ],
             ];
@@ -220,12 +218,11 @@ class SendFeedbackForm
     private function buildMaxKeyboard(int $botUserId, int $feedbackId): array
     {
         $buttons = [];
-        $stars = ['⭐', '⭐⭐', '⭐⭐⭐', '⭐⭐⭐⭐', '⭐⭐⭐⭐⭐'];
 
         for ($score = 1; $score <= 5; $score++) {
             $buttons[] = [
                 'type' => 'callback',
-                'text' => $stars[$score - 1],
+                'text' => (string) $score,
                 'payload' => "feedback_rate_{$botUserId}_{$feedbackId}_{$score}",
             ];
         }

--- a/app/Modules/Feedback/FeedbackServiceProvider.php
+++ b/app/Modules/Feedback/FeedbackServiceProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Modules\Feedback;
+
+use App\Modules\Feedback\Actions\HandleFeedbackRating;
+use App\Modules\Feedback\Actions\SendFeedbackForm;
+use Illuminate\Support\ServiceProvider;
+
+class FeedbackServiceProvider extends ServiceProvider
+{
+    /**
+     * Register Feedback module bindings.
+     *
+     * @return void
+     */
+    public function register(): void
+    {
+        $this->app->bind(SendFeedbackForm::class);
+        $this->app->bind(HandleFeedbackRating::class);
+    }
+
+    /**
+     * Bootstrap Feedback module.
+     *
+     * @return void
+     */
+    public function boot(): void
+    {
+        //
+    }
+}

--- a/app/Modules/Max/Controllers/MaxBotController.php
+++ b/app/Modules/Max/Controllers/MaxBotController.php
@@ -3,6 +3,7 @@
 namespace App\Modules\Max\Controllers;
 
 use App\Models\BotUser;
+use App\Modules\Feedback\Actions\HandleFeedbackRating;
 use App\Modules\Max\Actions\SendBannedMessageMax;
 use App\Modules\Max\Actions\SendStartMessageMax;
 use App\Modules\Max\DTOs\MaxUpdateDto;
@@ -55,6 +56,12 @@ class MaxBotController
 
         if ($dataHook->type === 'message_created') {
             (new MaxMessageService($dataHook))->handleUpdate();
+        } elseif ($dataHook->type === 'message_callback') {
+            // Max callback button press — check if it's a feedback rating
+            $payload = $dataHook->rawData['callback']['payload'] ?? null;
+            if ($payload !== null && str_starts_with((string) $payload, 'feedback_rate_')) {
+                app(HandleFeedbackRating::class)->execute(callbackData: (string) $payload);
+            }
         }
 
         return response('ok', 200);

--- a/app/Modules/Telegram/Actions/CloseTopic.php
+++ b/app/Modules/Telegram/Actions/CloseTopic.php
@@ -3,6 +3,7 @@
 namespace App\Modules\Telegram\Actions;
 
 use App\Models\BotUser;
+use App\Modules\Feedback\Actions\SendFeedbackForm;
 use App\Modules\Telegram\DTOs\TGTextMessageDto;
 use App\Modules\Telegram\Jobs\SendTelegramSimpleQueryJob;
 use App\Modules\Vk\DTOs\VkTextMessageDto;
@@ -50,6 +51,8 @@ class CloseTopic
             'is_closed' => true,
             'closed_at' => now(),
         ]);
+
+        app(SendFeedbackForm::class)->execute($botUser);
     }
 
     /**

--- a/app/Modules/Telegram/Actions/CloseTopic.php
+++ b/app/Modules/Telegram/Actions/CloseTopic.php
@@ -8,6 +8,7 @@ use App\Modules\Telegram\DTOs\TGTextMessageDto;
 use App\Modules\Telegram\Jobs\SendTelegramSimpleQueryJob;
 use App\Modules\Vk\DTOs\VkTextMessageDto;
 use App\Modules\Vk\Jobs\SendVkSimpleMessageJob;
+use Illuminate\Support\Facades\Log;
 
 class CloseTopic
 {
@@ -52,7 +53,16 @@ class CloseTopic
             'closed_at' => now(),
         ]);
 
-        app(SendFeedbackForm::class)->execute($botUser);
+        try {
+            app(SendFeedbackForm::class)->execute($botUser);
+        } catch (\Throwable $e) {
+            Log::channel('loki')->error('CloseTopic: feedback form delivery failed, topic close completed regardless', [
+                'source' => 'close_topic_feedback_failed',
+                'bot_user_id' => $botUser->id,
+                'platform' => $botUser->platform,
+                'error' => $e->getMessage(),
+            ]);
+        }
     }
 
     /**

--- a/app/Modules/Telegram/Controllers/TelegramBotController.php
+++ b/app/Modules/Telegram/Controllers/TelegramBotController.php
@@ -102,6 +102,9 @@ class TelegramBotController
     public function bot_query(): void
     {
         $this->checkBotQuery();
+        if ($this->dataHook->typeQuery === 'callback_query') {
+            return;
+        }
         if ($this->dataHook->editedTopicStatus && $this->dataHook->typeSource === 'supergroup') {
             SendTelegramSimpleQueryJob::dispatch(TGTextMessageDto::from([
                 'methodQuery' => 'deleteMessage',

--- a/app/Modules/Telegram/Controllers/TelegramBotController.php
+++ b/app/Modules/Telegram/Controllers/TelegramBotController.php
@@ -8,6 +8,7 @@ use App\Modules\Ai\Actions\EditAiMessage;
 use App\Modules\Ai\Jobs\SendAiDraftJob;
 use App\Modules\Ai\Jobs\SendAiReplyJob;
 use App\Modules\Ai\Services\ShouldAiReply;
+use App\Modules\Feedback\Actions\HandleFeedbackRating;
 use App\Modules\Telegram\Actions\BannedContactMessage;
 use App\Modules\Telegram\Actions\CloseTopic;
 use App\Modules\Telegram\Actions\SendAiAnswerMessage;
@@ -81,6 +82,12 @@ class TelegramBotController
                 app(BannedContactMessage::class)->execute($this->botUser, $banStatus, $this->dataHook->messageId);
             } elseif ($this->dataHook->callbackData === 'close_topic') {
                 app(CloseTopic::class)->execute($this->botUser);
+            } elseif (str_starts_with((string) $this->dataHook->callbackData, 'feedback_rate_')) {
+                app(HandleFeedbackRating::class)->execute(
+                    callbackData: (string) $this->dataHook->callbackData,
+                    messageId: $this->dataHook->messageId,
+                    chatId: $this->dataHook->typeSource === 'private' ? $this->dataHook->chatId : null,
+                );
             }
 
             return;

--- a/app/Modules/Vk/Controllers/VkBotController.php
+++ b/app/Modules/Vk/Controllers/VkBotController.php
@@ -3,6 +3,7 @@
 namespace App\Modules\Vk\Controllers;
 
 use App\Models\BotUser;
+use App\Modules\Feedback\Actions\HandleFeedbackRating;
 use App\Modules\Vk\Actions\SendBannedMessageVk;
 use App\Modules\Vk\DTOs\VkUpdateDto;
 use App\Modules\Vk\Services\VkEditService;
@@ -50,6 +51,15 @@ class VkBotController
 
             case 'message_edit':
                 (new VkEditService($dataHook))->handleUpdate();
+                break;
+
+            case 'message_event':
+                // VK callback button press — check if it's a feedback rating
+                $payload = $dataHook->rawData['object']['payload'] ?? [];
+                $command = $payload['command'] ?? null;
+                if ($command !== null && str_starts_with((string) $command, 'feedback_rate_')) {
+                    app(HandleFeedbackRating::class)->execute(callbackData: (string) $command);
+                }
                 break;
         }
 

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -4,6 +4,7 @@ return [
     App\Modules\Admin\AdminServiceProvider::class,
     App\Modules\Admin\AdminPanelProvider::class,
     App\Modules\Ai\AiServiceProvider::class,
+    App\Modules\Feedback\FeedbackServiceProvider::class,
     App\Modules\External\ExternalServiceProvider::class,
     App\Modules\Telegram\TelegramServiceProvider::class,
     App\Modules\Vk\VkServiceProvider::class,

--- a/database/migrations/2026_05_20_000001_create_feedbacks_table.php
+++ b/database/migrations/2026_05_20_000001_create_feedbacks_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('feedbacks', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('bot_user_id')->constrained('bot_users')->cascadeOnDelete();
+            $table->smallInteger('rating')->nullable();
+            $table->text('comment')->nullable();
+            $table->string('status')->default('awaiting_rating');
+            $table->timestamp('closed_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('feedbacks');
+    }
+};

--- a/rules/api/endpoints.md
+++ b/rules/api/endpoints.md
@@ -95,9 +95,27 @@ The generated JSON is the authoritative OpenAPI file. Do not write a separate `o
 | `GET` | `/admin/conversations` | session | List all conversations (`ConversationResource`) |
 | `GET` | `/admin/conversations/{id}` | session | View conversation with message history (`ViewConversation`) |
 | `GET` | `/admin/bot-users` | session | List all bot users (`BotUserResource`) |
+| `GET` | `/admin/bot-users/{id}` | session | View bot user detail with feedback history (`ViewBotUser`) |
+| `GET` | `/admin/feedbacks` | session | List all feedback records (`FeedbackResource`) |
+| `GET` | `/admin/feedbacks/{id}` | session | View single feedback record (`ViewFeedback`) |
 | `GET` | `/admin/external-sources` | session | List external sources (`ExternalSourceResource`) |
 | `GET` | `/admin/external-sources/create` | session | Create external source form |
 | `GET` | `/admin/external-sources/{id}/edit` | session | Edit external source form |
+
+### Telegram callback_data prefixes (main bot webhook)
+
+| Prefix | Handler | Description |
+|---|---|---|
+| `topic_user_ban_` | `BannedContactMessage::execute()` | Ban / unban user toggle |
+| `close_topic` | `CloseTopic::execute()` | Close conversation topic |
+| `feedback_rate_{botUserId}_{feedbackId}_{score}` | `HandleFeedbackRating::execute()` | Save user's 1..5 star rating |
+
+### VK / Max callback routing
+
+| Platform | Event type | Payload field | Handler |
+|---|---|---|---|
+| VK | `message_event` | `payload.command` | `HandleFeedbackRating` when value starts with `feedback_rate_` |
+| Max | `message_callback` | `callback.payload` | `HandleFeedbackRating` when value starts with `feedback_rate_` |
 
 ---
 

--- a/rules/database/schema.md
+++ b/rules/database/schema.md
@@ -103,11 +103,22 @@ erDiagram
         timestamps
     }
 
+    FEEDBACKS {
+        bigint id PK
+        bigint bot_user_id FK
+        smallint rating
+        text comment
+        string status
+        timestamp closed_at
+        timestamps
+    }
+
     BOT_USERS ||--o{ MESSAGES : "has many"
     MESSAGES ||--o| EXTERNAL_MESSAGES : "has one"
     BOT_USERS ||--o| EXTERNAL_USERS : "has one"
     BOT_USERS ||--o| AI_CONDITIONS : "has one"
     BOT_USERS ||--o{ AI_MESSAGES : "has many"
+    BOT_USERS ||--o{ FEEDBACKS : "has many"
     EXTERNAL_SOURCES ||--o{ EXTERNAL_SOURCE_ACCESS_TOKENS : "has many"
 ```
 
@@ -307,6 +318,35 @@ Stores AI-generated draft responses before manager review.
 **Indexes:**
 - PRIMARY on `id`
 - FOREIGN KEY `bot_user_id` → `bot_users.id` ON DELETE CASCADE
+
+---
+
+### `feedbacks`
+
+Post-close feedback records. Created when `CloseTopic::execute()` closes a conversation. One record per close event — history accumulates.
+
+| Column | Type | Nullable | Default | Description |
+|---|---|---|---|---|
+| `id` | `bigint` | No | auto | Primary key |
+| `bot_user_id` | `bigint` | No | — | FK → `bot_users.id` (cascade delete) |
+| `rating` | `smallint` | Yes | NULL | User's rating 1..5; NULL until the user rates |
+| `comment` | `text` | Yes | NULL | Optional text comment (reserved for future use) |
+| `status` | `string` | No | `awaiting_rating` | Lifecycle status (see enum below) |
+| `closed_at` | `timestamp` | Yes | NULL | Timestamp of the conversation close that triggered this record |
+| `created_at` | `timestamp` | Yes | NULL | Creation time |
+| `updated_at` | `timestamp` | Yes | NULL | Last update time |
+
+**Indexes:**
+- PRIMARY on `id`
+- FOREIGN KEY `bot_user_id` → `bot_users.id` ON DELETE CASCADE
+
+**Enums:**
+
+`feedbacks.status`
+- `awaiting_rating` — rating form was sent; user has not yet tapped a star
+- `completed_no_comment` — user submitted a rating; comment column is NULL
+
+**Migration:** `database/migrations/2026_05_20_000001_create_feedbacks_table.php`
 
 ---
 

--- a/rules/domain/bot-users.md
+++ b/rules/domain/bot-users.md
@@ -55,6 +55,12 @@ _Enforced in:_ `app/Models/BotUser.php @ getOrCreateByTelegramUpdate()`
 **BR-008** — For `external_source` platform users, an `ExternalUser` sub-record must be created or found by `external_id` + `source`.
 _Enforced in:_ `app/Models/BotUser.php @ getOrCreateExternalBotUser()`
 
+**BR-020** — When `CloseTopic::execute()` successfully closes a conversation (`is_closed = true`), a `Feedback` record with `status = 'awaiting_rating'` must be created and a rating form must be sent to the user on their platform. Every close event creates a new feedback record — history accumulates.
+_Enforced in:_ `app/Modules/Telegram/Actions/CloseTopic.php`, `app/Modules/Feedback/Actions/SendFeedbackForm.php`
+
+**BR-021** — When a user submits a feedback rating (`callback_data` prefix `feedback_rate_{botUserId}_{feedbackId}_{score}`), the `Feedback` record must be updated with `rating = score` (1..5) and `status = 'completed_no_comment'`. The original form message must be edited to a thank-you text. No comment capture is triggered — `comment` remains nullable.
+_Enforced in:_ `app/Modules/Feedback/Actions/HandleFeedbackRating.php`, `TelegramBotController::checkBotQuery()`, `VkBotController::bot_query()`, `MaxBotController::bot_query()`
+
 ---
 
 ## 4. User State Machine
@@ -115,6 +121,7 @@ The agent must use these methods to look up or create `BotUser`:
 | `messages()` | `HasMany` | `Message` |
 | `lastMessage()` | `HasOne` | `Message` (latest) |
 | `lastMessageManager()` | `HasOne` | `Message` (latest outgoing) |
+| `feedbacks()` | `HasMany` | `Feedback` |
 
 ---
 

--- a/tests/Feature/Admin/FeedbackResourceTest.php
+++ b/tests/Feature/Admin/FeedbackResourceTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\BotUser;
+use App\Models\Feedback;
+use App\Models\User;
+use App\Modules\Admin\Filament\Resources\FeedbackResource;
+use App\Modules\Admin\Filament\Resources\FeedbackResource\Pages\ListFeedbacks;
+use App\Modules\Admin\Filament\Resources\FeedbackResource\Pages\ViewFeedback;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class FeedbackResourceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected BotUser $botUser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->actingAs(User::factory()->create());
+        $this->botUser = BotUser::create(['chat_id' => 999001, 'platform' => 'telegram']);
+    }
+
+    public function test_can_render_list_page(): void
+    {
+        Livewire::test(ListFeedbacks::class)
+            ->assertSuccessful();
+    }
+
+    public function test_list_page_shows_feedback_records(): void
+    {
+        $feedback = Feedback::create([
+            'bot_user_id' => $this->botUser->id,
+            'rating' => 4,
+            'status' => 'completed_no_comment',
+            'closed_at' => now(),
+        ]);
+
+        Livewire::test(ListFeedbacks::class)
+            ->assertCanSeeTableRecords([$feedback]);
+    }
+
+    public function test_can_filter_list_by_status(): void
+    {
+        $awaiting = Feedback::create([
+            'bot_user_id' => $this->botUser->id,
+            'status' => 'awaiting_rating',
+            'closed_at' => now(),
+        ]);
+        $completed = Feedback::create([
+            'bot_user_id' => $this->botUser->id,
+            'rating' => 5,
+            'status' => 'completed_no_comment',
+            'closed_at' => now(),
+        ]);
+
+        Livewire::test(ListFeedbacks::class)
+            ->filterTable('status', 'awaiting_rating')
+            ->assertCanSeeTableRecords([$awaiting])
+            ->assertCanNotSeeTableRecords([$completed]);
+    }
+
+    public function test_can_filter_list_by_rating(): void
+    {
+        $rating4 = Feedback::create([
+            'bot_user_id' => $this->botUser->id,
+            'rating' => 4,
+            'status' => 'completed_no_comment',
+            'closed_at' => now(),
+        ]);
+        $rating2 = Feedback::create([
+            'bot_user_id' => $this->botUser->id,
+            'rating' => 2,
+            'status' => 'completed_no_comment',
+            'closed_at' => now(),
+        ]);
+
+        Livewire::test(ListFeedbacks::class)
+            ->filterTable('rating', '4')
+            ->assertCanSeeTableRecords([$rating4])
+            ->assertCanNotSeeTableRecords([$rating2]);
+    }
+
+    public function test_can_render_view_page(): void
+    {
+        $feedback = Feedback::create([
+            'bot_user_id' => $this->botUser->id,
+            'rating' => 3,
+            'status' => 'completed_no_comment',
+            'closed_at' => now(),
+        ]);
+
+        Livewire::test(ViewFeedback::class, ['record' => $feedback->getRouteKey()])
+            ->assertSuccessful();
+    }
+
+    public function test_resource_is_read_only_no_create(): void
+    {
+        $this->assertFalse(FeedbackResource::canCreate());
+    }
+}

--- a/tests/Feature/Modules/Telegram/CloseTopicFeedbackTest.php
+++ b/tests/Feature/Modules/Telegram/CloseTopicFeedbackTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Tests\Feature\Modules\Telegram;
+
+use App\Models\BotUser;
+use App\Models\Feedback;
+use App\Modules\Telegram\Actions\CloseTopic;
+use App\Modules\Telegram\Jobs\SendTelegramSimpleQueryJob;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class CloseTopicFeedbackTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['traffic_source.settings.telegram.group_id' => -100123456789]);
+        config(['icons.outgoing' => '']);
+        Queue::fake();
+    }
+
+    public function test_close_topic_creates_feedback_record(): void
+    {
+        $botUser = BotUser::create([
+            'chat_id' => 50001,
+            'platform' => 'telegram',
+            'topic_id' => 111,
+            'is_closed' => false,
+        ]);
+
+        app(CloseTopic::class)->execute($botUser);
+
+        $this->assertDatabaseHas('feedbacks', [
+            'bot_user_id' => $botUser->id,
+            'status' => 'awaiting_rating',
+            'rating' => null,
+        ]);
+    }
+
+    public function test_close_topic_dispatches_feedback_form_job(): void
+    {
+        $botUser = BotUser::create([
+            'chat_id' => 50002,
+            'platform' => 'telegram',
+            'topic_id' => 112,
+            'is_closed' => false,
+        ]);
+
+        app(CloseTopic::class)->execute($botUser);
+
+        // SendFeedbackForm dispatches SendTelegramSimpleQueryJob for the rating form
+        // CloseTopic itself dispatches editForumTopic + closeForumTopic + close message + feedback form
+        /** @phpstan-ignore-next-line */
+        $pushed = Queue::pushedJobs()[SendTelegramSimpleQueryJob::class] ?? [];
+
+        // At minimum: editForumTopic, closeForumTopic, close message to user, feedback form
+        $this->assertGreaterThanOrEqual(3, count($pushed));
+
+        // The last job dispatched should be the feedback form (sendMessage to user's chat_id)
+        /** @phpstan-ignore-next-line */
+        $feedbackJob = collect($pushed)->firstWhere(
+            fn ($item) => $item['job']->queryParams->chat_id === $botUser->chat_id
+            && $item['job']->queryParams->methodQuery === 'sendMessage'
+            && isset($item['job']->queryParams->reply_markup['inline_keyboard'])
+        );
+
+        $this->assertNotNull($feedbackJob, 'Feedback form job was not dispatched');
+    }
+
+    public function test_close_topic_does_not_create_feedback_when_already_closed(): void
+    {
+        $botUser = BotUser::create([
+            'chat_id' => 50003,
+            'platform' => 'telegram',
+            'topic_id' => 113,
+            'is_closed' => true,
+        ]);
+
+        app(CloseTopic::class)->execute($botUser);
+
+        $this->assertDatabaseCount('feedbacks', 0);
+    }
+
+    public function test_multiple_close_events_create_multiple_feedback_records(): void
+    {
+        $botUser = BotUser::create([
+            'chat_id' => 50004,
+            'platform' => 'telegram',
+            'topic_id' => 114,
+            'is_closed' => false,
+        ]);
+
+        app(CloseTopic::class)->execute($botUser);
+
+        // Re-open for second close
+        $botUser->update(['is_closed' => false]);
+
+        app(CloseTopic::class)->execute($botUser);
+
+        $this->assertEquals(2, Feedback::where('bot_user_id', $botUser->id)->count());
+    }
+
+    public function test_close_topic_sets_bot_user_is_closed_true(): void
+    {
+        $botUser = BotUser::create([
+            'chat_id' => 50005,
+            'platform' => 'telegram',
+            'topic_id' => 115,
+            'is_closed' => false,
+        ]);
+
+        app(CloseTopic::class)->execute($botUser);
+
+        $this->assertTrue($botUser->fresh()->isClosed());
+    }
+}

--- a/tests/Unit/Models/FeedbackTest.php
+++ b/tests/Unit/Models/FeedbackTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\BotUser;
+use App\Models\Feedback;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class FeedbackTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        BotUser::truncate();
+        Feedback::truncate();
+    }
+
+    public function test_belongs_to_bot_user(): void
+    {
+        $botUser = BotUser::create(['chat_id' => 1001, 'platform' => 'telegram']);
+        $feedback = Feedback::create([
+            'bot_user_id' => $botUser->id,
+            'status' => 'awaiting_rating',
+            'closed_at' => now(),
+        ]);
+
+        $this->assertInstanceOf(BotUser::class, $feedback->botUser);
+        $this->assertEquals($botUser->id, $feedback->botUser->id);
+    }
+
+    public function test_bot_user_has_many_feedbacks(): void
+    {
+        $botUser = BotUser::create(['chat_id' => 1002, 'platform' => 'telegram']);
+        Feedback::create(['bot_user_id' => $botUser->id, 'status' => 'awaiting_rating', 'closed_at' => now()]);
+        Feedback::create(['bot_user_id' => $botUser->id, 'status' => 'completed_no_comment', 'rating' => 4, 'closed_at' => now()]);
+
+        $this->assertCount(2, $botUser->feedbacks);
+    }
+
+    public function test_rating_is_cast_to_integer(): void
+    {
+        $botUser = BotUser::create(['chat_id' => 1003, 'platform' => 'telegram']);
+        $feedback = Feedback::create([
+            'bot_user_id' => $botUser->id,
+            'rating' => 3,
+            'status' => 'completed_no_comment',
+            'closed_at' => now(),
+        ]);
+
+        $this->assertIsInt($feedback->rating);
+        $this->assertEquals(3, $feedback->rating);
+    }
+
+    public function test_rating_is_nullable(): void
+    {
+        $botUser = BotUser::create(['chat_id' => 1004, 'platform' => 'telegram']);
+        $feedback = Feedback::create([
+            'bot_user_id' => $botUser->id,
+            'status' => 'awaiting_rating',
+            'closed_at' => now(),
+        ]);
+
+        $this->assertNull($feedback->rating);
+    }
+
+    public function test_comment_is_nullable(): void
+    {
+        $botUser = BotUser::create(['chat_id' => 1005, 'platform' => 'telegram']);
+        $feedback = Feedback::create([
+            'bot_user_id' => $botUser->id,
+            'status' => 'awaiting_rating',
+            'closed_at' => now(),
+        ]);
+
+        $this->assertNull($feedback->comment);
+    }
+
+    public function test_fillable_fields(): void
+    {
+        $feedback = new Feedback();
+        $fillable = $feedback->getFillable();
+
+        $this->assertContains('bot_user_id', $fillable);
+        $this->assertContains('rating', $fillable);
+        $this->assertContains('comment', $fillable);
+        $this->assertContains('status', $fillable);
+        $this->assertContains('closed_at', $fillable);
+    }
+
+    public function test_closed_at_is_cast_to_datetime(): void
+    {
+        $botUser = BotUser::create(['chat_id' => 1006, 'platform' => 'telegram']);
+        $feedback = Feedback::create([
+            'bot_user_id' => $botUser->id,
+            'status' => 'awaiting_rating',
+            'closed_at' => now(),
+        ]);
+
+        $this->assertInstanceOf(\Illuminate\Support\Carbon::class, $feedback->closed_at);
+    }
+}

--- a/tests/Unit/Modules/Feedback/Actions/HandleFeedbackRatingTest.php
+++ b/tests/Unit/Modules/Feedback/Actions/HandleFeedbackRatingTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Tests\Unit\Modules\Feedback\Actions;
+
+use App\Models\BotUser;
+use App\Models\Feedback;
+use App\Modules\Feedback\Actions\HandleFeedbackRating;
+use App\Modules\Telegram\Jobs\SendTelegramSimpleQueryJob;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class HandleFeedbackRatingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        BotUser::truncate();
+        Feedback::truncate();
+        Queue::fake();
+    }
+
+    public function test_saves_rating_and_transitions_status_to_completed_no_comment(): void
+    {
+        $botUser = BotUser::create(['chat_id' => 1001, 'platform' => 'telegram']);
+        $feedback = Feedback::create([
+            'bot_user_id' => $botUser->id,
+            'status' => 'awaiting_rating',
+            'closed_at' => now(),
+        ]);
+
+        $callbackData = "feedback_rate_{$botUser->id}_{$feedback->id}_4";
+
+        (new HandleFeedbackRating())->execute($callbackData);
+
+        $feedback->refresh();
+        $this->assertEquals(4, $feedback->rating);
+        $this->assertEquals('completed_no_comment', $feedback->status);
+    }
+
+    public function test_dispatches_edit_message_when_message_id_and_chat_id_provided(): void
+    {
+        $botUser = BotUser::create(['chat_id' => 1002, 'platform' => 'telegram']);
+        $feedback = Feedback::create([
+            'bot_user_id' => $botUser->id,
+            'status' => 'awaiting_rating',
+            'closed_at' => now(),
+        ]);
+
+        $callbackData = "feedback_rate_{$botUser->id}_{$feedback->id}_5";
+
+        (new HandleFeedbackRating())->execute(
+            callbackData: $callbackData,
+            messageId: 9988,
+            chatId: (int) $botUser->chat_id,
+        );
+
+        /** @phpstan-ignore-next-line */
+        $pushed = Queue::pushedJobs()[SendTelegramSimpleQueryJob::class] ?? [];
+        $this->assertCount(1, $pushed);
+
+        $job = $pushed[0]['job'];
+        $this->assertEquals('editMessageText', $job->queryParams->methodQuery);
+        $this->assertEquals(9988, $job->queryParams->message_id);
+        $this->assertEquals($botUser->chat_id, $job->queryParams->chat_id);
+    }
+
+    public function test_does_not_dispatch_edit_message_when_message_id_is_null(): void
+    {
+        $botUser = BotUser::create(['chat_id' => 1003, 'platform' => 'telegram']);
+        $feedback = Feedback::create([
+            'bot_user_id' => $botUser->id,
+            'status' => 'awaiting_rating',
+            'closed_at' => now(),
+        ]);
+
+        $callbackData = "feedback_rate_{$botUser->id}_{$feedback->id}_3";
+
+        (new HandleFeedbackRating())->execute(callbackData: $callbackData);
+
+        Queue::assertNothingPushed();
+    }
+
+    public function test_does_nothing_for_invalid_callback_data(): void
+    {
+        (new HandleFeedbackRating())->execute('invalid_callback_data');
+
+        Queue::assertNothingPushed();
+        $this->assertDatabaseCount('feedbacks', 0);
+    }
+
+    public function test_does_nothing_when_feedback_record_not_found(): void
+    {
+        $botUser = BotUser::create(['chat_id' => 1004, 'platform' => 'telegram']);
+        $callbackData = "feedback_rate_{$botUser->id}_99999_3";
+
+        (new HandleFeedbackRating())->execute($callbackData);
+
+        Queue::assertNothingPushed();
+    }
+
+    public function test_parse_callback_data_returns_correct_values(): void
+    {
+        $handler = new HandleFeedbackRating();
+
+        $result = $handler->parseCallbackData('feedback_rate_42_100_3');
+
+        $this->assertNotNull($result);
+        $this->assertEquals(42, $result['botUserId']);
+        $this->assertEquals(100, $result['feedbackId']);
+        $this->assertEquals(3, $result['score']);
+    }
+
+    public function test_parse_callback_data_returns_null_for_invalid_format(): void
+    {
+        $handler = new HandleFeedbackRating();
+
+        $this->assertNull($handler->parseCallbackData('close_topic'));
+        $this->assertNull($handler->parseCallbackData('feedback_rate_42'));
+        $this->assertNull($handler->parseCallbackData('feedback_rate_42_100_6'));
+        $this->assertNull($handler->parseCallbackData('feedback_rate_42_100_0'));
+    }
+
+    public function test_all_valid_scores_1_to_5_are_accepted(): void
+    {
+        $botUser = BotUser::create(['chat_id' => 1005, 'platform' => 'telegram']);
+
+        for ($score = 1; $score <= 5; $score++) {
+            $feedback = Feedback::create([
+                'bot_user_id' => $botUser->id,
+                'status' => 'awaiting_rating',
+                'closed_at' => now(),
+            ]);
+
+            (new HandleFeedbackRating())->execute("feedback_rate_{$botUser->id}_{$feedback->id}_{$score}");
+
+            $feedback->refresh();
+            $this->assertEquals($score, $feedback->rating);
+            $this->assertEquals('completed_no_comment', $feedback->status);
+        }
+    }
+}

--- a/tests/Unit/Modules/Feedback/Actions/SendFeedbackFormTest.php
+++ b/tests/Unit/Modules/Feedback/Actions/SendFeedbackFormTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Tests\Unit\Modules\Feedback\Actions;
+
+use App\Models\BotUser;
+use App\Models\Feedback;
+use App\Modules\Feedback\Actions\SendFeedbackForm;
+use App\Modules\Max\Jobs\SendMaxMessageJob;
+use App\Modules\Telegram\Jobs\SendTelegramSimpleQueryJob;
+use App\Modules\Vk\Jobs\SendVkSimpleMessageJob;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class SendFeedbackFormTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        BotUser::truncate();
+        Feedback::truncate();
+        Queue::fake();
+    }
+
+    public function test_creates_feedback_record_with_awaiting_rating_status(): void
+    {
+        $botUser = BotUser::create(['chat_id' => 1001, 'platform' => 'telegram']);
+
+        (new SendFeedbackForm())->execute($botUser);
+
+        $this->assertDatabaseHas('feedbacks', [
+            'bot_user_id' => $botUser->id,
+            'status' => 'awaiting_rating',
+            'rating' => null,
+        ]);
+    }
+
+    public function test_dispatches_telegram_simple_query_job_for_telegram_user(): void
+    {
+        $botUser = BotUser::create(['chat_id' => 100001, 'platform' => 'telegram']);
+
+        (new SendFeedbackForm())->execute($botUser);
+
+        /** @phpstan-ignore-next-line */
+        $pushed = Queue::pushedJobs()[SendTelegramSimpleQueryJob::class] ?? [];
+        $this->assertCount(1, $pushed);
+
+        $job = $pushed[0]['job'];
+        $this->assertEquals('sendMessage', $job->queryParams->methodQuery);
+        $this->assertEquals($botUser->chat_id, $job->queryParams->chat_id);
+        $this->assertNotNull($job->queryParams->reply_markup);
+    }
+
+    public function test_telegram_keyboard_has_5_rating_buttons(): void
+    {
+        $botUser = BotUser::create(['chat_id' => 100002, 'platform' => 'telegram']);
+
+        (new SendFeedbackForm())->execute($botUser);
+
+        /** @phpstan-ignore-next-line */
+        $pushed = Queue::pushedJobs()[SendTelegramSimpleQueryJob::class] ?? [];
+        $this->assertCount(1, $pushed);
+
+        $job = $pushed[0]['job'];
+        $markup = $job->queryParams->reply_markup;
+        $this->assertIsArray($markup);
+        $this->assertArrayHasKey('inline_keyboard', $markup);
+        $this->assertCount(5, $markup['inline_keyboard'][0]);
+    }
+
+    public function test_telegram_callback_data_contains_bot_user_id_and_score(): void
+    {
+        $botUser = BotUser::create(['chat_id' => 100003, 'platform' => 'telegram']);
+
+        (new SendFeedbackForm())->execute($botUser);
+
+        $feedback = Feedback::where('bot_user_id', $botUser->id)->first();
+
+        /** @phpstan-ignore-next-line */
+        $pushed = Queue::pushedJobs()[SendTelegramSimpleQueryJob::class] ?? [];
+        $job = $pushed[0]['job'];
+        $buttons = $job->queryParams->reply_markup['inline_keyboard'][0];
+
+        foreach ($buttons as $index => $button) {
+            $score = $index + 1;
+            $this->assertEquals(
+                "feedback_rate_{$botUser->id}_{$feedback->id}_{$score}",
+                $button['callback_data']
+            );
+        }
+    }
+
+    public function test_dispatches_vk_simple_message_job_for_vk_user(): void
+    {
+        $botUser = BotUser::create(['chat_id' => 200001, 'platform' => 'vk']);
+
+        (new SendFeedbackForm())->execute($botUser);
+
+        /** @phpstan-ignore-next-line */
+        $pushed = Queue::pushedJobs()[SendVkSimpleMessageJob::class] ?? [];
+        $this->assertCount(1, $pushed);
+
+        $job = $pushed[0]['job'];
+        $this->assertEquals('messages.send', $job->queryParams->methodQuery);
+        $this->assertEquals($botUser->chat_id, $job->queryParams->peer_id);
+        $this->assertNotNull($job->queryParams->keyboard);
+    }
+
+    public function test_dispatches_max_message_job_for_max_user(): void
+    {
+        $botUser = BotUser::create(['chat_id' => 300001, 'platform' => 'max']);
+
+        (new SendFeedbackForm())->execute($botUser);
+
+        /** @phpstan-ignore-next-line */
+        $pushed = Queue::pushedJobs()[SendMaxMessageJob::class] ?? [];
+        $this->assertCount(1, $pushed);
+
+        $job = $pushed[0]['job'];
+        $this->assertEquals('sendMessage', $job->queryParams->methodQuery);
+        $this->assertEquals($botUser->chat_id, $job->queryParams->user_id);
+        $this->assertNotNull($job->queryParams->keyboard);
+    }
+
+    public function test_dispatches_nothing_for_unsupported_platform(): void
+    {
+        $botUser = BotUser::create(['chat_id' => 999999, 'platform' => 'unknown']);
+
+        (new SendFeedbackForm())->execute($botUser);
+
+        Queue::assertNothingPushed();
+
+        // Feedback record is still created even if delivery is skipped
+        $this->assertDatabaseHas('feedbacks', [
+            'bot_user_id' => $botUser->id,
+            'status' => 'awaiting_rating',
+        ]);
+    }
+
+    public function test_feedback_closed_at_is_set_on_creation(): void
+    {
+        $botUser = BotUser::create(['chat_id' => 100010, 'platform' => 'telegram']);
+
+        (new SendFeedbackForm())->execute($botUser);
+
+        $feedback = Feedback::where('bot_user_id', $botUser->id)->first();
+        $this->assertNotNull($feedback->closed_at);
+    }
+}

--- a/tests/Unit/Modules/Telegram/Actions/CloseTopicTest.php
+++ b/tests/Unit/Modules/Telegram/Actions/CloseTopicTest.php
@@ -57,7 +57,8 @@ class CloseTopicTest extends TestCase
 
         /** @phpstan-ignore-next-line */
         $pushed = Queue::pushedJobs()[SendTelegramSimpleQueryJob::class] ?? [];
-        $this->assertCount(3, $pushed);
+        // 4 jobs: close message to user, editForumTopic, closeForumTopic, feedback form to user
+        $this->assertCount(4, $pushed);
 
         $job = $pushed[0]['job'];
         $this->assertEquals('sendMessage', $job->queryParams->methodQuery);
@@ -72,6 +73,12 @@ class CloseTopicTest extends TestCase
         $this->assertEquals('closeForumTopic', $job->queryParams->methodQuery);
         $this->assertEquals($this->groupId, $job->queryParams->chat_id);
         $this->assertEquals($botUser->topic_id, $job->queryParams->message_thread_id);
+
+        // 4th job: SendFeedbackForm dispatches the rating form to the user
+        $job = $pushed[3]['job'];
+        $this->assertEquals('sendMessage', $job->queryParams->methodQuery);
+        $this->assertEquals($botUser->chat_id, $job->queryParams->chat_id);
+        $this->assertNotNull($job->queryParams->reply_markup);
     }
 
     public function test_close_topic_vk(): void
@@ -83,11 +90,18 @@ class CloseTopicTest extends TestCase
 
         /** @phpstan-ignore-next-line */
         $pushed = Queue::pushedJobs()[SendVkSimpleMessageJob::class] ?? [];
-        $this->assertCount(1, $pushed);
+        // 2 jobs: VK close message + SendFeedbackForm feedback form to VK user
+        $this->assertCount(2, $pushed);
 
         $job = $pushed[0]['job'];
         $this->assertEquals('messages.send', $job->queryParams->methodQuery);
         $this->assertEquals($botUser->chat_id, $job->queryParams->peer_id);
+
+        // 2nd job: SendFeedbackForm dispatches the rating form to the VK user
+        $job = $pushed[1]['job'];
+        $this->assertEquals('messages.send', $job->queryParams->methodQuery);
+        $this->assertEquals($botUser->chat_id, $job->queryParams->peer_id);
+        $this->assertNotNull($job->queryParams->keyboard);
 
         /** @phpstan-ignore-next-line */
         $pushed = Queue::pushedJobs()[SendTelegramSimpleQueryJob::class] ?? [];


### PR DESCRIPTION
## Summary

Adds a cross-platform post-close feedback rating form. When `CloseTopic` finalises a conversation, the user receives a 5-button rating keyboard (1..5) on their own platform. The rating is persisted in a new `feedbacks` table and surfaced in the Filament admin panel as a read-only resource + relation block on the BotUser page.

## What ships

- **New module** `app/Modules/Feedback/` — `SendFeedbackForm` action (creates `Feedback` row + dispatches rating keyboard via platform-routed Job, same pattern as `DeliverAiAnswerToUser`), `HandleFeedbackRating` action (saves rating, sets `status='completed_no_comment'`, edits message), `FeedbackServiceProvider`.
- **DB**: `feedbacks` table (`id`, `bot_user_id` FK cascade, `rating` smallint nullable, `comment` text nullable, `status` string, `closed_at` timestamp, timestamps).
- **Callback routing**: `feedback_rate_{botUserId}_{feedbackId}_{score}` — Telegram via `TelegramBotController::checkBotQuery()`, VK via `message_event`, Max via `message_callback`.
- **Admin**: `FeedbackResource` (List + View, read-only — no Create/Edit/Delete), `FeedbacksRelationManager` on `BotUserResource`.
- **Tests**: 32 new tests (unit + feature), all 373 project tests green.
- **Docs**: `rules/domain/bot-users.md` (BR-020/021), `rules/database/schema.md`, `rules/api/endpoints.md`, `CLAUDE.md` updated.

## Resolved product decisions

| Question | Decision |
|---|---|
| Rating scale | 1..5 numeric buttons (originally stars, switched to digits per UX request) |
| Module location | New `app/Modules/Feedback/` |
| Behavior on rating without comment | `completed_no_comment` immediately — no `expecting_feedback_comment` flag, no follow-up comment capture, `comment` column stays nullable for future use |
| Send to which closed conversations | All (no filter on "had ≥1 manager reply") |
| Admin behavior | Read-only, no notification badge |

## Bug fixes included

- **`TelegramBotController::bot_query()`**: early `return` after `checkBotQuery()` for `callback_query` updates. Previously fell through to `controllerPlatformTg/Vk/Max` where the `typeQuery` switch had no `callback_query` case and threw `"Unknown event type: callback_query"`. Latent bug — also affected `topic_user_ban_*` / `close_topic` callbacks for non-TG users.
- **`CloseTopic::execute()`**: `try/catch (\Throwable)` around `SendFeedbackForm::execute()` with Loki error log (`source=close_topic_feedback_failed`). A failure in feedback form delivery no longer aborts topic closure after `closed_at` was set.

## Known limitations / follow-ups

- VK `message_event` and Max `message_callback` callback routing is new — payload shapes (`rawData['object']['payload']['command']` for VK, `rawData['callback']['payload']` for Max) should be smoke-tested against live APIs before relying on them in prod.
- `MaxUpdateDto::fromRequest()` doesn't parse `message_callback` yet — controller uses raw array access; a dedicated DTO field is a follow-up.
- `comment` column is permanently `NULL` (no comment-capture UI by design).
- Strings hardcoded in Russian with `// TODO: move to lang/ru/messages.php` — `lang/` infra not introduced in this task.

## Migration

```bash
docker exec -it pet php artisan migrate
```

Rollback: `docker exec -it pet php artisan migrate:rollback`.

Closes #137