### PR TITLE
issues-150 | Персистентный слой настроек приложения

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,7 @@ Data Layer          app/Models/ + PostgreSQL
 - **Middleware Pattern** — webhook validation before controller runs
 - **Contract Pattern** — `ManagerInterfaceContract` decouples manager UI from business logic
 - **Platform Registry Pattern** — `PlatformChannel` + `PlatformChannelRegistry` (`app/Platform/`) let external (incl. paid, private) platform packages self-register delivery for a `platform` key without editing the core
+- **Settings Pattern** — `SettingsService` + `SettingKeyRegistry` (`app/Services/Settings/`) provide a unified `get/set/has/forget` API for runtime-editable settings (DB → `config()` fallback, Redis cache, `Crypt` encryption for secrets, type coercion); known keys registered in `SettingKeyRegistry`
 
 ---
 
@@ -120,6 +121,8 @@ app/
 ├── Contracts/        # Interfaces (AiProviderInterface, ManagerInterfaceContract, PlatformChannel)
 ├── Platform/         # PlatformChannelRegistry — registry for pluggable platform modules
 ├── DTOs/             # Shared Data Transfer Objects (Ai/, Button/, Redis/)
+├── Services/
+│   └── Settings/     # Settings persistence layer: SettingsService, SettingKeyRegistry
 ├── Enums/            # Enumerations (ButtonType, TelegramError, VkError)
 ├── Helpers/          # Utilities (TelegramHelper, AiHelper, DateHelper)
 ├── Http/
@@ -249,6 +252,17 @@ public static function execute(BotUser $botUser): TelegramAnswerDto
 - AI drafts NEVER write to `messages` (only to `ai_messages`); a `messages` row appears only when the message is actually sent to the user — this invariant is what makes "any outgoing row = delivered" safe for the chat-history assembler
 - AI runs across all user platforms (`telegram`, `vk`, `max`). Triggers: `TelegramBotController::maybeDispatchAi()` for TG, `VkMessageService::maybeDispatchAi()` for VK, `MaxMessageService::maybeDispatchAi()` for Max. Triggering is text-only — attachments do not start AI. Gating still goes through `ShouldAiReply` (TG-DTO and platform-agnostic variants share the same rules: AI_ENABLED, `MANAGER_INTERFACE=telegram_group`, replyable text, user active)
 - Final delivery of an AI answer to the user (Accept and auto-reply) is routed by `BotUser.platform` through `App\Modules\Ai\Actions\DeliverAiAnswerToUser` → `SendTelegramMessageJob` / `SendVkMessageJob` / `SendMaxMessageJob`. Any other platform is delegated to a `PlatformChannel` registered in `App\Platform\PlatformChannelRegistry` by a pluggable module (e.g. the paid Avito package). The Accept callback still edits the supergroup draft via `SendTelegramMessageJob` using the AI bot token regardless of user platform
+
+### Settings Persistence Layer
+
+- Runtime-editable application settings are stored in the `settings` table and accessed exclusively via `SettingsService` (`app/Services/Settings/SettingsService.php`)
+- **Reading priority:** DB row → `config()`/`.env` default (declared in `SettingKeyRegistry`) → `null`
+- **Never call `config()` directly** for a setting that may be overridden at runtime — use `app(\App\Services\Settings\SettingsService::class)->get('key')` instead
+- Secret keys (`is_secret=true` in `SettingKeyRegistry`) are encrypted with `Crypt::encrypt()` before DB write and decrypted transparently in `get()` — never read the raw `settings.value` column for secret keys
+- Cache: values cached forever in the default store (Redis); invalidated on `set()` / `forget()`
+- Known keys and their types/fallbacks/secret flags are registered in `SettingKeyRegistry::$keys`
+- The `settings` table is empty by default — fallback to `config()` is always active until a value is explicitly saved
+- Admin UI for editing settings is in dependent tasks #144/#145/#146; wiring `ManagerInterfaceContract` and platform tokens to DB is also deferred to those tasks
 
 ### External Sources
 

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property int         $id
+ * @property string      $key        Dot-notation setting key (e.g. 'app.manager_interface')
+ * @property string|null $value      Raw stored value; encrypted string when is_secret = true
+ * @property string      $type       PHP type for coercion: 'string' | 'bool' | 'int' | 'json'
+ * @property bool        $is_secret  When true, value is encrypted in the DB by SettingsService
+ * @property string      $created_at
+ * @property string      $updated_at
+ *
+ * NOTE: Encryption of the `value` column is handled by SettingsService, not by a model cast.
+ * SettingsService uses Crypt::encrypt() before writing and Crypt::decrypt() after reading for
+ * keys flagged is_secret=true. This avoids the fill()-order problem that arises when combining
+ * a dynamic getCasts() override with Eloquent's attribute hydration sequence.
+ */
+class Setting extends Model
+{
+    use HasFactory;
+
+    protected $table = 'settings';
+
+    protected $fillable = [
+        'key',
+        'value',
+        'type',
+        'is_secret',
+    ];
+
+    protected $casts = [
+        'is_secret' => 'boolean',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,6 +6,7 @@ use App\Contracts\ManagerInterfaceContract;
 use App\Modules\Admin\Services\AdminPanelInterface;
 use App\Modules\Telegram\Services\TelegramGroupInterface;
 use App\Platform\PlatformChannelRegistry;
+use App\Services\Settings\SettingsService;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -26,6 +27,11 @@ class AppServiceProvider extends ServiceProvider
         // (e.g. the paid Avito package) register their PlatformChannel into this
         // singleton from their own ServiceProvider — without editing the core.
         $this->app->singleton(PlatformChannelRegistry::class);
+
+        // Settings persistence layer — single shared instance throughout the
+        // request lifecycle. Consumers inject SettingsService via the container
+        // or resolve it with app(SettingsService::class).
+        $this->app->singleton(SettingsService::class);
     }
 
     /**

--- a/app/Services/Settings/SettingKeyRegistry.php
+++ b/app/Services/Settings/SettingKeyRegistry.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace App\Services\Settings;
+
+/**
+ * Registry of all known application setting keys and their metadata.
+ *
+ * Each entry maps a dot-notation key to:
+ *   - type        : PHP type for coercion ('string', 'bool', 'int', 'json')
+ *   - config      : config() path used as the fallback when no DB row exists
+ *   - is_secret   : whether the value must be stored encrypted in the DB
+ *
+ * Keys not listed here are still valid — unknown keys fall back to 'string'
+ * type with no config fallback (they return null unless a DB row exists).
+ *
+ * To add a new key simply append an entry; no other file needs to change.
+ */
+class SettingKeyRegistry
+{
+    /**
+     * @var array<string, array{type: string, config: string|null, is_secret: bool}>
+     */
+    private static array $keys = [
+        // ── App ─────────────────────────────────────────────────────────────
+        'app.manager_interface' => [
+            'type' => 'string',
+            'config' => 'app.manager_interface',
+            'is_secret' => false,
+        ],
+
+        // ── Telegram (main bot) ──────────────────────────────────────────────
+        'telegram.token' => [
+            'type' => 'string',
+            'config' => 'traffic_source.settings.telegram.token',
+            'is_secret' => true,
+        ],
+        'telegram.secret_key' => [
+            'type' => 'string',
+            'config' => 'traffic_source.settings.telegram.secret_key',
+            'is_secret' => true,
+        ],
+        'telegram.group_id' => [
+            'type' => 'string',
+            'config' => 'traffic_source.settings.telegram.group_id',
+            'is_secret' => false,
+        ],
+        'telegram.bot_id' => [
+            'type' => 'int',
+            'config' => 'traffic_source.settings.telegram.bot_id',
+            'is_secret' => false,
+        ],
+        'telegram.template_topic_name' => [
+            'type' => 'string',
+            'config' => 'traffic_source.settings.telegram.template_topic_name',
+            'is_secret' => false,
+        ],
+
+        // ── Telegram AI bot ──────────────────────────────────────────────────
+        'telegram_ai.token' => [
+            'type' => 'string',
+            'config' => 'traffic_source.settings.telegram_ai.token',
+            'is_secret' => true,
+        ],
+        'telegram_ai.secret' => [
+            'type' => 'string',
+            'config' => 'traffic_source.settings.telegram_ai.secret',
+            'is_secret' => true,
+        ],
+        'telegram_ai.id' => [
+            'type' => 'int',
+            'config' => 'traffic_source.settings.telegram_ai.id',
+            'is_secret' => false,
+        ],
+        'telegram_ai.username' => [
+            'type' => 'string',
+            'config' => 'traffic_source.settings.telegram_ai.username',
+            'is_secret' => false,
+        ],
+
+        // ── VK ───────────────────────────────────────────────────────────────
+        'vk.token' => [
+            'type' => 'string',
+            'config' => 'traffic_source.settings.vk.token',
+            'is_secret' => true,
+        ],
+        'vk.secret_key' => [
+            'type' => 'string',
+            'config' => 'traffic_source.settings.vk.secret_key',
+            'is_secret' => true,
+        ],
+        'vk.confirm_code' => [
+            'type' => 'string',
+            'config' => 'traffic_source.settings.vk.confirm_code',
+            'is_secret' => true,
+        ],
+
+        // ── Max ──────────────────────────────────────────────────────────────
+        'max.token' => [
+            'type' => 'string',
+            'config' => 'traffic_source.settings.max.token',
+            'is_secret' => true,
+        ],
+        'max.secret_key' => [
+            'type' => 'string',
+            'config' => 'traffic_source.settings.max.secret_key',
+            'is_secret' => true,
+        ],
+
+        // ── AI assistant ─────────────────────────────────────────────────────
+        'ai.enabled' => [
+            'type' => 'bool',
+            'config' => 'ai.enabled',
+            'is_secret' => false,
+        ],
+        'ai.auto_reply' => [
+            'type' => 'bool',
+            'config' => 'ai.auto_reply',
+            'is_secret' => false,
+        ],
+        'ai.default_provider' => [
+            'type' => 'string',
+            'config' => 'ai.default_provider',
+            'is_secret' => false,
+        ],
+        'ai.max_context_tokens' => [
+            'type' => 'int',
+            'config' => 'ai.max_context_tokens',
+            'is_secret' => false,
+        ],
+        'ai.openai_api_key' => [
+            'type' => 'string',
+            'config' => 'ai.providers.openai.api_key',
+            'is_secret' => true,
+        ],
+        'ai.openai_model' => [
+            'type' => 'string',
+            'config' => 'ai.providers.openai.model',
+            'is_secret' => false,
+        ],
+        'ai.deepseek_client_id' => [
+            'type' => 'string',
+            'config' => 'ai.providers.deepseek.client_id',
+            'is_secret' => false,
+        ],
+        'ai.deepseek_client_secret' => [
+            'type' => 'string',
+            'config' => 'ai.providers.deepseek.client_secret',
+            'is_secret' => true,
+        ],
+        'ai.gigachat_client_id' => [
+            'type' => 'string',
+            'config' => 'ai.providers.gigachat.client_id',
+            'is_secret' => false,
+        ],
+        'ai.gigachat_client_secret' => [
+            'type' => 'string',
+            'config' => 'ai.providers.gigachat.client_secret',
+            'is_secret' => true,
+        ],
+    ];
+
+    /**
+     * Return metadata for a known key, or a sensible default for unknown keys.
+     *
+     * @return array{type: string, config: string|null, is_secret: bool}
+     */
+    public static function meta(string $key): array
+    {
+        return self::$keys[$key] ?? [
+            'type' => 'string',
+            'config' => null,
+            'is_secret' => false,
+        ];
+    }
+
+    /**
+     * Return all registered keys.
+     *
+     * @return array<string>
+     */
+    public static function keys(): array
+    {
+        return array_keys(self::$keys);
+    }
+
+    /**
+     * Check whether a key is registered in the registry.
+     */
+    public static function registered(string $key): bool
+    {
+        return isset(self::$keys[$key]);
+    }
+}

--- a/app/Services/Settings/SettingsService.php
+++ b/app/Services/Settings/SettingsService.php
@@ -1,0 +1,226 @@
+<?php
+
+namespace App\Services\Settings;
+
+use App\Models\Setting;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Crypt;
+
+/**
+ * Unified settings access layer.
+ *
+ * Reading priority: DB row → config()/env default → null.
+ *
+ * Secret keys (is_secret = true in SettingKeyRegistry) are encrypted with
+ * Laravel's Crypt facade before being written to the DB and decrypted
+ * transparently on every get(). Encryption lives here, NOT in the model,
+ * to avoid the attribute-fill ordering problem with dynamic Eloquent casts.
+ *
+ * Type coercion uses the DB row's stored `type` column when a row exists,
+ * otherwise falls back to the SettingKeyRegistry declaration.
+ *
+ * Cache: each key is stored under "settings.{key}:{type}" forever and
+ * invalidated on set() / forget(). The sentinel CACHE_NULL is cached when
+ * there is no DB row (to avoid repeated DB hits on hot paths).
+ */
+class SettingsService
+{
+    private const CACHE_PREFIX = 'settings.';
+
+    /**
+     * Sentinel stored in the cache when there is no DB row for a key.
+     * This lets us distinguish "not in cache" from "DB row is absent".
+     */
+    private const CACHE_NULL = '__settings_null__';
+
+    /**
+     * Retrieve a setting value.
+     *
+     * Priority: DB → config()/env default → null.
+     * The returned value is coerced to the type declared in SettingKeyRegistry
+     * (or the type stored in the DB row if available).
+     *
+     * @param mixed $default Override the registry's config() fallback with a caller-supplied default.
+     *
+     * @return mixed
+     */
+    public function get(string $key, mixed $default = null): mixed
+    {
+        $cacheEntry = Cache::get($this->cacheKey($key));
+
+        if ($cacheEntry !== null) {
+            // Sentinel means we previously confirmed there is no DB row.
+            if ($cacheEntry === self::CACHE_NULL) {
+                return $this->resolveDefault($key, $default);
+            }
+
+            // Cache entry is stored as "type:value" to preserve the type.
+            [$type, $plain] = $this->unpackCacheEntry($cacheEntry);
+
+            return $this->coerceByType($plain, $type);
+        }
+
+        $setting = Setting::where('key', $key)->first();
+
+        if ($setting !== null) {
+            // Decrypt if secret, then cache as "type:value".
+            $plain = $this->decryptIfSecret($key, $setting->value);
+            Cache::forever($this->cacheKey($key), $this->packCacheEntry($setting->type, $plain));
+
+            return $this->coerceByType($plain, $setting->type);
+        }
+
+        // No DB row — cache the sentinel so we skip DB on next read.
+        Cache::forever($this->cacheKey($key), self::CACHE_NULL);
+
+        return $this->resolveDefault($key, $default);
+    }
+
+    /**
+     * Persist a setting value to the DB and invalidate the cache entry.
+     *
+     * The value is encoded to a string representation for storage.
+     * Secret keys are encrypted with Crypt::encrypt() before writing.
+     *
+     * @param mixed $value
+     */
+    public function set(string $key, mixed $value): void
+    {
+        $meta = SettingKeyRegistry::meta($key);
+        $raw = $this->encode($value, $meta['type']);
+
+        if ($meta['is_secret']) {
+            $raw = Crypt::encrypt($raw);
+        }
+
+        $setting = Setting::firstOrNew(['key' => $key]);
+        $setting->type = $meta['type'];
+        $setting->is_secret = $meta['is_secret'];
+        $setting->value = $raw;
+        $setting->save();
+
+        Cache::forget($this->cacheKey($key));
+    }
+
+    /**
+     * Determine whether a DB row exists for the given key.
+     */
+    public function has(string $key): bool
+    {
+        return Setting::where('key', $key)->exists();
+    }
+
+    /**
+     * Delete a DB row for the given key and invalidate the cache entry.
+     */
+    public function forget(string $key): void
+    {
+        Setting::where('key', $key)->delete();
+        Cache::forget($this->cacheKey($key));
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────────
+
+    /**
+     * Resolve the fallback value: caller-supplied default → registry config() path → null.
+     *
+     * @return mixed
+     */
+    private function resolveDefault(string $key, mixed $callerDefault): mixed
+    {
+        if ($callerDefault !== null) {
+            return $callerDefault;
+        }
+
+        $meta = SettingKeyRegistry::meta($key);
+
+        if ($meta['config'] !== null) {
+            return config($meta['config']);
+        }
+
+        return null;
+    }
+
+    /**
+     * Decrypt the stored value when the key is marked as a secret.
+     */
+    private function decryptIfSecret(string $key, ?string $raw): ?string
+    {
+        if ($raw === null) {
+            return null;
+        }
+
+        if (SettingKeyRegistry::meta($key)['is_secret']) {
+            return Crypt::decrypt($raw);
+        }
+
+        return $raw;
+    }
+
+    /**
+     * Coerce a raw string to a PHP type.
+     *
+     * @return mixed
+     */
+    private function coerceByType(?string $raw, string $type): mixed
+    {
+        if ($raw === null) {
+            return null;
+        }
+
+        return match ($type) {
+            'bool' => filter_var($raw, FILTER_VALIDATE_BOOLEAN),
+            'int' => (int) $raw,
+            'json' => json_decode($raw, true),
+            default => $raw,
+        };
+    }
+
+    /**
+     * Encode a PHP value to a string for DB storage.
+     *
+     * @param mixed $value
+     */
+    private function encode(mixed $value, string $type): string
+    {
+        return match ($type) {
+            'bool' => $value ? '1' : '0',
+            'json' => json_encode($value),
+            default => (string) $value,
+        };
+    }
+
+    /**
+     * Pack a type+value pair into a single cache string.
+     * Format: "{type}\x00{value}"
+     */
+    private function packCacheEntry(string $type, ?string $value): string
+    {
+        return $type . "\x00" . ($value ?? '');
+    }
+
+    /**
+     * Unpack a cache entry created by packCacheEntry().
+     *
+     * @return array{string, string|null}
+     */
+    private function unpackCacheEntry(string $entry): array
+    {
+        $pos = strpos($entry, "\x00");
+
+        if ($pos === false) {
+            // Fallback: treat as plain string (legacy / corrupted entry).
+            return ['string', $entry];
+        }
+
+        return [substr($entry, 0, $pos), substr($entry, $pos + 1)];
+    }
+
+    /**
+     * Return the cache key for a setting key.
+     */
+    private function cacheKey(string $key): string
+    {
+        return self::CACHE_PREFIX . $key;
+    }
+}

--- a/database/migrations/2026_05_29_000001_create_settings_table.php
+++ b/database/migrations/2026_05_29_000001_create_settings_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('settings', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')->unique();
+            $table->text('value')->nullable();
+            $table->string('type')->default('string'); // string | bool | int | json
+            $table->boolean('is_secret')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('settings');
+    }
+};

--- a/rules/database/schema.md
+++ b/rules/database/schema.md
@@ -113,6 +113,15 @@ erDiagram
         timestamps
     }
 
+    SETTINGS {
+        bigint id PK
+        string key UK
+        text value
+        string type
+        boolean is_secret
+        timestamps
+    }
+
     BOT_USERS ||--o{ MESSAGES : "has many"
     MESSAGES ||--o| EXTERNAL_MESSAGES : "has one"
     BOT_USERS ||--o| EXTERNAL_USERS : "has one"
@@ -347,6 +356,36 @@ Post-close feedback records. Created when `CloseTopic::execute()` closes a conve
 - `completed_no_comment` — user submitted a rating; comment column is NULL
 
 **Migration:** `database/migrations/2026_05_20_000001_create_feedbacks_table.php`
+
+---
+
+### `settings`
+
+Persistent key-value store for runtime-editable application configuration. Created by the Settings Persistence Layer (issue #150). Admin-panel UI for editing these values is implemented in dependent issues #144/#145/#146.
+
+| Column | Type | Nullable | Default | Description |
+|---|---|---|---|---|
+| `id` | `bigint` | No | auto | Primary key |
+| `key` | `string` | No | — | Dot-notation setting key (e.g. `app.manager_interface`, `telegram.token`) — unique |
+| `value` | `text` | Yes | NULL | Stored value; plain text for non-secrets, Laravel `Crypt::encrypt()` output for secrets |
+| `type` | `string` | No | `string` | PHP type for coercion when reading: `string` \| `bool` \| `int` \| `json` |
+| `is_secret` | `boolean` | No | `false` | When `true`, `value` is encrypted by `SettingsService`; readable in plain text only via `SettingsService::get()` |
+| `created_at` | `timestamp` | Yes | NULL | Creation time |
+| `updated_at` | `timestamp` | Yes | NULL | Last update time |
+
+**Indexes:**
+- PRIMARY on `id`
+- UNIQUE on `key` — one row per setting key
+
+**Reading priority:** `SettingsService::get($key)` reads: DB row → `config()`/`.env` default (defined in `SettingKeyRegistry`) → `null`.
+
+**Known keys and types** are declared in `app/Services/Settings/SettingKeyRegistry.php`. Unknown keys are accepted but default to `type=string`, no config fallback, `is_secret=false`.
+
+**Encryption:** `SettingsService` calls `Crypt::encrypt()` before writing and `Crypt::decrypt()` after reading for keys where `is_secret=true`. The `value` column stores the raw encrypted string — do not read it directly; always go through `SettingsService`.
+
+**DB stays empty by default.** No seed data is written at first deploy. `SettingsService::get()` falls back to `config()`/`.env` for every unknown key, so the app works normally with an empty `settings` table. Values enter the DB only when saved from the admin panel.
+
+**Migration:** `database/migrations/2026_05_29_000001_create_settings_table.php`
 
 ---
 

--- a/rules/process/architecture-design.md
+++ b/rules/process/architecture-design.md
@@ -289,7 +289,66 @@ Large monolithic generations are forbidden.
 
 ---
 
-## 9. Forbidden Behaviors
+## 9. Settings Access Pattern
+
+Any code that needs to read an editable application setting must use `SettingsService`, not `config()` directly.
+
+### Rule
+
+```php
+// ✅ Correct — reads via settings layer (DB → config fallback)
+$managerInterface = app(\App\Services\Settings\SettingsService::class)->get('app.manager_interface');
+
+// ❌ Incorrect in new settings-aware code — bypasses DB override layer
+$managerInterface = config('app.manager_interface');
+```
+
+### How it works
+
+```
+get($key)
+    │
+    ├─ Cache hit? ──────────────────────────────── return cached value (type-coerced)
+    │
+    ├─ DB row exists? ──── decrypt if secret ───── cache + return (type-coerced)
+    │
+    └─ No DB row ────────── config($key.path) ───── cache sentinel + return fallback
+                         └─ caller default
+                         └─ null
+```
+
+### Files
+
+| File | Role |
+|---|---|
+| `app/Services/Settings/SettingsService.php` | `get()` / `set()` / `has()` / `forget()` — single access point |
+| `app/Services/Settings/SettingKeyRegistry.php` | Registry of known keys: type, config fallback path, is_secret flag |
+| `app/Models/Setting.php` | Eloquent model for the `settings` table |
+| `database/migrations/2026_05_29_000001_create_settings_table.php` | Migration |
+
+### Adding a new setting key
+
+1. Add the key to `SettingKeyRegistry::$keys` with its `type`, `config` fallback, and `is_secret` flag.
+2. If a new `.env` variable is needed, add it to the appropriate `config/` file.
+3. No other file changes are required.
+
+### Secret handling
+
+Keys with `is_secret=true` in the registry are encrypted with `Crypt::encrypt()` before storage and decrypted transparently in `get()`. Do NOT read the `settings.value` column directly for secret keys.
+
+### Cache behaviour
+
+- Values are cached in the default cache store (Redis) under `settings.{key}` forever.
+- Cache is invalidated when `set()` or `forget()` is called.
+- A sentinel (`__settings_null__`) is cached when there is no DB row, preventing repeated DB misses.
+
+### Scope
+
+The Settings layer is a **backend foundation only**. Dependent tasks #144/#145/#146 add the Filament admin UI. Wiring `ManagerInterfaceContract` and platform module tokens to read from DB is also deferred to those tasks.
+
+---
+
+## 10. Forbidden Behaviors
 
 - ❌ Coding before design
 - ❌ Generating speculative architecture
@@ -301,7 +360,7 @@ Large monolithic generations are forbidden.
 
 ---
 
-## Checklist
+## 11. Checklist
 
 - [ ] Context files read
 - [ ] Problem defined in 1–3 sentences

--- a/tests/Unit/Models/SettingTest.php
+++ b/tests/Unit/Models/SettingTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Setting;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SettingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_fillable_fields(): void
+    {
+        $setting = new Setting();
+        $fillable = $setting->getFillable();
+
+        $this->assertContains('key', $fillable);
+        $this->assertContains('value', $fillable);
+        $this->assertContains('type', $fillable);
+        $this->assertContains('is_secret', $fillable);
+    }
+
+    public function test_is_secret_is_cast_to_boolean(): void
+    {
+        $setting = Setting::create([
+            'key' => 'test.bool_cast',
+            'value' => 'hello',
+            'type' => 'string',
+            'is_secret' => false,
+        ]);
+
+        $this->assertFalse($setting->is_secret);
+    }
+
+    public function test_is_secret_true_stored_and_retrieved(): void
+    {
+        $setting = Setting::create([
+            'key' => 'test.secret_flag',
+            'value' => 'some-value',
+            'type' => 'string',
+            'is_secret' => true,
+        ]);
+
+        $fresh = Setting::find($setting->id);
+        $this->assertNotNull($fresh);
+        $this->assertTrue($fresh->is_secret);
+    }
+
+    public function test_value_is_stored_as_text_in_db(): void
+    {
+        $setting = Setting::create([
+            'key' => 'test.plain',
+            'value' => 'plain-value',
+            'type' => 'string',
+            'is_secret' => false,
+        ]);
+
+        $rawRow = \Illuminate\Support\Facades\DB::table('settings')
+            ->where('id', $setting->id)
+            ->value('value');
+
+        $this->assertSame('plain-value', $rawRow);
+    }
+
+    public function test_type_column_is_stored_correctly(): void
+    {
+        foreach (['string', 'bool', 'int', 'json'] as $type) {
+            $setting = Setting::create([
+                'key' => 'test.type_' . $type,
+                'value' => 'x',
+                'type' => $type,
+                'is_secret' => false,
+            ]);
+
+            $fresh = Setting::find($setting->id);
+            $this->assertNotNull($fresh);
+            $this->assertSame($type, $fresh->type, "type column should store '{$type}'");
+        }
+    }
+
+    public function test_value_is_nullable(): void
+    {
+        $setting = Setting::create([
+            'key' => 'test.nullable',
+            'value' => null,
+            'type' => 'string',
+            'is_secret' => false,
+        ]);
+
+        $this->assertNull($setting->value);
+    }
+
+    public function test_created_at_is_cast_to_datetime(): void
+    {
+        $setting = Setting::create([
+            'key' => 'test.datetime_cast',
+            'value' => null,
+            'type' => 'string',
+            'is_secret' => false,
+        ]);
+
+        $this->assertInstanceOf(\Illuminate\Support\Carbon::class, $setting->created_at);
+    }
+}

--- a/tests/Unit/Services/Settings/SettingKeyRegistryTest.php
+++ b/tests/Unit/Services/Settings/SettingKeyRegistryTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Tests\Unit\Services\Settings;
+
+use App\Services\Settings\SettingKeyRegistry;
+use Tests\TestCase;
+
+class SettingKeyRegistryTest extends TestCase
+{
+    // ── meta() for known keys ────────────────────────────────────────────────
+
+    public function test_meta_returns_metadata_for_a_known_key(): void
+    {
+        $meta = SettingKeyRegistry::meta('app.manager_interface');
+
+        $this->assertSame('string', $meta['type']);
+        $this->assertSame('app.manager_interface', $meta['config']);
+        $this->assertFalse($meta['is_secret']);
+    }
+
+    public function test_meta_marks_secret_keys_as_secret(): void
+    {
+        $this->assertTrue(SettingKeyRegistry::meta('telegram.token')['is_secret']);
+        $this->assertTrue(SettingKeyRegistry::meta('vk.token')['is_secret']);
+        $this->assertTrue(SettingKeyRegistry::meta('ai.openai_api_key')['is_secret']);
+        $this->assertTrue(SettingKeyRegistry::meta('ai.gigachat_client_secret')['is_secret']);
+    }
+
+    public function test_meta_does_not_mark_non_secret_keys_as_secret(): void
+    {
+        $this->assertFalse(SettingKeyRegistry::meta('telegram.group_id')['is_secret']);
+        $this->assertFalse(SettingKeyRegistry::meta('ai.enabled')['is_secret']);
+        $this->assertFalse(SettingKeyRegistry::meta('ai.default_provider')['is_secret']);
+    }
+
+    public function test_meta_carries_the_typed_keys(): void
+    {
+        $this->assertSame('bool', SettingKeyRegistry::meta('ai.enabled')['type']);
+        $this->assertSame('int', SettingKeyRegistry::meta('ai.max_context_tokens')['type']);
+        $this->assertSame('int', SettingKeyRegistry::meta('telegram.bot_id')['type']);
+        $this->assertSame('string', SettingKeyRegistry::meta('max.token')['type']);
+    }
+
+    public function test_meta_points_each_key_to_its_config_fallback_path(): void
+    {
+        $this->assertSame(
+            'traffic_source.settings.telegram.token',
+            SettingKeyRegistry::meta('telegram.token')['config']
+        );
+        $this->assertSame(
+            'ai.providers.openai.api_key',
+            SettingKeyRegistry::meta('ai.openai_api_key')['config']
+        );
+    }
+
+    // ── meta() for unknown keys ──────────────────────────────────────────────
+
+    public function test_meta_returns_safe_defaults_for_an_unknown_key(): void
+    {
+        $meta = SettingKeyRegistry::meta('totally.unknown.key');
+
+        $this->assertSame('string', $meta['type']);
+        $this->assertNull($meta['config']);
+        $this->assertFalse($meta['is_secret']);
+    }
+
+    // ── keys() ───────────────────────────────────────────────────────────────
+
+    public function test_keys_returns_all_registered_keys(): void
+    {
+        $keys = SettingKeyRegistry::keys();
+
+        $this->assertContains('app.manager_interface', $keys);
+        $this->assertContains('telegram.token', $keys);
+        $this->assertContains('vk.confirm_code', $keys);
+        $this->assertContains('max.secret_key', $keys);
+        $this->assertContains('ai.default_provider', $keys);
+    }
+
+    public function test_keys_returns_a_list_of_unique_strings(): void
+    {
+        $keys = SettingKeyRegistry::keys();
+
+        $this->assertSame(array_values($keys), $keys);
+        $this->assertSame(array_unique($keys), $keys);
+        $this->assertContainsOnly('string', $keys);
+    }
+
+    // ── registered() ──────────────────────────────────────────────────────────
+
+    public function test_registered_is_true_for_a_known_key(): void
+    {
+        $this->assertTrue(SettingKeyRegistry::registered('app.manager_interface'));
+    }
+
+    public function test_registered_is_false_for_an_unknown_key(): void
+    {
+        $this->assertFalse(SettingKeyRegistry::registered('totally.unknown.key'));
+    }
+
+    public function test_every_registered_key_has_consistent_metadata_shape(): void
+    {
+        foreach (SettingKeyRegistry::keys() as $key) {
+            $meta = SettingKeyRegistry::meta($key);
+
+            $this->assertArrayHasKey('type', $meta);
+            $this->assertArrayHasKey('config', $meta);
+            $this->assertArrayHasKey('is_secret', $meta);
+            $this->assertContains($meta['type'], ['string', 'bool', 'int', 'json']);
+            $this->assertTrue(SettingKeyRegistry::registered($key));
+        }
+    }
+}

--- a/tests/Unit/Services/Settings/SettingsServiceTest.php
+++ b/tests/Unit/Services/Settings/SettingsServiceTest.php
@@ -1,0 +1,303 @@
+<?php
+
+namespace Tests\Unit\Services\Settings;
+
+use App\Models\Setting;
+use App\Services\Settings\SettingsService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class SettingsServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private SettingsService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Cache::flush();
+        $this->service = new SettingsService();
+    }
+
+    // ── Fallback to config() ─────────────────────────────────────────────────
+
+    public function test_get_falls_back_to_config_when_no_db_row_exists(): void
+    {
+        // 'app.manager_interface' has config fallback 'app.manager_interface'.
+        config(['app.manager_interface' => 'telegram_group']);
+
+        $value = $this->service->get('app.manager_interface');
+
+        $this->assertSame('telegram_group', $value);
+    }
+
+    public function test_get_returns_null_for_unknown_key_with_no_db_row(): void
+    {
+        $value = $this->service->get('unknown.key.xyz');
+
+        $this->assertNull($value);
+    }
+
+    public function test_get_returns_caller_default_when_no_db_row_and_no_config(): void
+    {
+        $value = $this->service->get('unknown.key.xyz', 'my-default');
+
+        $this->assertSame('my-default', $value);
+    }
+
+    // ── DB override ──────────────────────────────────────────────────────────
+
+    public function test_get_returns_db_value_overriding_config_fallback(): void
+    {
+        config(['app.manager_interface' => 'telegram_group']);
+
+        Setting::create([
+            'key' => 'app.manager_interface',
+            'value' => 'admin_panel',
+            'type' => 'string',
+            'is_secret' => false,
+        ]);
+
+        $value = $this->service->get('app.manager_interface');
+
+        $this->assertSame('admin_panel', $value);
+    }
+
+    // ── set() + cache invalidation ───────────────────────────────────────────
+
+    public function test_set_creates_db_row_and_get_returns_new_value(): void
+    {
+        $this->service->set('app.manager_interface', 'admin_panel');
+
+        $value = $this->service->get('app.manager_interface');
+
+        $this->assertSame('admin_panel', $value);
+    }
+
+    public function test_set_invalidates_cache_so_next_get_reads_from_db(): void
+    {
+        // Prime the cache with the old value by calling get() first.
+        Setting::create([
+            'key' => 'app.manager_interface',
+            'value' => 'telegram_group',
+            'type' => 'string',
+            'is_secret' => false,
+        ]);
+        $this->service->get('app.manager_interface'); // warms the cache
+
+        // Now overwrite via set().
+        $this->service->set('app.manager_interface', 'admin_panel');
+
+        // After set() the cache entry must be gone; next get() reads from DB.
+        $value = $this->service->get('app.manager_interface');
+        $this->assertSame('admin_panel', $value);
+    }
+
+    public function test_set_updates_existing_db_row(): void
+    {
+        $this->service->set('app.manager_interface', 'telegram_group');
+        $this->service->set('app.manager_interface', 'admin_panel');
+
+        $count = Setting::where('key', 'app.manager_interface')->count();
+        $this->assertSame(1, $count);
+
+        $value = $this->service->get('app.manager_interface');
+        $this->assertSame('admin_panel', $value);
+    }
+
+    // ── Secret encryption ────────────────────────────────────────────────────
+
+    public function test_set_stores_secret_value_encrypted_in_db(): void
+    {
+        $this->service->set('telegram.token', 'super-secret-token');
+
+        $rawRow = \Illuminate\Support\Facades\DB::table('settings')
+            ->where('key', 'telegram.token')
+            ->value('value');
+
+        $this->assertNotSame('super-secret-token', $rawRow, 'Secret value must be encrypted in DB');
+        $this->assertNotEmpty($rawRow);
+    }
+
+    public function test_get_returns_decrypted_value_for_secret_key(): void
+    {
+        $this->service->set('telegram.token', 'super-secret-token');
+        Cache::flush(); // force a fresh DB read
+
+        $value = $this->service->get('telegram.token');
+
+        $this->assertSame('super-secret-token', $value);
+    }
+
+    public function test_non_secret_key_is_stored_as_plain_text(): void
+    {
+        $this->service->set('app.manager_interface', 'admin_panel');
+
+        $rawRow = \Illuminate\Support\Facades\DB::table('settings')
+            ->where('key', 'app.manager_interface')
+            ->value('value');
+
+        $this->assertSame('admin_panel', $rawRow, 'Non-secret value must be stored as plain text');
+    }
+
+    // ── Type coercion ────────────────────────────────────────────────────────
+
+    public function test_get_coerces_bool_type_to_php_bool(): void
+    {
+        Setting::create(['key' => 'ai.enabled', 'value' => '1', 'type' => 'bool', 'is_secret' => false]);
+
+        $value = $this->service->get('ai.enabled');
+
+        $this->assertIsBool($value);
+        $this->assertTrue($value);
+    }
+
+    public function test_get_coerces_bool_false_correctly(): void
+    {
+        Setting::create(['key' => 'ai.enabled', 'value' => '0', 'type' => 'bool', 'is_secret' => false]);
+
+        $value = $this->service->get('ai.enabled');
+
+        $this->assertIsBool($value);
+        $this->assertFalse($value);
+    }
+
+    public function test_get_coerces_int_type_to_php_int(): void
+    {
+        Setting::create(['key' => 'ai.max_context_tokens', 'value' => '5000', 'type' => 'int', 'is_secret' => false]);
+
+        $value = $this->service->get('ai.max_context_tokens');
+
+        $this->assertIsInt($value);
+        $this->assertSame(5000, $value);
+    }
+
+    public function test_get_coerces_json_type_to_php_array(): void
+    {
+        // Use the DB row's `type` column directly — unregistered key, but type='json' in DB.
+        Setting::create([
+            'key' => 'test.json_setting',
+            'value' => '{"foo":"bar","num":42}',
+            'type' => 'json',
+            'is_secret' => false,
+        ]);
+
+        $value = $this->service->get('test.json_setting');
+
+        $this->assertIsArray($value);
+        $this->assertSame('bar', $value['foo']);
+        $this->assertSame(42, $value['num']);
+    }
+
+    public function test_set_encodes_bool_value_to_string_for_storage(): void
+    {
+        $this->service->set('ai.enabled', true);
+
+        $rawRow = \Illuminate\Support\Facades\DB::table('settings')
+            ->where('key', 'ai.enabled')
+            ->value('value');
+
+        $this->assertSame('1', $rawRow);
+    }
+
+    public function test_set_encodes_int_value_to_string_for_storage(): void
+    {
+        $this->service->set('ai.max_context_tokens', 9999);
+
+        $rawRow = \Illuminate\Support\Facades\DB::table('settings')
+            ->where('key', 'ai.max_context_tokens')
+            ->value('value');
+
+        $this->assertSame('9999', $rawRow);
+    }
+
+    // ── has() ────────────────────────────────────────────────────────────────
+
+    public function test_has_returns_false_when_no_db_row(): void
+    {
+        $this->assertFalse($this->service->has('app.manager_interface'));
+    }
+
+    public function test_has_returns_true_when_db_row_exists(): void
+    {
+        $this->service->set('app.manager_interface', 'telegram_group');
+
+        $this->assertTrue($this->service->has('app.manager_interface'));
+    }
+
+    // ── forget() ────────────────────────────────────────────────────────────
+
+    public function test_forget_deletes_db_row(): void
+    {
+        $this->service->set('app.manager_interface', 'admin_panel');
+        $this->service->forget('app.manager_interface');
+
+        $this->assertFalse($this->service->has('app.manager_interface'));
+    }
+
+    public function test_forget_invalidates_cache_so_get_falls_back_to_config(): void
+    {
+        config(['app.manager_interface' => 'telegram_group']);
+
+        $this->service->set('app.manager_interface', 'admin_panel');
+        $this->service->get('app.manager_interface'); // warms cache with 'admin_panel'
+
+        $this->service->forget('app.manager_interface');
+
+        // After forget, get() must return the config fallback.
+        $value = $this->service->get('app.manager_interface');
+        $this->assertSame('telegram_group', $value);
+    }
+
+    public function test_forget_does_not_throw_when_key_does_not_exist(): void
+    {
+        // Must not throw.
+        $this->service->forget('non.existent.key');
+        $this->assertFalse($this->service->has('non.existent.key'));
+    }
+
+    // ── Caching ──────────────────────────────────────────────────────────────
+
+    public function test_get_serves_value_from_cache_on_second_call(): void
+    {
+        Setting::create([
+            'key' => 'app.manager_interface',
+            'value' => 'admin_panel',
+            'type' => 'string',
+            'is_secret' => false,
+        ]);
+
+        $first = $this->service->get('app.manager_interface'); // warms cache
+        // Delete the DB row to prove the next call uses cache, not DB.
+        Setting::where('key', 'app.manager_interface')->delete();
+
+        $second = $this->service->get('app.manager_interface');
+
+        $this->assertSame('admin_panel', $first);
+        $this->assertSame('admin_panel', $second);
+    }
+
+    public function test_get_caches_null_sentinel_when_no_db_row(): void
+    {
+        config(['app.manager_interface' => 'telegram_group']);
+
+        // First call: no DB row — should cache the sentinel.
+        $first = $this->service->get('app.manager_interface');
+
+        // Insert a DB row now — a second get() must still return config fallback
+        // because the sentinel is cached and we haven't called set().
+        Setting::create([
+            'key' => 'app.manager_interface',
+            'value' => 'admin_panel',
+            'type' => 'string',
+            'is_secret' => false,
+        ]);
+        $second = $this->service->get('app.manager_interface');
+
+        $this->assertSame('telegram_group', $first);
+        $this->assertSame('telegram_group', $second);
+    }
+}


### PR DESCRIPTION
## Summary

Backend-фундамент для редактируемых из админ-панели настроек: единый слой чтения/записи конфигурации с приоритетом **БД → `config()`/`.env` → `null`**, кэшем, типизацией и шифрованием секретов. UI/Filament не входит в задачу (его делают зависимые задачи #144/#145/#146).

> Базовая ветка PR — **`dev`** (работа велась от `dev` по запросу), не `main`.

## Что сделано

- **Миграция `settings`** (`database/migrations/2026_05_29_000001_create_settings_table.php`) — `key` (unique), `value` (nullable text), `type`, `is_secret`, timestamps.
- **Модель** `app/Models/Setting.php` — fillable + cast `is_secret`→bool.
- **`SettingsService`** (`app/Services/Settings/SettingsService.php`) — `get/set/has/forget`. Приоритет чтения БД → `config()`/`.env` → `null`; шифрование секретных ключей через `Crypt` (в сервисе, не в модели — чтобы обойти проблему порядка fill при динамических кастах); приведение типов `string/bool/int/json`; кэш в дефолтном сторе с инвалидацией на `set`/`forget` и sentinel для отсутствующих строк.
- **`SettingKeyRegistry`** (`app/Services/Settings/SettingKeyRegistry.php`) — реестр известных ключей (app/telegram/telegram_ai/vk/max/ai) с метаданными `type` / `config`-fallback / `is_secret`. Новый ключ = одна строка массива.
- **`AppServiceProvider`** — `SettingsService` зарегистрирован синглтоном.
- **Тесты** — `tests/Unit/Models/SettingTest.php` (7), `tests/Unit/Services/Settings/SettingsServiceTest.php` (23), `tests/Unit/Services/Settings/SettingKeyRegistryTest.php` (11). Всего **41** новый тест.
- **Документация** — `rules/database/schema.md` (таблица `settings`), `rules/process/architecture-design.md` (раздел «Settings Access Pattern»), `CLAUDE.md` (Settings Pattern + структура + бизнес-правила).

## Принятые решения (по открытым вопросам спека)

- Собственная таблица `settings` + модель — **без** пакета `spatie/laravel-settings`.
- Шифрование секретов — в `SettingsService` через `Crypt`, ключи помечаются `is_secret` в реестре.
- БД по умолчанию пустая: до первого сохранения всё читается из `config()`/`.env` — поведение приложения не меняется.
- Перепривязка `ManagerInterfaceContract` и платформенных токенов на чтение из БД **отложена** в зависимые задачи (вне scope) — здесь заложен только механизм.
- boot-override `config()` не вводился: потребители вызывают `SettingsService::get()` явно.

## Проверки

- Pint — чисто; PHPStan level 6 — 0 ошибок; `php artisan test` — **423 passed (1188 assertions)**, включая 41 новый тест.
- Репозиторный pre-commit gate `find_test` потребовал тест для `SettingKeyRegistry` (его не было) — добавлен; исправлены `assertIsBool`-замечания PHPStan в тестах.

## Блокирует
- #144 (Интеграции / Подключение каналов), #145 (ИИ-ассистент), #146 (Основные настройки)

Closes #150