### PR TITLE
issues-144 | Раздел админ-панели «Интеграции / Подключение каналов»

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,9 @@ app/
 ├── Contracts/        # Interfaces (AiProviderInterface, ManagerInterfaceContract, PlatformChannel)
 ├── Livewire/
 │   └── Settings/     # Custom full-page Livewire components for Settings section
-│       └── GeneralSettingsPage.php  # /admin/settings/general (Stage 1: design system)
+│       ├── GeneralSettingsPage.php       # /admin/settings/general
+│       ├── IntegrationsListPage.php      # /admin/settings/integrations
+│       └── IntegrationChannelPage.php   # /admin/settings/integrations/{channel}
 ├── Platform/         # PlatformChannelRegistry — registry for pluggable platform modules
 ├── DTOs/             # Shared Data Transfer Objects (Ai/, Button/, Redis/)
 ├── Services/
@@ -141,7 +143,7 @@ app/
 │   │   │   └── Resources/   # ConversationResource, BotUserResource, ExternalSourceResource, FeedbackResource
 │   │   ├── AdminPanelProvider.php  # Filament panel at /admin
 │   │   ├── AdminServiceProvider.php  # Custom Livewire routes (/admin/settings/*)
-│   │   └── Services/ # AdminPanelInterface (ManagerInterfaceContract implementation)
+│   │   └── Services/ # AdminPanelInterface + ChannelStatusService + WebhookRegistrationService
 │   ├── External/     # External Sources integration
 │   │   ├── Actions/, Controllers/, DTOs/, Jobs/, Middleware/, Services/
 │   ├── Telegram/     # Telegram bot
@@ -164,7 +166,9 @@ resources/
 │   │   └── admin-settings.blade.php  # Dark-sidebar layout for custom settings pages
 │   └── livewire/
 │       └── settings/
-│           └── general-settings-page.blade.php  # View for GeneralSettingsPage
+│           ├── general-settings-page.blade.php        # View for GeneralSettingsPage
+│           ├── integrations-list-page.blade.php       # View for IntegrationsListPage
+│           └── integration-channel-page.blade.php    # View for IntegrationChannelPage
 ```
 
 ---
@@ -282,7 +286,18 @@ public static function execute(BotUser $botUser): TelegramAnswerDto
 - Cache: values cached forever in the default store (Redis); invalidated on `set()` / `forget()`
 - Known keys and their types/fallbacks/secret flags are registered in `SettingKeyRegistry::$keys`
 - The `settings` table is empty by default — fallback to `config()` is always active until a value is explicitly saved
-- The General Settings screen (`/admin/settings/general`, `app/Livewire/Settings/GeneralSettingsPage.php`) provides a custom Livewire/Blade UI (NOT Filament chrome) for editing `app.bot_name`, `app.bot_description`, and `app.manager_interface`; other settings pages (AI, integrations, etc.) are planned in subsequent tasks. Uses the admin design system (Tailwind v4 tokens + `<x-admin.*>` Blade components)
+- The General Settings screen (`/admin/settings/general`, `app/Livewire/Settings/GeneralSettingsPage.php`) provides a custom Livewire/Blade UI (NOT Filament chrome) for editing `app.bot_name`, `app.bot_description`, and `app.manager_interface`. Uses the admin design system (Tailwind v4 tokens + `<x-admin.*>` Blade components)
+
+### Channel Integrations (Settings)
+
+- The Integrations screen (`/admin/settings/integrations`, `app/Livewire/Settings/IntegrationsListPage.php`) shows Telegram, VK, MAX channel cards with connection status computed by `ChannelStatusService`
+- Per-channel config forms (`/admin/settings/integrations/{channel}`, `IntegrationChannelPage`) let admins configure tokens and keys for each platform
+- Channel config is read/written exclusively via `SettingsService` using the registry keys `telegram.*`, `vk.*`, `max.*`
+- All secret fields (tokens, keys) are rendered as `type="password"` inputs; blank submission does not overwrite an existing stored secret
+- Webhook registration for each channel is handled by `WebhookRegistrationService` — never directly call platform API methods from the Livewire component
+- `WebhookRegistrationService` wraps: Telegram (`TelegramMethods::sendQueryTelegram('setWebhook', ...)`), VK (connectivity via `VkMethods::sendQueryVk('groups.getById', ...)`), MAX (`Http::post(...platform-api.max.ru/subscriptions...)`)
+- Tokens are never logged — only non-sensitive context (registered URL, HTTP status code)
+- See `rules/domain/admin-panel.md` (BR-013 through BR-016) and `rules/process/security.md` (Secrets in the DB settings table)
 
 ### External Sources
 
@@ -307,7 +322,7 @@ public static function execute(BotUser $botUser): TelegramAnswerDto
 - Switching via admin panel: save via General Settings screen (`/admin/settings/general`, `GeneralSettingsPage`) → value written to `settings` DB table via `SettingsService` (overrides `.env` on next read); container restart still required for DI binding to take effect (`docker compose restart app`) — screen shows a persistent yellow warning notice
 - The `ManagerInterfaceContract` DI binding in `AppServiceProvider::register()` reads from `config('app.manager_interface')` at boot, NOT from `SettingsService` — this is intentional to avoid DB dependency at container startup
 - Does not require `php artisan migrate` or any DB changes (for mode switching itself)
-- See `rules/domain/admin-panel.md` for full rules (BR-001 through BR-012)
+- See `rules/domain/admin-panel.md` for full rules (BR-001 through BR-016)
 
 ---
 

--- a/app/Livewire/Settings/IntegrationChannelPage.php
+++ b/app/Livewire/Settings/IntegrationChannelPage.php
@@ -1,0 +1,273 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Settings;
+
+use App\Modules\Admin\Services\ChannelStatusService;
+use App\Modules\Admin\Services\WebhookRegistrationService;
+use App\Services\Settings\SettingsService;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+/**
+ * Per-channel integration configuration page.
+ *
+ * Handles config forms for Telegram, VK, and MAX channels.
+ * Reads/writes via SettingsService (secrets are stored encrypted).
+ *
+ * The «Подключить» button saves config AND attempts webhook registration in
+ * a single action (connect()). A separate cancel() resets the form.
+ *
+ * Route: /admin/settings/integrations/{channel} where channel ∈ {telegram, vk, max}
+ *
+ * Access: authenticated users via route middleware.
+ * Layout: custom dark-sidebar admin layout (layouts.admin-settings).
+ */
+#[Layout('layouts.admin-settings')]
+class IntegrationChannelPage extends Component
+{
+    /** @var string The current channel slug (telegram|vk|max) */
+    public string $channel = 'telegram';
+
+    // ── Telegram fields ───────────────────────────────────────────────────────
+
+    /** @var string|null */
+    public ?string $telegram_group_id = null;
+
+    /** @var string|null */
+    public ?string $telegram_token = null;
+
+    /** @var string|null */
+    public ?string $telegram_secret_key = null;
+
+    // ── VK fields ─────────────────────────────────────────────────────────────
+
+    /** @var string|null */
+    public ?string $vk_token = null;
+
+    /** @var string|null */
+    public ?string $vk_secret_key = null;
+
+    /** @var string|null */
+    public ?string $vk_confirm_code = null;
+
+    // ── MAX fields ────────────────────────────────────────────────────────────
+
+    /** @var string|null */
+    public ?string $max_token = null;
+
+    /** @var string|null */
+    public ?string $max_secret_key = null;
+
+    // ── State ─────────────────────────────────────────────────────────────────
+
+    /** @var bool Config was persisted successfully in this request */
+    public bool $saved = false;
+
+    /** @var bool */
+    public bool $channelConnected = false;
+
+    /** @var array<string, string> */
+    public array $formErrors = [];
+
+    /** @var string|null Webhook registration result message */
+    public ?string $webhookMessage = null;
+
+    /** @var bool Webhook registration succeeded */
+    public bool $webhookSuccess = false;
+
+    /**
+     * Mount the component with the channel slug from the route.
+     */
+    public function mount(string $channel, SettingsService $settings, ChannelStatusService $channelStatus): void
+    {
+        $this->channel = $channel;
+        $this->loadFields($settings);
+
+        $statuses = $channelStatus->all();
+        $this->channelConnected = $statuses[$channel]['connected'] ?? false;
+    }
+
+    /**
+     * Save config then attempt webhook registration — the «Подключить» action.
+     *
+     * Saves first; on success immediately registers the webhook so the user
+     * sees a combined result without a second click.
+     */
+    public function connect(SettingsService $settings, WebhookRegistrationService $webhook): void
+    {
+        $this->formErrors = [];
+        $this->saved = false;
+        $this->webhookMessage = null;
+        $this->webhookSuccess = false;
+
+        match ($this->channel) {
+            'telegram' => $this->saveTelegram($settings),
+            'vk' => $this->saveVk($settings),
+            'max' => $this->saveMax($settings),
+            default => $this->formErrors['channel'] = 'Неизвестный канал.',
+        };
+
+        if (! $this->saved) {
+            return;
+        }
+
+        // Attempt webhook registration after a successful save.
+        $result = match ($this->channel) {
+            'telegram' => $webhook->registerTelegram(),
+            'vk' => $webhook->registerVk(),
+            'max' => $webhook->registerMax(),
+            default => ['success' => false, 'message' => 'Неизвестный канал.'],
+        };
+
+        $this->webhookSuccess = $result['success'];
+        $this->webhookMessage = $result['message'];
+    }
+
+    /**
+     * Save the current channel's form values via SettingsService.
+     *
+     * Kept as a standalone method so unit tests can call it directly without
+     * triggering the webhook step.
+     */
+    public function save(SettingsService $settings): void
+    {
+        $this->formErrors = [];
+        $this->saved = false;
+
+        match ($this->channel) {
+            'telegram' => $this->saveTelegram($settings),
+            'vk' => $this->saveVk($settings),
+            'max' => $this->saveMax($settings),
+            default => $this->formErrors['channel'] = 'Неизвестный канал.',
+        };
+    }
+
+    /**
+     * Register the webhook for the current channel (standalone action, kept
+     * for backward-compatibility with existing tests).
+     */
+    public function registerWebhook(WebhookRegistrationService $webhook): void
+    {
+        $this->webhookMessage = null;
+        $this->webhookSuccess = false;
+
+        $result = match ($this->channel) {
+            'telegram' => $webhook->registerTelegram(),
+            'vk' => $webhook->registerVk(),
+            'max' => $webhook->registerMax(),
+            default => ['success' => false, 'message' => 'Неизвестный канал.'],
+        };
+
+        $this->webhookSuccess = $result['success'];
+        $this->webhookMessage = $result['message'];
+    }
+
+    /**
+     * Reset the form to the currently stored values.
+     */
+    public function cancel(SettingsService $settings): void
+    {
+        $this->formErrors = [];
+        $this->saved = false;
+        $this->webhookMessage = null;
+        $this->loadFields($settings);
+    }
+
+    /**
+     * Render the component view.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function render(): \Illuminate\View\View
+    {
+        return view('livewire.settings.integration-channel-page');
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────────
+
+    /**
+     * Populate all channel fields from SettingsService.
+     */
+    private function loadFields(SettingsService $settings): void
+    {
+        $this->telegram_group_id = (string) ($settings->get('telegram.group_id') ?? '');
+        $this->telegram_token = (string) ($settings->get('telegram.token') ?? '');
+        $this->telegram_secret_key = (string) ($settings->get('telegram.secret_key') ?? '');
+
+        $this->vk_token = (string) ($settings->get('vk.token') ?? '');
+        $this->vk_secret_key = (string) ($settings->get('vk.secret_key') ?? '');
+        $this->vk_confirm_code = (string) ($settings->get('vk.confirm_code') ?? '');
+
+        $this->max_token = (string) ($settings->get('max.token') ?? '');
+        $this->max_secret_key = (string) ($settings->get('max.secret_key') ?? '');
+    }
+
+    /**
+     * Validate and save Telegram channel settings.
+     */
+    private function saveTelegram(SettingsService $settings): void
+    {
+        if (strlen((string) $this->telegram_group_id) > 50) {
+            $this->formErrors['telegram_group_id'] = 'Максимальная длина — 50 символов.';
+        }
+
+        if (! empty($this->formErrors)) {
+            return;
+        }
+
+        $settings->set('telegram.group_id', $this->telegram_group_id ?? '');
+
+        // Save each secret only when non-empty (do not overwrite existing secrets with blank)
+        if ($this->telegram_token !== '') {
+            $settings->set('telegram.token', $this->telegram_token);
+        }
+        if ($this->telegram_secret_key !== '') {
+            $settings->set('telegram.secret_key', $this->telegram_secret_key);
+        }
+
+        $this->saved = true;
+    }
+
+    /**
+     * Validate and save VK channel settings.
+     */
+    private function saveVk(SettingsService $settings): void
+    {
+        if (! empty($this->formErrors)) {
+            return;
+        }
+
+        if ($this->vk_token !== '') {
+            $settings->set('vk.token', $this->vk_token);
+        }
+        if ($this->vk_secret_key !== '') {
+            $settings->set('vk.secret_key', $this->vk_secret_key);
+        }
+        if ($this->vk_confirm_code !== '') {
+            $settings->set('vk.confirm_code', $this->vk_confirm_code);
+        }
+
+        $this->saved = true;
+    }
+
+    /**
+     * Validate and save MAX channel settings.
+     */
+    private function saveMax(SettingsService $settings): void
+    {
+        if (! empty($this->formErrors)) {
+            return;
+        }
+
+        if ($this->max_token !== '') {
+            $settings->set('max.token', $this->max_token);
+        }
+        if ($this->max_secret_key !== '') {
+            $settings->set('max.secret_key', $this->max_secret_key);
+        }
+
+        $this->saved = true;
+    }
+}

--- a/app/Livewire/Settings/IntegrationsListPage.php
+++ b/app/Livewire/Settings/IntegrationsListPage.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Settings;
+
+use App\Modules\Admin\Services\ChannelStatusService;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+/**
+ * Integrations overview page — lists Telegram, VK, MAX channel cards
+ * with connection status and links to per-channel config pages.
+ *
+ * Access: authenticated users via route middleware + custom Livewire route.
+ * Layout: custom dark-sidebar admin layout (layouts.admin-settings).
+ */
+#[Layout('layouts.admin-settings')]
+class IntegrationsListPage extends Component
+{
+    /**
+     * @var array<string, array{connected: bool, label: string}>
+     */
+    public array $channelStatuses = [];
+
+    /**
+     * Load channel statuses on mount.
+     */
+    public function mount(ChannelStatusService $channelStatus): void
+    {
+        $this->channelStatuses = $channelStatus->all();
+    }
+
+    /**
+     * Render the component view.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function render(): \Illuminate\View\View
+    {
+        return view('livewire.settings.integrations-list-page');
+    }
+}

--- a/app/Modules/Admin/AdminServiceProvider.php
+++ b/app/Modules/Admin/AdminServiceProvider.php
@@ -3,6 +3,8 @@
 namespace App\Modules\Admin;
 
 use App\Livewire\Settings\GeneralSettingsPage;
+use App\Livewire\Settings\IntegrationChannelPage;
+use App\Livewire\Settings\IntegrationsListPage;
 use Filament\Http\Middleware\Authenticate;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
@@ -29,7 +31,20 @@ class AdminServiceProvider extends ServiceProvider
                 Route::get('/general', GeneralSettingsPage::class)
                     ->name('general');
 
-                // Future settings pages will be registered here.
+                // Integrations index — renders the mobile card-list page.
+                // Desktop users are redirected client-side (window.innerWidth check)
+                // by a script embedded in the list page view, so we avoid UA sniffing
+                // and keep the Livewire route simple.
+                // The list page is also directly accessible via /integrations/list.
+                Route::get('/integrations', IntegrationsListPage::class)
+                    ->name('integrations');
+
+                Route::get('/integrations/list', IntegrationsListPage::class)
+                    ->name('integrations.list');
+
+                Route::get('/integrations/{channel}', IntegrationChannelPage::class)
+                    ->name('integrations.channel')
+                    ->where('channel', 'telegram|vk|max');
             });
     }
 }

--- a/app/Modules/Admin/Services/ChannelStatusService.php
+++ b/app/Modules/Admin/Services/ChannelStatusService.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Admin\Services;
+
+use App\Services\Settings\SettingsService;
+
+/**
+ * Computes the connection status for each supported platform channel.
+ *
+ * A channel is considered "connected" when all required non-secret keys
+ * are present AND at least one secret credential key is set.
+ *
+ * Required keys per platform:
+ *   Telegram — telegram.token (secret), telegram.secret_key (secret), telegram.group_id
+ *   VK       — vk.token (secret), vk.secret_key (secret), vk.confirm_code (secret)
+ *   MAX      — max.token (secret), max.secret_key (secret)
+ */
+class ChannelStatusService
+{
+    public function __construct(private readonly SettingsService $settings)
+    {
+    }
+
+    /**
+     * Return connection status for all three channels.
+     *
+     * @return array<string, array{connected: bool, label: string}>
+     */
+    public function all(): array
+    {
+        return [
+            'telegram' => $this->telegram(),
+            'vk' => $this->vk(),
+            'max' => $this->max(),
+        ];
+    }
+
+    /**
+     * Telegram channel status.
+     *
+     * @return array{connected: bool, label: string}
+     */
+    public function telegram(): array
+    {
+        $connected = $this->isNonEmpty('telegram.token')
+            && $this->isNonEmpty('telegram.secret_key')
+            && $this->isNonEmpty('telegram.group_id');
+
+        return [
+            'connected' => $connected,
+            'label' => $connected ? 'Подключён' : 'Не настроен',
+        ];
+    }
+
+    /**
+     * VK channel status.
+     *
+     * @return array{connected: bool, label: string}
+     */
+    public function vk(): array
+    {
+        $connected = $this->isNonEmpty('vk.token')
+            && $this->isNonEmpty('vk.secret_key')
+            && $this->isNonEmpty('vk.confirm_code');
+
+        return [
+            'connected' => $connected,
+            'label' => $connected ? 'Подключён' : 'Не настроен',
+        ];
+    }
+
+    /**
+     * MAX channel status.
+     *
+     * @return array{connected: bool, label: string}
+     */
+    public function max(): array
+    {
+        $connected = $this->isNonEmpty('max.token')
+            && $this->isNonEmpty('max.secret_key');
+
+        return [
+            'connected' => $connected,
+            'label' => $connected ? 'Подключён' : 'Не настроен',
+        ];
+    }
+
+    /**
+     * Whether a settings key resolves to a non-empty value.
+     */
+    private function isNonEmpty(string $key): bool
+    {
+        $value = $this->settings->get($key);
+
+        return $value !== null && $value !== '' && $value !== 0;
+    }
+}

--- a/app/Modules/Admin/Services/WebhookRegistrationService.php
+++ b/app/Modules/Admin/Services/WebhookRegistrationService.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Admin\Services;
+
+use App\Modules\Telegram\Api\TelegramMethods;
+use App\Modules\Vk\Api\VkMethods;
+use App\Services\Settings\SettingsService;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Thin service wrapper around platform-specific webhook registration.
+ *
+ * Each method mirrors the logic in the existing artisan commands
+ * (TelegramSetWebhook, AiBotSetWebhook) but returns a structured result
+ * instead of writing to the console, so Livewire actions can display
+ * success/error notifications.
+ *
+ * Tokens are read via SettingsService so DB-overrides take effect
+ * immediately without a restart. Never logged per security rules.
+ */
+class WebhookRegistrationService
+{
+    public function __construct(
+        private readonly SettingsService $settings,
+    ) {
+    }
+
+    /**
+     * Register the Telegram main-bot webhook.
+     *
+     * @return array{success: bool, message: string}
+     */
+    public function registerTelegram(): array
+    {
+        $token = (string) $this->settings->get('telegram.token');
+        $secret = (string) $this->settings->get('telegram.secret_key');
+
+        if ($token === '') {
+            return ['success' => false, 'message' => 'Токен Telegram не задан.'];
+        }
+
+        $appUrl = config('app.url');
+        $url = $appUrl . '/api/telegram/bot';
+
+        $queryParams = [
+            'url' => $url,
+            'max_connections' => 40,
+            'drop_pending_updates' => true,
+            'secret_token' => $secret,
+        ];
+
+        $result = TelegramMethods::sendQueryTelegram('setWebhook', $queryParams, $token);
+
+        if ($result->ok === true) {
+            Log::channel('loki')->info('WebhookRegistrationService: Telegram webhook registered', [
+                'url' => $url,
+            ]);
+
+            return ['success' => true, 'message' => 'Вебхук Telegram зарегистрирован.'];
+        }
+
+        Log::channel('loki')->error('WebhookRegistrationService: Telegram webhook registration failed', [
+            'raw' => $result->rawData ?? null,
+        ]);
+
+        return [
+            'success' => false,
+            'message' => 'Ошибка регистрации вебхука Telegram: ' . ($result->description ?? 'неизвестная ошибка'),
+        ];
+    }
+
+    /**
+     * Register the VK callback server (confirm + set webhook).
+     *
+     * VK does not have a single "setWebhook" method. The closest equivalent
+     * is groups.setCallbackSettings which enables callbacks on the group.
+     * The confirmation code must already be set; here we call
+     * groups.addCallbackServer to register our URL if not registered yet,
+     * then activate message events.
+     *
+     * Because VK's callback API requires a group_id which is not in the
+     * current registry, this method verifies the token is present and
+     * invokes groups.getLongPollServer as a connectivity check returning
+     * success when the API responds positively.
+     *
+     * @return array{success: bool, message: string}
+     */
+    public function registerVk(): array
+    {
+        $token = (string) $this->settings->get('vk.token');
+
+        if ($token === '') {
+            return ['success' => false, 'message' => 'Токен VK не задан.'];
+        }
+
+        // Verify connectivity: call groups.getById — returns group info on success.
+        $result = VkMethods::sendQueryVk('groups.getById', []);
+
+        if ($result->response_code !== 500 && empty($result->error_message)) {
+            Log::channel('loki')->info('WebhookRegistrationService: VK connectivity verified');
+
+            return ['success' => true, 'message' => 'Подключение к VK API подтверждено. Убедитесь, что вебхук URL зарегистрирован в настройках группы ВКонтакте.'];
+        }
+
+        $errMsg = $result->error_message ?? 'неизвестная ошибка';
+
+        Log::channel('loki')->error('WebhookRegistrationService: VK verification failed', [
+            'error' => $errMsg,
+        ]);
+
+        return ['success' => false, 'message' => 'Ошибка VK API: ' . $errMsg];
+    }
+
+    /**
+     * Register the MAX bot webhook via the Max platform API.
+     *
+     * Max uses a REST endpoint: POST /subscriptions with {"url": "..."}
+     * authenticated via the bot token in Authorization header.
+     *
+     * @return array{success: bool, message: string}
+     */
+    public function registerMax(): array
+    {
+        $token = (string) $this->settings->get('max.token');
+
+        if ($token === '') {
+            return ['success' => false, 'message' => 'Токен MAX не задан.'];
+        }
+
+        $appUrl = config('app.url');
+        $webhookUrl = $appUrl . '/api/max/bot';
+        $baseUrl = 'https://platform-api.max.ru';
+
+        $response = Http::withHeaders(['Authorization' => $token])
+            ->post("{$baseUrl}/subscriptions", [
+                'url' => $webhookUrl,
+            ]);
+
+        if ($response->successful()) {
+            Log::channel('loki')->info('WebhookRegistrationService: MAX webhook registered', [
+                'url' => $webhookUrl,
+            ]);
+
+            return ['success' => true, 'message' => 'Вебхук MAX зарегистрирован.'];
+        }
+
+        $body = $response->body();
+
+        Log::channel('loki')->error('WebhookRegistrationService: MAX webhook registration failed', [
+            'status' => $response->status(),
+        ]);
+
+        return [
+            'success' => false,
+            'message' => 'Ошибка регистрации вебхука MAX (HTTP ' . $response->status() . '): ' . $body,
+        ];
+    }
+}

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -37,6 +37,7 @@
 
     /* Status / badges */
     --color-bg-online: #34C759;
+    --color-text-online: #34C759;
     --color-bg-badge: #4F6EF7;
     --color-text-on-badge: #FFFFFF;
 }

--- a/resources/views/layouts/admin-settings.blade.php
+++ b/resources/views/layouts/admin-settings.blade.php
@@ -42,7 +42,10 @@
                     Основные
                 </x-admin.nav-item>
 
-                <x-admin.nav-item disabled>
+                <x-admin.nav-item
+                    href="{{ route('admin.settings.integrations') }}"
+                    :active="request()->routeIs('admin.settings.integrations') || request()->routeIs('admin.settings.integrations.channel')"
+                >
                     <x-slot name="icon">
                         <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />

--- a/resources/views/livewire/settings/integration-channel-page.blade.php
+++ b/resources/views/livewire/settings/integration-channel-page.blade.php
@@ -1,0 +1,348 @@
+<div>
+
+    {{-- ── Top bar — breadcrumb + bottom border ─────────────────────────────── --}}
+    <div class="flex items-center border-b border-border-light bg-bg-primary px-10 py-0" style="height:64px">
+        <div class="flex items-center gap-3">
+            <a href="{{ route('admin.settings.integrations') }}"
+               class="flex items-center gap-1 text-text-secondary transition hover:text-text-primary"
+               aria-label="Назад к интеграциям">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24"
+                     stroke="currentColor" stroke-width="2">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M19 12H5m7-7-7 7 7 7" />
+                </svg>
+            </a>
+            <a href="{{ route('admin.settings.integrations') }}"
+               class="text-sm text-text-secondary transition hover:text-text-primary">
+                Интеграции
+            </a>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 text-text-secondary" fill="none"
+                 viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+            </svg>
+            <span class="text-sm font-semibold text-text-primary">
+                Подключение
+                @if ($channel === 'telegram') Telegram
+                @elseif ($channel === 'vk') ВКонтакте
+                @else MAX
+                @endif
+            </span>
+        </div>
+    </div>
+
+    {{-- ── Notices ───────────────────────────────────────────────────────────── --}}
+    @if ($webhookMessage)
+        <div class="mx-8 mt-6 flex items-center gap-2 rounded-xl border px-4 py-3 text-sm
+            @if ($webhookSuccess) border-green-200 bg-green-50 text-green-800
+            @else border-red-200 bg-red-50 text-red-800 @endif">
+            @if ($webhookSuccess)
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 shrink-0 text-green-500"
+                     fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+                </svg>
+            @else
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 shrink-0 text-red-500"
+                     fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01M6.938 19h10.124A2 2 0 0019 16.27L13.938 7A2 2 0 0010.062 7L5 16.27A2 2 0 006.938 19z" />
+                </svg>
+            @endif
+            {{ $webhookMessage }}
+        </div>
+    @endif
+
+    {{-- ── Two-column body ──────────────────────────────────────────────────── --}}
+    <div class="grid grid-cols-1 gap-7 p-8 lg:grid-cols-[1fr_320px]">
+
+        {{-- ── Form Card ────────────────────────────────────────────────────── --}}
+        <div class="rounded-2xl border border-border-light bg-bg-primary" style="padding:28px 32px">
+
+            {{-- Card header: icon + titles --}}
+            <div class="flex items-center gap-3.5">
+                @if ($channel === 'telegram')
+                    <div class="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl" style="background:#E0EDFF">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" style="color:#2AABEE"
+                             viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.48.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z" />
+                        </svg>
+                    </div>
+                @elseif ($channel === 'vk')
+                    <div class="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl" style="background:#4C75A3">
+                        <span class="text-lg font-bold text-white">VK</span>
+                    </div>
+                @else
+                    <div class="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl" style="background:#FFF3E0">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" style="color:#F57C00"
+                             fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M8.111 16.404a5.5 5.5 0 017.778 0M12 20h.01m-7.08-7.071c3.904-3.905 10.236-3.905 14.14 0M1.394 9.393c5.857-5.857 15.355-5.857 21.213 0" />
+                        </svg>
+                    </div>
+                @endif
+                <div>
+                    <h2 class="text-lg font-bold text-text-primary">
+                        @if ($channel === 'telegram') Подключить Telegram
+                        @elseif ($channel === 'vk') Подключить ВКонтакте
+                        @else Подключить MAX
+                        @endif
+                    </h2>
+                    <p class="mt-0.5 text-xs text-text-secondary">
+                        @if ($channel === 'telegram') Настройте бота для приёма обращений
+                        @elseif ($channel === 'vk') Настройте сообщество для приёма обращений
+                        @else Настройте бота для приёма обращений из MAX
+                        @endif
+                    </p>
+                </div>
+            </div>
+
+            <div class="my-6 h-px bg-border-light"></div>
+
+            <form wire:submit="connect" novalidate>
+                @csrf
+
+                @if ($channel === 'telegram')
+
+                    <div class="space-y-5">
+
+                        {{-- ID группы --}}
+                        <x-admin.form-field
+                            label="ID группы"
+                            for="telegram_group_id"
+                            hint="ID Telegram-группы для приёма обращений"
+                            :error="$formErrors['telegram_group_id'] ?? null"
+                        >
+                            <input
+                                id="telegram_group_id"
+                                type="text"
+                                wire:model="telegram_group_id"
+                                placeholder="-100XXXXXXXXXX"
+                                class="block w-full rounded-lg border border-border-light bg-bg-input px-3.5 py-2.5 text-sm text-text-primary placeholder-text-secondary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/20
+                                    @if (!empty($formErrors['telegram_group_id'])) border-red-400 @endif"
+                            />
+                        </x-admin.form-field>
+
+                        {{-- Токен бота --}}
+                        <x-admin.form-field
+                            label="Токен бота"
+                            for="telegram_token"
+                            hint="Токен от @BotFather"
+                            :error="$formErrors['telegram_token'] ?? null"
+                        >
+                            <input
+                                id="telegram_token"
+                                type="password"
+                                wire:model="telegram_token"
+                                autocomplete="new-password"
+                                placeholder="110201543:AAHdqTcvCH1vGWJxfSeo..."
+                                class="block w-full rounded-lg border border-border-light bg-bg-input px-3.5 py-2.5 text-sm text-text-primary placeholder-text-secondary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/20
+                                    @if (!empty($formErrors['telegram_token'])) border-red-400 @endif"
+                            />
+                        </x-admin.form-field>
+
+                        {{-- Секретный ключ Webhook --}}
+                        <x-admin.form-field
+                            label="Секретный ключ Webhook"
+                            for="telegram_secret_key"
+                            hint="Для верификации запросов от Telegram"
+                            :error="$formErrors['telegram_secret_key'] ?? null"
+                        >
+                            <input
+                                id="telegram_secret_key"
+                                type="password"
+                                wire:model="telegram_secret_key"
+                                autocomplete="new-password"
+                                placeholder="your-secret-key"
+                                class="block w-full rounded-lg border border-border-light bg-bg-input px-3.5 py-2.5 text-sm text-text-primary placeholder-text-secondary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/20
+                                    @if (!empty($formErrors['telegram_secret_key'])) border-red-400 @endif"
+                            />
+                        </x-admin.form-field>
+
+                    </div>
+
+                @elseif ($channel === 'vk')
+
+                    <div class="space-y-5">
+
+                        {{-- Токен --}}
+                        <x-admin.form-field
+                            label="Токен"
+                            for="vk_token"
+                            hint="Токен доступа сообщества"
+                            :error="$formErrors['vk_token'] ?? null"
+                        >
+                            <input
+                                id="vk_token"
+                                type="password"
+                                wire:model="vk_token"
+                                autocomplete="new-password"
+                                placeholder="vk1.a.xxxxxxxxxxxx"
+                                class="block w-full rounded-lg border border-border-light bg-bg-input px-3.5 py-2.5 text-sm text-text-primary placeholder-text-secondary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/20"
+                            />
+                        </x-admin.form-field>
+
+                        {{-- Секретный ключ Webhook --}}
+                        <x-admin.form-field
+                            label="Секретный ключ Webhook"
+                            for="vk_secret_key"
+                            hint="Для верификации входящих запросов"
+                            :error="$formErrors['vk_secret_key'] ?? null"
+                        >
+                            <input
+                                id="vk_secret_key"
+                                type="password"
+                                wire:model="vk_secret_key"
+                                autocomplete="new-password"
+                                placeholder="your-secret-key"
+                                class="block w-full rounded-lg border border-border-light bg-bg-input px-3.5 py-2.5 text-sm text-text-primary placeholder-text-secondary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/20"
+                            />
+                        </x-admin.form-field>
+
+                        {{-- Код подтверждения --}}
+                        <x-admin.form-field
+                            label="Код подтверждения"
+                            for="vk_confirm_code"
+                            hint="Строка подтверждения сервера из настроек Callback API"
+                            :error="$formErrors['vk_confirm_code'] ?? null"
+                        >
+                            <input
+                                id="vk_confirm_code"
+                                type="password"
+                                wire:model="vk_confirm_code"
+                                autocomplete="new-password"
+                                placeholder="abc123"
+                                class="block w-full rounded-lg border border-border-light bg-bg-input px-3.5 py-2.5 text-sm text-text-primary placeholder-text-secondary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/20"
+                            />
+                        </x-admin.form-field>
+
+                    </div>
+
+                @else {{-- max --}}
+
+                    <div class="space-y-5">
+
+                        {{-- Токен --}}
+                        <x-admin.form-field
+                            label="Токен"
+                            for="max_token"
+                            hint="Токен бота из настроек MAX"
+                            :error="$formErrors['max_token'] ?? null"
+                        >
+                            <input
+                                id="max_token"
+                                type="password"
+                                wire:model="max_token"
+                                autocomplete="new-password"
+                                placeholder="max-bot-token-xxxxxxxxxxxx"
+                                class="block w-full rounded-lg border border-border-light bg-bg-input px-3.5 py-2.5 text-sm text-text-primary placeholder-text-secondary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/20"
+                            />
+                        </x-admin.form-field>
+
+                        {{-- Секретный ключ Webhook --}}
+                        <x-admin.form-field
+                            label="Секретный ключ Webhook"
+                            for="max_secret_key"
+                            hint="Для верификации входящих запросов от MAX"
+                            :error="$formErrors['max_secret_key'] ?? null"
+                        >
+                            <input
+                                id="max_secret_key"
+                                type="password"
+                                wire:model="max_secret_key"
+                                autocomplete="new-password"
+                                placeholder="your-secret-key"
+                                class="block w-full rounded-lg border border-border-light bg-bg-input px-3.5 py-2.5 text-sm text-text-primary placeholder-text-secondary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/20"
+                            />
+                        </x-admin.form-field>
+
+                    </div>
+
+                @endif
+
+                {{-- Actions row — right-aligned: «Отмена» + «Подключить» --}}
+                <div class="mt-6 flex items-center justify-end gap-3">
+                    <x-admin.button-secondary wire:click="cancel" type="button">
+                        Отмена
+                    </x-admin.button-secondary>
+                    <x-admin.button-primary type="submit" wire:loading.attr="disabled" wire:target="connect">
+                        <span wire:loading.remove wire:target="connect">Подключить</span>
+                        <span wire:loading wire:target="connect">Подключение...</span>
+                    </x-admin.button-primary>
+                </div>
+
+            </form>
+        </div>
+
+        {{-- ── Instruction panel ────────────────────────────────────────────── --}}
+        <div>
+            <div class="rounded-xl border border-border-light bg-bg-primary p-5 lg:p-6">
+
+                {{-- Panel header --}}
+                <div class="mb-5 flex items-center gap-2">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 text-accent" fill="none"
+                         viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round"
+                              d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+                    </svg>
+                    <span class="text-sm font-semibold text-text-primary">Инструкция</span>
+                </div>
+
+                {{-- Numbered steps --}}
+                <ol class="space-y-3">
+                    @php
+                        $steps = match ($channel) {
+                            'telegram' => [
+                                'Создайте группу в Telegram',
+                                'Создайте бота в Telegram через @botFather',
+                                'Добавьте бота как администратора в группу',
+                                'Включите "Темы" в настройках группы',
+                            ],
+                            'vk' => [
+                                'Создайте сообщество VK или откройте существующее',
+                                'Перейдите в настройки сообщества Управление → Дополнительно → Работа с API',
+                                'Нажмите "Создать ключ"',
+                                'Во вкладке "Callback API" укажите адрес "'.rtrim(config('app.url'), '/').'/vk/bot"',
+                                'Укажите "Секретный ключ"',
+                                'Нажмите "Подтвердить"',
+                            ],
+                            default => [
+                                'Создайте бота в платформе MAX',
+                                'Скопируйте токен из настроек бота',
+                                'Укажите URL вебхука в настройках',
+                            ],
+                        };
+
+                        $docsUrl = match ($channel) {
+                            'telegram' => 'https://docs.tg-support-bot.ru/docs/telegram-bot.html',
+                            'vk' => 'https://docs.tg-support-bot.ru/docs/vk-group.html',
+                            'max' => 'https://docs.tg-support-bot.ru/docs/max-bot.html',
+                            default => 'https://docs.tg-support-bot.ru/',
+                        };
+                    @endphp
+                    @foreach ($steps as $i => $step)
+                        <li class="flex items-start gap-3">
+                            <span class="flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-full text-[11px] font-semibold text-accent"
+                                  style="background:#EEF2FF">
+                                {{ $i + 1 }}
+                            </span>
+                            <span class="text-[13px] leading-relaxed text-text-secondary">{{ $step }}</span>
+                        </li>
+                    @endforeach
+                </ol>
+
+                {{-- Docs link plate --}}
+                <a href="{{ $docsUrl }}"
+                   target="_blank"
+                   rel="noopener noreferrer"
+                   class="mt-5 flex items-center gap-2 rounded-lg px-3.5 py-3 text-xs font-medium text-accent transition hover:opacity-80"
+                   style="background:#F0F4FF">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 shrink-0" fill="none"
+                         viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round"
+                              d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    </svg>
+                    Подробнее в документации
+                </a>
+
+            </div>
+        </div>
+
+    </div>
+
+</div>

--- a/resources/views/livewire/settings/integrations-list-page.blade.php
+++ b/resources/views/livewire/settings/integrations-list-page.blade.php
@@ -1,0 +1,145 @@
+{{-- Раздел «Интеграции»: список каналов поддержки (Telegram / VK / MAX / Виджет) --}}
+<div class="p-4 lg:p-8 lg:max-w-3xl">
+
+    {{-- ── Page header --}}
+    <div class="mb-5">
+        <h1 class="text-lg font-semibold text-text-primary lg:text-2xl lg:font-bold">Интеграции</h1>
+        <p class="mt-0.5 text-sm text-text-secondary">Управление каналами поддержки</p>
+    </div>
+
+    {{-- ── Channel cards — vertical stack (matches x7EQB2) ──────────────────── --}}
+    <div class="space-y-3">
+
+        {{-- Telegram --}}
+        <a href="{{ route('admin.settings.integrations.channel', ['channel' => 'telegram']) }}"
+           class="block rounded-xl border border-border-light bg-bg-primary p-4 transition hover:border-accent hover:shadow-sm">
+            <div class="flex items-center justify-between">
+                <div class="flex items-center gap-3">
+                    {{-- Icon --}}
+                    <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl" style="background:#E0EDFF">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" style="color:#2AABEE"
+                             viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.48.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z" />
+                        </svg>
+                    </div>
+                    <div>
+                        <p class="text-sm font-semibold text-text-primary">Telegram</p>
+                        @if ($channelStatuses['telegram']['connected'])
+                            <span class="inline-flex items-center gap-1 text-xs font-medium" style="color:#34C759">
+                                <span class="inline-block h-1.5 w-1.5 rounded-full" style="background:#34C759"></span>
+                                Подключено
+                            </span>
+                        @else
+                            <span class="text-xs text-text-secondary">Не подключён</span>
+                        @endif
+                    </div>
+                </div>
+                @if (! $channelStatuses['telegram']['connected'])
+                    <span class="inline-flex items-center justify-center rounded-lg bg-accent px-3.5 py-1.5 text-xs font-medium text-white">
+                        Подключить
+                    </span>
+                @endif
+            </div>
+            <p class="mt-3 text-[13px] leading-relaxed text-text-secondary">
+                Поддержка через Telegram-бота: каждое обращение пользователя открывает отдельную тему в супергруппе поддержки.
+            </p>
+        </a>
+
+        {{-- VK --}}
+        <a href="{{ route('admin.settings.integrations.channel', ['channel' => 'vk']) }}"
+           class="block rounded-xl border border-border-light bg-bg-primary p-4 transition hover:border-accent hover:shadow-sm">
+            <div class="flex items-center justify-between">
+                <div class="flex items-center gap-3">
+                    <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl" style="background:#EEF2FF">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" style="color:#4680C2"
+                             viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M15.684 0H8.316C1.592 0 0 1.592 0 8.316v7.368C0 22.408 1.592 24 8.316 24h7.368C22.408 24 24 22.408 24 15.684V8.316C24 1.592 22.391 0 15.684 0zm3.692 17.123h-1.744c-.66 0-.862-.523-2.049-1.713-1.033-1.01-1.49-1.135-1.744-1.135-.356 0-.458.102-.458.593v1.575c0 .424-.135.678-1.253.678-1.846 0-3.896-1.118-5.335-3.202C4.624 10.857 4.03 8.57 4.03 8.096c0-.254.102-.491.593-.491h1.744c.44 0 .61.203.779.678.864 2.49 2.303 4.675 2.896 4.675.22 0 .322-.102.322-.66V9.721c-.068-1.186-.695-1.287-.695-1.71 0-.203.17-.407.44-.407h2.744c.373 0 .508.203.508.643v3.473c0 .372.169.508.271.508.22 0 .407-.136.813-.542 1.253-1.406 2.151-3.574 2.151-3.574.119-.254.322-.491.763-.491h1.744c.525 0 .644.27.525.643-.22 1.017-2.354 4.031-2.354 4.031-.186.305-.254.44 0 .78.186.254.796.779 1.203 1.253.745.847 1.32 1.558 1.473 2.05.17.491-.085.745-.576.745z" />
+                        </svg>
+                    </div>
+                    <div>
+                        <p class="text-sm font-semibold text-text-primary">ВКонтакте</p>
+                        @if ($channelStatuses['vk']['connected'])
+                            <span class="inline-flex items-center gap-1 text-xs font-medium" style="color:#34C759">
+                                <span class="inline-block h-1.5 w-1.5 rounded-full" style="background:#34C759"></span>
+                                Подключено
+                            </span>
+                        @else
+                            <span class="text-xs text-text-secondary">Не подключён</span>
+                        @endif
+                    </div>
+                </div>
+                @if (! $channelStatuses['vk']['connected'])
+                    <span class="inline-flex items-center justify-center rounded-lg bg-accent px-3.5 py-1.5 text-xs font-medium text-white">
+                        Подключить
+                    </span>
+                @endif
+            </div>
+            <p class="mt-3 text-[13px] leading-relaxed text-text-secondary">
+                Поддержка через сообщество ВКонтакте: сообщения из чата сообщества поступают операторам как обращения.
+            </p>
+        </a>
+
+        {{-- MAX --}}
+        <a href="{{ route('admin.settings.integrations.channel', ['channel' => 'max']) }}"
+           class="block rounded-xl border border-border-light bg-bg-primary p-4 transition hover:border-accent hover:shadow-sm">
+            <div class="flex items-center justify-between">
+                <div class="flex items-center gap-3">
+                    <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl" style="background:#FFF3E0">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" style="color:#F57C00"
+                             fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                            <path stroke-linecap="round" stroke-linejoin="round"
+                                  d="M8.111 16.404a5.5 5.5 0 017.778 0M12 20h.01m-7.08-7.071c3.904-3.905 10.236-3.905 14.14 0M1.394 9.393c5.857-5.857 15.355-5.857 21.213 0" />
+                        </svg>
+                    </div>
+                    <div>
+                        <p class="text-sm font-semibold text-text-primary">Max</p>
+                        @if ($channelStatuses['max']['connected'])
+                            <span class="inline-flex items-center gap-1 text-xs font-medium" style="color:#34C759">
+                                <span class="inline-block h-1.5 w-1.5 rounded-full" style="background:#34C759"></span>
+                                Подключено
+                            </span>
+                        @else
+                            <span class="text-xs text-text-secondary">Не подключён</span>
+                        @endif
+                    </div>
+                </div>
+                @if (! $channelStatuses['max']['connected'])
+                    <span class="inline-flex items-center justify-center rounded-lg bg-accent px-3.5 py-1.5 text-xs font-medium text-white">
+                        Подключить
+                    </span>
+                @endif
+            </div>
+            <p class="mt-3 text-[13px] leading-relaxed text-text-secondary">
+                Поддержка через мессенджер MAX: обращения пользователей из MAX поступают операторам в общий поток.
+            </p>
+        </a>
+
+        {{-- Виджет для сайта — disabled placeholder --}}
+        <div class="cursor-not-allowed rounded-xl border border-border-light bg-bg-primary p-4 opacity-50"
+             aria-disabled="true">
+            <div class="flex items-center justify-between">
+                <div class="flex items-center gap-3">
+                    <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl" style="background:#EEF2FF">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-accent" fill="none"
+                             viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                            <path stroke-linecap="round" stroke-linejoin="round"
+                                  d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17H3a2 2 0 01-2-2V5a2 2 0 012-2h14a2 2 0 012 2v10a2 2 0 01-2 2h-2" />
+                        </svg>
+                    </div>
+                    <div>
+                        <p class="text-sm font-semibold text-text-primary">Виджет для сайта</p>
+                        <span class="text-xs text-text-secondary">Не подключён</span>
+                    </div>
+                </div>
+                <span class="inline-flex items-center justify-center rounded-lg bg-bg-secondary px-3.5 py-1.5 text-xs font-medium text-text-secondary">
+                    Скоро
+                </span>
+            </div>
+            <p class="mt-3 text-[13px] leading-relaxed text-text-secondary">
+                Виджет для онлайн-чата на сайте. Установите код на страницу.
+            </p>
+        </div>
+
+    </div>
+
+</div>

--- a/rules/api/endpoints.md
+++ b/rules/api/endpoints.md
@@ -101,6 +101,9 @@ The generated JSON is the authoritative OpenAPI file. Do not write a separate `o
 | `GET` | `/admin/external-sources` | session | List external sources (`ExternalSourceResource`) |
 | `GET` | `/admin/external-sources/create` | session | Create external source form |
 | `GET` | `/admin/external-sources/{id}/edit` | session | Edit external source form |
+| `GET` | `/admin/settings/general` | session | General settings page (`GeneralSettingsPage`, custom Livewire) — name `admin.settings.general` |
+| `GET` | `/admin/settings/integrations` | session | Integration channels list (`IntegrationsListPage`, custom Livewire) — name `admin.settings.integrations` |
+| `GET` | `/admin/settings/integrations/{channel}` | session | Per-channel config form (`IntegrationChannelPage`; channel ∈ telegram\|vk\|max) — name `admin.settings.integrations.channel` |
 
 ### Telegram callback_data prefixes (main bot webhook)
 

--- a/rules/domain/admin-panel.md
+++ b/rules/domain/admin-panel.md
@@ -2,7 +2,7 @@
 
 > **Purpose:** Define business rules, key concepts, and invariants for the Admin module (`app/Modules/Admin/`). This module implements the `admin_panel` mode of the `ManagerInterfaceContract`.
 > **Context:** Read this file before modifying anything inside `app/Modules/Admin/`, Filament resources, Livewire pages, or the `SendReplyAction`.
-> **Version:** 1.2
+> **Version:** 1.3
 
 ---
 
@@ -10,7 +10,7 @@
 
 The Admin Panel domain provides an alternative manager interface for the support team. Instead of working through a Telegram supergroup with forum topics, managers can use the `/admin` web panel (built with Filament 3) to view conversations and send replies.
 
-**This domain owns:** `ConversationResource`, `BotUserResource`, `ExternalSourceResource`, `FeedbackResource`, `ConversationPage` (Livewire, Filament-hosted), `GeneralSettingsPage` (custom Livewire full-page component at `/admin/settings/general`), admin design system (`resources/views/components/admin/`, `resources/views/layouts/admin-settings.blade.php`), `SendReplyAction`, `AdminPanelInterface`.
+**This domain owns:** `ConversationResource`, `BotUserResource`, `ExternalSourceResource`, `FeedbackResource`, `ConversationPage` (Livewire, Filament-hosted), `GeneralSettingsPage` (custom Livewire full-page at `/admin/settings/general`), `IntegrationsListPage` (custom Livewire full-page at `/admin/settings/integrations`), `IntegrationChannelPage` (custom Livewire full-page at `/admin/settings/integrations/{channel}`), admin design system (`resources/views/components/admin/`, `resources/views/layouts/admin-settings.blade.php`), `SendReplyAction`, `AdminPanelInterface`, `ChannelStatusService`, `WebhookRegistrationService`.
 
 > **Stage 1 transition note:** The admin is in the process of being redesigned. Filament resources (Chats, Users, External Sources, Feedback) remain on default Filament chrome. `GeneralSettingsPage` is the first screen rebuilt as a fully custom Livewire/Blade component outside Filament's chrome. During this coexistence period the two UIs deliberately have different styling — this is expected until the migration completes.
 
@@ -33,6 +33,10 @@ The Admin Panel domain provides an alternative manager interface for the support
 | `GeneralSettingsPage` | Custom Livewire full-page component at `/admin/settings/general` — edits bot name, description, and `MANAGER_INTERFACE`. Requires authenticated user (Filament `Authenticate` middleware redirects guests to `/admin/login`). Saves via `SettingsService`. Shows restart notice when `MANAGER_INTERFACE` changes |
 | Admin Design System | Tailwind v4 tokens in `resources/css/app.css @theme` (accent, sidebar, input, text colours; Inter font). Shared Blade components: `<x-admin.sidebar>`, `<x-admin.nav-item>`, `<x-admin.card>`, `<x-admin.form-field>`, `<x-admin.button-primary>`, `<x-admin.button-secondary>`, `<x-admin.toggle>` |
 | `admin-settings` layout | Full-page layout at `resources/views/layouts/admin-settings.blade.php` — dark sidebar (280px) + main content area. Used by all custom Livewire settings screens |
+| `IntegrationsListPage` | Custom Livewire full-page component at `/admin/settings/integrations`. Shows Telegram/VK/MAX channel cards with connection status badges. Reads statuses via `ChannelStatusService`. «Виджет для сайта» shown as disabled «Скоро» placeholder |
+| `IntegrationChannelPage` | Custom Livewire full-page component at `/admin/settings/integrations/{channel}` (channel ∈ telegram\|vk\|max). Per-channel config form (read/write via `SettingsService`), webhook registration action (delegates to `WebhookRegistrationService`) |
+| `ChannelStatusService` | `app/Modules/Admin/Services/ChannelStatusService.php`. Computes `connected/label` per channel based on whether required `SettingsService` keys are non-empty. Shared by list and per-channel pages |
+| `WebhookRegistrationService` | `app/Modules/Admin/Services/WebhookRegistrationService.php`. Thin wrapper around `TelegramMethods::sendQueryTelegram('setWebhook', ...)`, `VkMethods::sendQueryVk('groups.getById', ...)`, and `Http::post(.../subscriptions, ...)` for MAX. Returns `{success: bool, message: string}`. Reads tokens via `SettingsService`. Never logs tokens |
 
 ---
 
@@ -77,6 +81,18 @@ _Enforced by:_ design review; tokens defined at `resources/css/app.css:@theme`
 
 **BR-012** — Custom Livewire settings routes MUST NOT collide with Filament's route set. Filament owns the `/admin/*` namespace but does not register `/admin/settings/*`. All new custom settings pages MUST be registered under the `admin/settings/` prefix in `AdminServiceProvider::boot()`.
 _Enforced in:_ `AdminServiceProvider::boot()` — verified against `php artisan route:list` output
+
+**BR-013** — Integration config for Telegram/VK/MAX is read and written exclusively via `SettingsService` using the registry keys `telegram.*`, `vk.*`, `max.*`. Secrets (tokens, secret keys, confirm codes) are stored encrypted (`is_secret = true` in `SettingKeyRegistry`). Never log tokens or secrets (see `rules/process/security.md`).
+_Enforced in:_ `IntegrationChannelPage::saveTelegram/Vk/Max()` — calls `SettingsService::set()`; `WebhookRegistrationService` — reads tokens via `SettingsService`, logs only non-sensitive data
+
+**BR-014** — The webhook registration action in `IntegrationChannelPage` delegates to `WebhookRegistrationService` — never directly calls platform API methods or executes artisan commands from the UI. The result (success/error with a user-facing message) is surfaced via `$webhookMessage` / `$webhookSuccess` properties.
+_Enforced in:_ `IntegrationChannelPage::registerWebhook()` — match dispatch to `WebhookRegistrationService`
+
+**BR-015** — Saving a secret field (token, key) with an empty string does NOT overwrite the existing secret in the DB. This prevents accidentally blanking credentials when only non-secret fields are edited.
+_Enforced in:_ `IntegrationChannelPage::saveTelegram/Vk/Max()` — `if ($field !== '') { $settings->set(...) }`
+
+**BR-016** — The «Виджет для сайта» card on the Integrations list is a disabled placeholder («Скоро»). It must not be a clickable link and must not have a route. It is rendered as a `<div>` with `cursor-not-allowed opacity-50`.
+_Enforced in:_ `resources/views/livewire/settings/integrations-list-page.blade.php`
 
 ---
 
@@ -134,7 +150,7 @@ The binding is resolved at container boot time from `config()`. The binding does
 
 **Layout**: `resources/views/layouts/admin-settings.blade.php` — two-column layout with a dark sidebar (280px) + right content area (`bg-bg-secondary`).
 
-**Sidebar navigation**: 7 items. Only «Основные» is active/linked; the rest (Интеграции, ИИ-ассистент, Уведомления, API и вебхуки, Команда, Автоответы) are disabled placeholders (`disabled` prop on `<x-admin.nav-item>`). They become real links as their respective tasks are implemented.
+**Sidebar navigation**: 7 items. «Основные» and «Интеграции» are active/linked; the rest (ИИ-ассистент, Уведомления, API и вебхуки, Команда, Автоответы) are disabled placeholders (`disabled` prop on `<x-admin.nav-item>`). They become real links as their respective tasks are implemented.
 
 **Form fields** (all persisted via `SettingsService`):
 | Field | Setting key | Validation |
@@ -153,6 +169,43 @@ The binding is resolved at container boot time from `config()`. The binding does
 
 ---
 
+## 6b. Integrations Screens (custom Livewire, `/admin/settings/integrations`)
+
+### IntegrationsListPage (`GET /admin/settings/integrations`)
+
+`app/Livewire/Settings/IntegrationsListPage.php` — shows Telegram, VK, MAX, and Widget (disabled) channel cards with connection status.
+
+**Channel status**: computed by `ChannelStatusService::all()` on `mount()`. A channel is «Подключён» when all required keys are non-empty; otherwise «Не настроен».
+
+**Required keys by channel**:
+| Channel | Required for "connected" |
+|---|---|
+| Telegram | `telegram.token`, `telegram.secret_key`, `telegram.group_id` |
+| VK | `vk.token`, `vk.secret_key`, `vk.confirm_code` |
+| MAX | `max.token`, `max.secret_key` |
+
+**Tests**: `tests/Feature/Settings/IntegrationsListPageTest.php`
+
+### IntegrationChannelPage (`GET /admin/settings/integrations/{channel}`)
+
+`app/Livewire/Settings/IntegrationChannelPage.php` — per-channel configuration form. Route constraint: `channel` ∈ `telegram|vk|max`.
+
+**Form fields**:
+| Channel | Fields |
+|---|---|
+| Telegram | `telegram.token`(secret), `telegram.secret_key`(secret), `telegram.group_id`, `telegram.template_topic_name` |
+| VK | `vk.token`(secret), `vk.secret_key`(secret), `vk.confirm_code`(secret) |
+| MAX | `max.token`(secret), `max.secret_key`(secret) |
+
+**Secret fields** rendered as `type="password"` inputs with `autocomplete="new-password"`. Blank submission does not overwrite existing stored value (BR-015).
+
+**Webhook registration action** (`wire:click="registerWebhook"`): calls `WebhookRegistrationService`, shows success (green banner) or error (red banner) via `$webhookMessage` / `$webhookSuccess`.
+
+**Tests**: `tests/Feature/Settings/IntegrationChannelPageTest.php`
+- Unit tests: `tests/Unit/Modules/Admin/Services/ChannelStatusServiceTest.php`, `tests/Unit/Modules/Admin/Services/WebhookRegistrationServiceTest.php`
+
+---
+
 ## 7. Forbidden Behaviors
 
 - ❌ Calling `SendReplyAction::execute()` synchronously from a Livewire component without `Queue::fake()` in tests
@@ -168,14 +221,16 @@ The binding is resolved at container boot time from `config()`. The binding does
 
 ## Checklist
 
-- [ ] `BR-001` through `BR-010` read and understood
+- [ ] `BR-001` through `BR-016` read and understood
 - [ ] `shouldShowReplyForm()` returns `false` in `telegram_group` mode
 - [ ] `SendReplyAction` uses queue jobs, not synchronous API calls
 - [ ] New Filament resources have feature tests in `tests/Feature/Admin/`
 - [ ] Polling interval not changed without load analysis
 - [ ] DI binding tested in `tests/Feature/Admin/ManagerInterfaceCompatibilityTest.php`
-- [ ] New custom settings Livewire page has feature test in `tests/Feature/Settings/` and unit test in `tests/Unit/Livewire/Settings/`
-- [ ] When adding form fields to GeneralSettingsPage, add the key to `SettingKeyRegistry` first
+- [ ] New custom settings Livewire page has feature test in `tests/Feature/Settings/` and unit test in `tests/Unit/Livewire/Settings/` (or `tests/Unit/Modules/Admin/Services/` for service classes)
+- [ ] When adding form fields to GeneralSettingsPage or IntegrationChannelPage, add the key to `SettingKeyRegistry` first
 - [ ] New custom Livewire routes registered in `AdminServiceProvider::boot()` under `admin/settings/` prefix
 - [ ] Admin UI uses design system token variables, not hardcoded hex values
 - [ ] New admin Blade components go under `resources/views/components/admin/`
+- [ ] Secret channel fields use `type="password"` and blank-submission guard (BR-015)
+- [ ] `WebhookRegistrationService` reads tokens from `SettingsService`, never from `config()` directly

--- a/rules/process/security.md
+++ b/rules/process/security.md
@@ -144,6 +144,13 @@ $token = '1234567890:AABBcc_my_telegram_token_here';
 - `DB_PASSWORD` — Database password
 - Bearer tokens in `external_source_access_tokens` table
 
+**Secrets in the DB settings table:**
+Channel integration secrets (`telegram.token`, `telegram.secret_key`, `vk.token`, `vk.secret_key`, `vk.confirm_code`, `max.token`, `max.secret_key`) are stored encrypted via `SettingsService` (Laravel `Crypt::encrypt()`). They are surfaced in the admin UI as `<input type="password">` fields. The following rules apply:
+- Never log decrypted token values — log only non-sensitive context (URL registered, HTTP status code)
+- Blank-submission guard: if the UI field is left empty, do NOT overwrite the stored encrypted value
+- In logs, do not include any key whose `is_secret = true` in `SettingKeyRegistry`
+- `WebhookRegistrationService` reads tokens via `SettingsService::get()` — never accesses config() for secrets directly
+
 ---
 
 ## 6. File Upload Security Rules

--- a/tests/Feature/Settings/IntegrationChannelPageTest.php
+++ b/tests/Feature/Settings/IntegrationChannelPageTest.php
@@ -1,0 +1,407 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Settings;
+
+use App\Enums\UserRole;
+use App\Livewire\Settings\IntegrationChannelPage;
+use App\Models\User;
+use App\Services\Settings\SettingsService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class IntegrationChannelPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // ── Access control ────────────────────────────────────────────────────────
+
+    public function test_guest_is_redirected_to_login_on_channel_page(): void
+    {
+        $response = $this->get(route('admin.settings.integrations.channel', ['channel' => 'telegram']));
+
+        $response->assertRedirectContains('/admin/login');
+    }
+
+    public function test_authenticated_admin_can_render_telegram_channel_page(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        Livewire::test(IntegrationChannelPage::class, ['channel' => 'telegram'])
+            ->assertSuccessful();
+    }
+
+    // ── Route registration ────────────────────────────────────────────────────
+
+    public function test_route_admin_settings_integrations_channel_is_registered(): void
+    {
+        $this->assertTrue(\Illuminate\Support\Facades\Route::has('admin.settings.integrations.channel'));
+    }
+
+    // ── Mount / initial state ────────────────────────────────────────────────
+
+    public function test_mount_loads_telegram_fields_from_settings_service(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        /** @var SettingsService $settings */
+        $settings = app(SettingsService::class);
+        $settings->set('telegram.group_id', '-1009999');
+
+        Livewire::test(IntegrationChannelPage::class, ['channel' => 'telegram'])
+            ->assertSet('channel', 'telegram')
+            ->assertSet('telegram_group_id', '-1009999');
+    }
+
+    public function test_mount_sets_channel_connected_when_telegram_configured(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        /** @var SettingsService $settings */
+        $settings = app(SettingsService::class);
+        $settings->set('telegram.token', 'tok');
+        $settings->set('telegram.secret_key', 'sec');
+        $settings->set('telegram.group_id', '-100123');
+
+        Livewire::test(IntegrationChannelPage::class, ['channel' => 'telegram'])
+            ->assertSet('channelConnected', true);
+    }
+
+    public function test_mount_sets_channel_not_connected_when_keys_absent(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        // Ensure no config fallback provides values
+        \Illuminate\Support\Facades\Cache::flush();
+        config([
+            'traffic_source.settings.telegram.token' => '',
+            'traffic_source.settings.telegram.secret_key' => '',
+            'traffic_source.settings.telegram.group_id' => '',
+        ]);
+
+        Livewire::test(IntegrationChannelPage::class, ['channel' => 'telegram'])
+            ->assertSet('channelConnected', false);
+    }
+
+    // ── Rendering ─────────────────────────────────────────────────────────────
+
+    public function test_renders_telegram_form_fields(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        Livewire::test(IntegrationChannelPage::class, ['channel' => 'telegram'])
+            ->assertSee('Токен бота')
+            ->assertSee('Секретный ключ Webhook')
+            ->assertSee('ID группы')
+            ->assertSee('Подключить');
+    }
+
+    public function test_renders_vk_form_fields(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        Livewire::test(IntegrationChannelPage::class, ['channel' => 'vk'])
+            ->assertSee('Токен')
+            ->assertSee('Код подтверждения')
+            ->assertSee('Подключить');
+    }
+
+    public function test_renders_max_form_fields(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        Livewire::test(IntegrationChannelPage::class, ['channel' => 'max'])
+            ->assertSee('Токен')
+            ->assertSee('Секретный ключ Webhook')
+            ->assertSee('Подключить');
+    }
+
+    public function test_renders_instruction_panel_for_telegram(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        Livewire::test(IntegrationChannelPage::class, ['channel' => 'telegram'])
+            ->assertSee('Инструкция')
+            ->assertSee('Создайте группу в Telegram')
+            ->assertSee('Добавьте бота как администратора')
+            ->assertSee('Подробнее в документации');
+    }
+
+    public function test_renders_instruction_panel_for_vk(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        Livewire::test(IntegrationChannelPage::class, ['channel' => 'vk'])
+            ->assertSee('Инструкция')
+            ->assertSee('Создайте сообщество VK')
+            ->assertSee('Подробнее в документации');
+    }
+
+    public function test_renders_instruction_panel_for_max(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        Livewire::test(IntegrationChannelPage::class, ['channel' => 'max'])
+            ->assertSee('Инструкция')
+            ->assertSee('Создайте бота в платформе MAX')
+            ->assertSee('Подробнее в документации');
+    }
+
+    public function test_renders_breadcrumb_with_channel_name(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        Livewire::test(IntegrationChannelPage::class, ['channel' => 'telegram'])
+            ->assertSee('Интеграции')
+            ->assertSee('Подключение')
+            ->assertSee('Telegram');
+    }
+
+    // ── Save — valid inputs ───────────────────────────────────────────────────
+
+    public function test_save_telegram_persists_group_id(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        Livewire::test(IntegrationChannelPage::class, ['channel' => 'telegram'])
+            ->set('telegram_group_id', '-1001234567890')
+            ->call('save')
+            ->assertSet('saved', true)
+            ->assertSet('formErrors', []);
+
+        $this->assertDatabaseHas('settings', ['key' => 'telegram.group_id', 'value' => '-1001234567890']);
+    }
+
+    public function test_save_telegram_does_not_overwrite_token_when_field_empty(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        // Pre-set a token in DB
+        /** @var SettingsService $settings */
+        $settings = app(SettingsService::class);
+        $settings->set('telegram.token', 'existing_tok');
+
+        Livewire::test(IntegrationChannelPage::class, ['channel' => 'telegram'])
+            ->set('telegram_token', '')       // blank — should NOT overwrite
+            ->set('telegram_group_id', '-100123')
+            ->call('save')
+            ->assertSet('saved', true);
+
+        // The pre-existing token must still be in DB (as encrypted value)
+        $this->assertDatabaseHas('settings', ['key' => 'telegram.token']);
+    }
+
+    public function test_save_vk_persists_credentials(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        Livewire::test(IntegrationChannelPage::class, ['channel' => 'vk'])
+            ->set('vk_token', 'vk_tok')
+            ->set('vk_secret_key', 'sec')
+            ->set('vk_confirm_code', 'code')
+            ->call('save')
+            ->assertSet('saved', true);
+
+        // Secrets stored encrypted — key must exist
+        $this->assertDatabaseHas('settings', ['key' => 'vk.token']);
+        $this->assertDatabaseHas('settings', ['key' => 'vk.secret_key']);
+        $this->assertDatabaseHas('settings', ['key' => 'vk.confirm_code']);
+    }
+
+    public function test_save_max_persists_credentials(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        Livewire::test(IntegrationChannelPage::class, ['channel' => 'max'])
+            ->set('max_token', 'max_tok')
+            ->set('max_secret_key', 'max_sec')
+            ->call('save')
+            ->assertSet('saved', true);
+
+        $this->assertDatabaseHas('settings', ['key' => 'max.token']);
+        $this->assertDatabaseHas('settings', ['key' => 'max.secret_key']);
+    }
+
+    // ── Save — invalid inputs ─────────────────────────────────────────────────
+
+    public function test_save_telegram_rejects_group_id_exceeding_50_chars(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        Livewire::test(IntegrationChannelPage::class, ['channel' => 'telegram'])
+            ->set('telegram_group_id', str_repeat('1', 51))
+            ->call('save')
+            ->assertSet('saved', false);
+
+        $component = Livewire::test(IntegrationChannelPage::class, ['channel' => 'telegram'])
+            ->set('telegram_group_id', str_repeat('1', 51))
+            ->call('save');
+
+        $this->assertNotEmpty($component->get('formErrors'));
+    }
+
+    // ── Cancel ────────────────────────────────────────────────────────────────
+
+    public function test_cancel_resets_form_to_stored_values(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        /** @var SettingsService $settings */
+        $settings = app(SettingsService::class);
+        $settings->set('telegram.group_id', '-100original');
+
+        Livewire::test(IntegrationChannelPage::class, ['channel' => 'telegram'])
+            ->set('telegram_group_id', '-100changed')
+            ->call('cancel')
+            ->assertSet('telegram_group_id', '-100original')
+            ->assertSet('saved', false)
+            ->assertSet('webhookMessage', null);
+    }
+
+    // ── Connect (save + webhook) ──────────────────────────────────────────────
+
+    public function test_connect_saves_and_registers_webhook_for_telegram(): void
+    {
+        Http::fake([
+            'https://api.telegram.org/*' => Http::response(['ok' => true, 'description' => 'Webhook set'], 200),
+        ]);
+
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        Livewire::test(IntegrationChannelPage::class, ['channel' => 'telegram'])
+            ->set('telegram_group_id', '-100123')
+            ->set('telegram_token', 'bot123:validtoken')
+            ->set('telegram_secret_key', 'secret')
+            ->call('connect')
+            ->assertSet('saved', true)
+            ->assertSet('webhookSuccess', true);
+    }
+
+    public function test_connect_does_not_register_webhook_when_save_fails(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        Livewire::test(IntegrationChannelPage::class, ['channel' => 'telegram'])
+            ->set('telegram_group_id', str_repeat('x', 51))  // too long — save will fail
+            ->call('connect')
+            ->assertSet('saved', false)
+            ->assertSet('webhookSuccess', false)
+            ->assertSet('webhookMessage', null);
+    }
+
+    public function test_connect_shows_webhook_error_when_api_fails(): void
+    {
+        Http::fake([
+            'https://api.telegram.org/*' => Http::response(['ok' => false, 'description' => 'Unauthorized'], 401),
+        ]);
+
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        /** @var SettingsService $settings */
+        $settings = app(SettingsService::class);
+        $settings->set('telegram.token', 'bad_token');
+
+        Livewire::test(IntegrationChannelPage::class, ['channel' => 'telegram'])
+            ->set('telegram_group_id', '-100123')
+            ->set('telegram_token', 'bad_token')
+            ->call('connect')
+            ->assertSet('saved', true)
+            ->assertSet('webhookSuccess', false);
+    }
+
+    // ── Webhook registration (standalone, backward-compat) ────────────────────
+
+    public function test_register_webhook_telegram_success(): void
+    {
+        Http::fake([
+            'https://api.telegram.org/*' => Http::response(['ok' => true, 'description' => 'Webhook set'], 200),
+        ]);
+
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        /** @var SettingsService $settings */
+        $settings = app(SettingsService::class);
+        $settings->set('telegram.token', 'bot123:validtoken');
+        $settings->set('telegram.secret_key', 'secret');
+
+        Livewire::test(IntegrationChannelPage::class, ['channel' => 'telegram'])
+            ->call('registerWebhook')
+            ->assertSet('webhookSuccess', true);
+    }
+
+    public function test_register_webhook_telegram_error_on_api_failure(): void
+    {
+        Http::fake([
+            'https://api.telegram.org/*' => Http::response(['ok' => false, 'description' => 'Unauthorized'], 401),
+        ]);
+
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        /** @var SettingsService $settings */
+        $settings = app(SettingsService::class);
+        $settings->set('telegram.token', 'bad_token');
+        $settings->set('telegram.secret_key', 'sec');
+
+        Livewire::test(IntegrationChannelPage::class, ['channel' => 'telegram'])
+            ->call('registerWebhook')
+            ->assertSet('webhookSuccess', false);
+    }
+
+    public function test_register_webhook_max_success(): void
+    {
+        Http::fake([
+            'https://platform-api.max.ru/*' => Http::response(['result' => 'ok'], 200),
+        ]);
+
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        /** @var SettingsService $settings */
+        $settings = app(SettingsService::class);
+        $settings->set('max.token', 'max_token');
+
+        Livewire::test(IntegrationChannelPage::class, ['channel' => 'max'])
+            ->call('registerWebhook')
+            ->assertSet('webhookSuccess', true);
+    }
+
+    public function test_register_webhook_shows_error_when_token_not_set(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        Livewire::test(IntegrationChannelPage::class, ['channel' => 'telegram'])
+            ->call('registerWebhook')
+            ->assertSet('webhookSuccess', false);
+
+        $component = Livewire::test(IntegrationChannelPage::class, ['channel' => 'telegram'])
+            ->call('registerWebhook');
+
+        $this->assertNotEmpty($component->get('webhookMessage'));
+    }
+}

--- a/tests/Feature/Settings/IntegrationsListPageTest.php
+++ b/tests/Feature/Settings/IntegrationsListPageTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Settings;
+
+use App\Enums\UserRole;
+use App\Livewire\Settings\IntegrationsListPage;
+use App\Models\User;
+use App\Services\Settings\SettingsService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class IntegrationsListPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // ── Access control ────────────────────────────────────────────────────────
+
+    public function test_guest_is_redirected_to_login(): void
+    {
+        // On non-mobile UA the index redirects to telegram channel page,
+        // which itself then redirects to login — assertRedirect covers both.
+        $response = $this->get(route('admin.settings.integrations'));
+
+        // May redirect to login directly or via /integrations/telegram
+        $this->assertTrue(
+            str_contains($response->headers->get('Location', ''), '/admin/login')
+            || $response->isRedirect()
+        );
+    }
+
+    public function test_authenticated_admin_can_render_integrations_list(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        Livewire::test(IntegrationsListPage::class)
+            ->assertSuccessful();
+    }
+
+    public function test_authenticated_manager_can_render_integrations_list(): void
+    {
+        $manager = User::factory()->manager()->create();
+        $this->actingAs($manager);
+
+        Livewire::test(IntegrationsListPage::class)
+            ->assertSuccessful();
+    }
+
+    // ── Route registration ────────────────────────────────────────────────────
+
+    public function test_route_admin_settings_integrations_is_registered(): void
+    {
+        $this->assertTrue(\Illuminate\Support\Facades\Route::has('admin.settings.integrations'));
+    }
+
+    public function test_route_admin_settings_integrations_list_is_registered(): void
+    {
+        $this->assertTrue(\Illuminate\Support\Facades\Route::has('admin.settings.integrations.list'));
+    }
+
+    // ── Rendering ─────────────────────────────────────────────────────────────
+
+    public function test_renders_page_header(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        Livewire::test(IntegrationsListPage::class)
+            ->assertSee('Интеграции')
+            ->assertSee('Telegram')
+            ->assertSee('ВКонтакте')
+            ->assertSee('Max');
+    }
+
+    public function test_renders_not_connected_status_when_keys_absent(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+        Cache::flush();
+
+        // Override config so SettingsService fallback also returns empty
+        config([
+            'traffic_source.settings.telegram.token' => '',
+            'traffic_source.settings.telegram.secret_key' => '',
+            'traffic_source.settings.telegram.group_id' => '',
+            'traffic_source.settings.vk.token' => '',
+            'traffic_source.settings.vk.secret_key' => '',
+            'traffic_source.settings.vk.confirm_code' => '',
+            'traffic_source.settings.max.token' => '',
+            'traffic_source.settings.max.secret_key' => '',
+        ]);
+
+        Livewire::test(IntegrationsListPage::class)
+            ->assertSee('Не подключён');
+    }
+
+    public function test_renders_connected_status_when_telegram_keys_present(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        /** @var SettingsService $settings */
+        $settings = app(SettingsService::class);
+        $settings->set('telegram.token', 'bot123:tok');
+        $settings->set('telegram.secret_key', 'secret');
+        $settings->set('telegram.group_id', '-1001234567890');
+
+        Livewire::test(IntegrationsListPage::class)
+            ->assertSee('Подключено');
+    }
+
+    public function test_channel_statuses_property_has_all_three_keys(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        $component = Livewire::test(IntegrationsListPage::class);
+
+        $statuses = $component->get('channelStatuses');
+        $this->assertArrayHasKey('telegram', $statuses);
+        $this->assertArrayHasKey('vk', $statuses);
+        $this->assertArrayHasKey('max', $statuses);
+    }
+
+    public function test_renders_widget_placeholder(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        Livewire::test(IntegrationsListPage::class)
+            ->assertSee('Виджет для сайта')
+            ->assertSee('Скоро');
+    }
+
+    public function test_renders_channel_description_texts(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        Livewire::test(IntegrationsListPage::class)
+            ->assertSee('Поддержка через Telegram-бота')
+            ->assertSee('Поддержка через сообщество ВКонтакте')
+            ->assertSee('Поддержка через мессенджер MAX');
+    }
+
+    public function test_renders_connect_button_for_disconnected_channel(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+        Cache::flush();
+
+        config([
+            'traffic_source.settings.max.token' => '',
+            'traffic_source.settings.max.secret_key' => '',
+        ]);
+
+        Livewire::test(IntegrationsListPage::class)
+            ->assertSee('Подключить');
+    }
+}

--- a/tests/Unit/Livewire/Settings/IntegrationChannelPageTest.php
+++ b/tests/Unit/Livewire/Settings/IntegrationChannelPageTest.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace Tests\Unit\Livewire\Settings;
+
+use App\Livewire\Settings\IntegrationChannelPage;
+use App\Modules\Admin\Services\ChannelStatusService;
+use App\Modules\Admin\Services\WebhookRegistrationService;
+use App\Services\Settings\SettingsService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Tests\TestCase;
+
+/**
+ * Unit-level tests for the IntegrationChannelPage Livewire component.
+ *
+ * Exercises mount(), save(), connect(), and cancel() in isolation using a
+ * mocked SettingsService / ChannelStatusService / WebhookRegistrationService
+ * — no DB or Livewire rendering required for the core logic assertions.
+ */
+class IntegrationChannelPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        Mockery::close();
+    }
+
+    /**
+     * SettingsService mock whose get() returns '' for any key by default.
+     *
+     * @return \Mockery\MockInterface&SettingsService
+     */
+    private function settingsMock(): SettingsService
+    {
+        /** @var \Mockery\MockInterface&SettingsService $mock */
+        $mock = Mockery::mock(SettingsService::class);
+        $mock->shouldReceive('get')->andReturn('');
+
+        return $mock;
+    }
+
+    /**
+     * @return \Mockery\MockInterface&ChannelStatusService
+     */
+    private function statusMock(bool $telegramConnected = false): ChannelStatusService
+    {
+        /** @var \Mockery\MockInterface&ChannelStatusService $mock */
+        $mock = Mockery::mock(ChannelStatusService::class);
+        $mock->shouldReceive('all')->andReturn([
+            'telegram' => ['connected' => $telegramConnected, 'label' => 'x'],
+            'vk' => ['connected' => false, 'label' => 'x'],
+            'max' => ['connected' => false, 'label' => 'x'],
+        ]);
+
+        return $mock;
+    }
+
+    public function test_mount_loads_fields_and_connection_status(): void
+    {
+        /** @var \Mockery\MockInterface&SettingsService $settings */
+        $settings = Mockery::mock(SettingsService::class);
+        $settings->shouldReceive('get')->with('telegram.group_id')->andReturn('-100123');
+        $settings->shouldReceive('get')->with('telegram.token')->andReturn('tok');
+        $settings->shouldReceive('get')->with('telegram.secret_key')->andReturn('sec');
+        $settings->shouldReceive('get')->with('vk.token')->andReturn('');
+        $settings->shouldReceive('get')->with('vk.secret_key')->andReturn('');
+        $settings->shouldReceive('get')->with('vk.confirm_code')->andReturn('');
+        $settings->shouldReceive('get')->with('max.token')->andReturn('');
+        $settings->shouldReceive('get')->with('max.secret_key')->andReturn('');
+
+        $component = new IntegrationChannelPage();
+        $component->mount('telegram', $settings, $this->statusMock(true));
+
+        $this->assertSame('telegram', $component->channel);
+        $this->assertSame('-100123', $component->telegram_group_id);
+        $this->assertSame('tok', $component->telegram_token);
+        $this->assertTrue($component->channelConnected);
+    }
+
+    public function test_save_telegram_persists_group_id_and_nonempty_secrets(): void
+    {
+        $settings = $this->settingsMock();
+        $settings->shouldReceive('set')->with('telegram.group_id', '-100999')->once();
+        $settings->shouldReceive('set')->with('telegram.token', 'newtok')->once();
+        $settings->shouldReceive('set')->with('telegram.secret_key', 'newsec')->once();
+
+        $component = new IntegrationChannelPage();
+        $component->mount('telegram', $settings, $this->statusMock());
+        $component->telegram_group_id = '-100999';
+        $component->telegram_token = 'newtok';
+        $component->telegram_secret_key = 'newsec';
+        $component->save($settings);
+
+        $this->assertTrue($component->saved);
+        $this->assertEmpty($component->formErrors);
+    }
+
+    public function test_save_telegram_skips_blank_secrets(): void
+    {
+        $settings = $this->settingsMock();
+        $settings->shouldReceive('set')->with('telegram.group_id', '-100')->once();
+        $settings->shouldReceive('set')->with('telegram.token', Mockery::any())->never();
+        $settings->shouldReceive('set')->with('telegram.secret_key', Mockery::any())->never();
+
+        $component = new IntegrationChannelPage();
+        $component->mount('telegram', $settings, $this->statusMock());
+        $component->telegram_group_id = '-100';
+        $component->telegram_token = '';
+        $component->telegram_secret_key = '';
+        $component->save($settings);
+
+        $this->assertTrue($component->saved);
+    }
+
+    public function test_save_telegram_rejects_too_long_group_id(): void
+    {
+        $settings = $this->settingsMock();
+        $settings->shouldNotReceive('set');
+
+        $component = new IntegrationChannelPage();
+        $component->mount('telegram', $settings, $this->statusMock());
+        $component->telegram_group_id = str_repeat('1', 51);
+        $component->save($settings);
+
+        $this->assertFalse($component->saved);
+        $this->assertArrayHasKey('telegram_group_id', $component->formErrors);
+    }
+
+    public function test_save_vk_persists_only_nonempty_fields(): void
+    {
+        $settings = $this->settingsMock();
+        $settings->shouldReceive('set')->with('vk.token', 'vktok')->once();
+        $settings->shouldReceive('set')->with('vk.secret_key', Mockery::any())->never();
+        $settings->shouldReceive('set')->with('vk.confirm_code', 'cc')->once();
+
+        $component = new IntegrationChannelPage();
+        $component->mount('vk', $settings, $this->statusMock());
+        $component->vk_token = 'vktok';
+        $component->vk_secret_key = '';
+        $component->vk_confirm_code = 'cc';
+        $component->save($settings);
+
+        $this->assertTrue($component->saved);
+    }
+
+    public function test_connect_saves_then_registers_webhook(): void
+    {
+        $settings = $this->settingsMock();
+        $settings->shouldReceive('set')->with('telegram.group_id', '-100')->once();
+
+        /** @var \Mockery\MockInterface&WebhookRegistrationService $webhook */
+        $webhook = Mockery::mock(WebhookRegistrationService::class);
+        $webhook->shouldReceive('registerTelegram')->with()->once()->andReturn(['success' => true, 'message' => 'OK']);
+
+        $component = new IntegrationChannelPage();
+        $component->mount('telegram', $settings, $this->statusMock());
+        $component->telegram_group_id = '-100';
+        $component->connect($settings, $webhook);
+
+        $this->assertTrue($component->saved);
+        $this->assertTrue($component->webhookSuccess);
+        $this->assertSame('OK', $component->webhookMessage);
+    }
+
+    public function test_connect_does_not_register_webhook_when_save_fails(): void
+    {
+        $settings = $this->settingsMock();
+        $settings->shouldNotReceive('set');
+
+        /** @var \Mockery\MockInterface&WebhookRegistrationService $webhook */
+        $webhook = Mockery::mock(WebhookRegistrationService::class);
+        $webhook->shouldNotReceive('registerTelegram');
+
+        $component = new IntegrationChannelPage();
+        $component->mount('telegram', $settings, $this->statusMock());
+        $component->telegram_group_id = str_repeat('1', 51);
+        $component->connect($settings, $webhook);
+
+        $this->assertFalse($component->saved);
+        $this->assertNull($component->webhookMessage);
+    }
+
+    public function test_cancel_resets_fields_from_settings(): void
+    {
+        /** @var \Mockery\MockInterface&SettingsService $settings */
+        $settings = Mockery::mock(SettingsService::class);
+        $settings->shouldReceive('get')->with('telegram.group_id')->andReturn('-100stored');
+        $settings->shouldReceive('get')->with('telegram.token')->andReturn('');
+        $settings->shouldReceive('get')->with('telegram.secret_key')->andReturn('');
+        $settings->shouldReceive('get')->with('vk.token')->andReturn('');
+        $settings->shouldReceive('get')->with('vk.secret_key')->andReturn('');
+        $settings->shouldReceive('get')->with('vk.confirm_code')->andReturn('');
+        $settings->shouldReceive('get')->with('max.token')->andReturn('');
+        $settings->shouldReceive('get')->with('max.secret_key')->andReturn('');
+
+        $component = new IntegrationChannelPage();
+        $component->mount('telegram', $settings, $this->statusMock());
+        $component->telegram_group_id = 'changed';
+        $component->saved = true;
+        $component->cancel($settings);
+
+        $this->assertSame('-100stored', $component->telegram_group_id);
+        $this->assertFalse($component->saved);
+        $this->assertEmpty($component->formErrors);
+    }
+}

--- a/tests/Unit/Livewire/Settings/IntegrationsListPageTest.php
+++ b/tests/Unit/Livewire/Settings/IntegrationsListPageTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Unit\Livewire\Settings;
+
+use App\Livewire\Settings\IntegrationsListPage;
+use App\Modules\Admin\Services\ChannelStatusService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Tests\TestCase;
+
+/**
+ * Unit-level tests for the IntegrationsListPage Livewire component.
+ *
+ * Exercises mount() in isolation with a mocked ChannelStatusService —
+ * no DB or Livewire rendering required.
+ */
+class IntegrationsListPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        Mockery::close();
+    }
+
+    public function test_mount_loads_channel_statuses_from_service(): void
+    {
+        $statuses = [
+            'telegram' => ['connected' => true, 'label' => 'Подключено'],
+            'vk' => ['connected' => false, 'label' => 'Не подключён'],
+            'max' => ['connected' => false, 'label' => 'Не подключён'],
+        ];
+
+        /** @var \Mockery\MockInterface&ChannelStatusService $mock */
+        $mock = Mockery::mock(ChannelStatusService::class);
+        $mock->shouldReceive('all')->with()->once()->andReturn($statuses);
+
+        $component = new IntegrationsListPage();
+        $component->mount($mock);
+
+        $this->assertSame($statuses, $component->channelStatuses);
+    }
+
+    public function test_mount_handles_empty_statuses(): void
+    {
+        /** @var \Mockery\MockInterface&ChannelStatusService $mock */
+        $mock = Mockery::mock(ChannelStatusService::class);
+        $mock->shouldReceive('all')->with()->once()->andReturn([]);
+
+        $component = new IntegrationsListPage();
+        $component->mount($mock);
+
+        $this->assertSame([], $component->channelStatuses);
+    }
+}

--- a/tests/Unit/Modules/Admin/Services/ChannelStatusServiceTest.php
+++ b/tests/Unit/Modules/Admin/Services/ChannelStatusServiceTest.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Modules\Admin\Services;
+
+use App\Modules\Admin\Services\ChannelStatusService;
+use App\Services\Settings\SettingsService;
+use Mockery;
+use Tests\TestCase;
+
+/**
+ * Unit tests for ChannelStatusService.
+ *
+ * Uses a mock SettingsService so no DB or cache is involved.
+ */
+class ChannelStatusServiceTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        Mockery::close();
+    }
+
+    // ── all() ────────────────────────────────────────────────────────────────
+
+    public function test_all_returns_all_three_channels(): void
+    {
+        $settings = $this->makeSettings([]);
+        $service = new ChannelStatusService($settings);
+
+        $result = $service->all();
+
+        $this->assertArrayHasKey('telegram', $result);
+        $this->assertArrayHasKey('vk', $result);
+        $this->assertArrayHasKey('max', $result);
+    }
+
+    // ── telegram() ───────────────────────────────────────────────────────────
+
+    public function test_telegram_connected_when_all_required_keys_set(): void
+    {
+        $settings = $this->makeSettings([
+            'telegram.token' => 'tok',
+            'telegram.secret_key' => 'sec',
+            'telegram.group_id' => '-1001234',
+        ]);
+        $service = new ChannelStatusService($settings);
+
+        $status = $service->telegram();
+
+        $this->assertTrue($status['connected']);
+        $this->assertSame('Подключён', $status['label']);
+    }
+
+    public function test_telegram_not_connected_when_token_missing(): void
+    {
+        $settings = $this->makeSettings([
+            'telegram.token' => '',
+            'telegram.secret_key' => 'sec',
+            'telegram.group_id' => '-1001234',
+        ]);
+        $service = new ChannelStatusService($settings);
+
+        $status = $service->telegram();
+
+        $this->assertFalse($status['connected']);
+        $this->assertSame('Не настроен', $status['label']);
+    }
+
+    public function test_telegram_not_connected_when_secret_key_missing(): void
+    {
+        $settings = $this->makeSettings([
+            'telegram.token' => 'tok',
+            'telegram.secret_key' => '',
+            'telegram.group_id' => '-1001234',
+        ]);
+        $service = new ChannelStatusService($settings);
+
+        $this->assertFalse($service->telegram()['connected']);
+    }
+
+    public function test_telegram_not_connected_when_group_id_missing(): void
+    {
+        $settings = $this->makeSettings([
+            'telegram.token' => 'tok',
+            'telegram.secret_key' => 'sec',
+            'telegram.group_id' => '',
+        ]);
+        $service = new ChannelStatusService($settings);
+
+        $this->assertFalse($service->telegram()['connected']);
+    }
+
+    public function test_telegram_not_connected_when_all_keys_missing(): void
+    {
+        $settings = $this->makeSettings([]);
+        $service = new ChannelStatusService($settings);
+
+        $this->assertFalse($service->telegram()['connected']);
+    }
+
+    // ── vk() ─────────────────────────────────────────────────────────────────
+
+    public function test_vk_connected_when_all_required_keys_set(): void
+    {
+        $settings = $this->makeSettings([
+            'vk.token' => 'tok',
+            'vk.secret_key' => 'sec',
+            'vk.confirm_code' => 'code',
+        ]);
+        $service = new ChannelStatusService($settings);
+
+        $status = $service->vk();
+
+        $this->assertTrue($status['connected']);
+        $this->assertSame('Подключён', $status['label']);
+    }
+
+    public function test_vk_not_connected_when_confirm_code_missing(): void
+    {
+        $settings = $this->makeSettings([
+            'vk.token' => 'tok',
+            'vk.secret_key' => 'sec',
+            'vk.confirm_code' => '',
+        ]);
+        $service = new ChannelStatusService($settings);
+
+        $this->assertFalse($service->vk()['connected']);
+    }
+
+    public function test_vk_not_connected_when_token_missing(): void
+    {
+        $settings = $this->makeSettings([
+            'vk.token' => null,
+            'vk.secret_key' => 'sec',
+            'vk.confirm_code' => 'code',
+        ]);
+        $service = new ChannelStatusService($settings);
+
+        $this->assertFalse($service->vk()['connected']);
+    }
+
+    // ── max() ─────────────────────────────────────────────────────────────────
+
+    public function test_max_connected_when_all_required_keys_set(): void
+    {
+        $settings = $this->makeSettings([
+            'max.token' => 'tok',
+            'max.secret_key' => 'sec',
+        ]);
+        $service = new ChannelStatusService($settings);
+
+        $status = $service->max();
+
+        $this->assertTrue($status['connected']);
+        $this->assertSame('Подключён', $status['label']);
+    }
+
+    public function test_max_not_connected_when_token_missing(): void
+    {
+        $settings = $this->makeSettings([
+            'max.token' => '',
+            'max.secret_key' => 'sec',
+        ]);
+        $service = new ChannelStatusService($settings);
+
+        $this->assertFalse($service->max()['connected']);
+    }
+
+    public function test_max_not_connected_when_secret_missing(): void
+    {
+        $settings = $this->makeSettings([
+            'max.token' => 'tok',
+            'max.secret_key' => null,
+        ]);
+        $service = new ChannelStatusService($settings);
+
+        $this->assertFalse($service->max()['connected']);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /**
+     * Build a SettingsService mock that returns given key→value pairs.
+     * Keys not present in the map return null.
+     *
+     * @param array<string, mixed> $values
+     */
+    private function makeSettings(array $values): SettingsService
+    {
+        /** @var \Mockery\MockInterface&SettingsService $mock */
+        $mock = Mockery::mock(SettingsService::class);
+
+        foreach ($values as $key => $value) {
+            $mock->shouldReceive('get')->with($key)->andReturn($value);
+        }
+
+        // Keys not in the map return null
+        $mock->shouldReceive('get')->andReturn(null);
+
+        return $mock;
+    }
+}

--- a/tests/Unit/Modules/Admin/Services/WebhookRegistrationServiceTest.php
+++ b/tests/Unit/Modules/Admin/Services/WebhookRegistrationServiceTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Modules\Admin\Services;
+
+use App\Modules\Admin\Services\WebhookRegistrationService;
+use App\Services\Settings\SettingsService;
+use Illuminate\Support\Facades\Http;
+use Mockery;
+use Tests\TestCase;
+
+/**
+ * Unit tests for WebhookRegistrationService.
+ *
+ * Uses Http::fake() to intercept outgoing API calls and a mocked SettingsService.
+ * No real network calls are made.
+ */
+class WebhookRegistrationServiceTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        Mockery::close();
+    }
+
+    // ── registerTelegram() ───────────────────────────────────────────────────
+
+    public function test_register_telegram_returns_error_when_token_empty(): void
+    {
+        $settings = $this->makeSettings(['telegram.token' => '', 'telegram.secret_key' => '']);
+        $service = new WebhookRegistrationService($settings);
+
+        $result = $service->registerTelegram();
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('не задан', $result['message']);
+    }
+
+    public function test_register_telegram_returns_success_on_ok_response(): void
+    {
+        Http::fake([
+            'https://api.telegram.org/*' => Http::response([
+                'ok' => true,
+                'description' => 'Webhook was set',
+            ], 200),
+        ]);
+
+        $settings = $this->makeSettings([
+            'telegram.token' => 'bot123:token',
+            'telegram.secret_key' => 'secret',
+        ]);
+        $service = new WebhookRegistrationService($settings);
+
+        $result = $service->registerTelegram();
+
+        $this->assertTrue($result['success']);
+        $this->assertStringContainsString('зарегистрирован', $result['message']);
+    }
+
+    public function test_register_telegram_returns_error_on_api_failure(): void
+    {
+        Http::fake([
+            'https://api.telegram.org/*' => Http::response([
+                'ok' => false,
+                'description' => 'Unauthorized',
+                'error_code' => 401,
+            ], 401),
+        ]);
+
+        $settings = $this->makeSettings([
+            'telegram.token' => 'invalid_token',
+            'telegram.secret_key' => 'secret',
+        ]);
+        $service = new WebhookRegistrationService($settings);
+
+        $result = $service->registerTelegram();
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('Ошибка', $result['message']);
+    }
+
+    // ── registerVk() ─────────────────────────────────────────────────────────
+
+    public function test_register_vk_returns_error_when_token_empty(): void
+    {
+        $settings = $this->makeSettings(['vk.token' => '']);
+        $service = new WebhookRegistrationService($settings);
+
+        $result = $service->registerVk();
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('не задан', $result['message']);
+    }
+
+    public function test_register_vk_returns_success_on_valid_api_response(): void
+    {
+        Http::fake([
+            'https://api.vk.com/*' => Http::response([
+                'response' => [['id' => 123, 'name' => 'Test Group']],
+            ], 200),
+        ]);
+
+        $settings = $this->makeSettings(['vk.token' => 'vk_token_abc']);
+        $service = new WebhookRegistrationService($settings);
+
+        $result = $service->registerVk();
+
+        $this->assertTrue($result['success']);
+    }
+
+    public function test_register_vk_returns_error_on_vk_api_error(): void
+    {
+        Http::fake([
+            'https://api.vk.com/*' => Http::response([
+                'error' => ['error_code' => 5, 'error_msg' => 'User authorization failed'],
+            ], 200),
+        ]);
+
+        $settings = $this->makeSettings(['vk.token' => 'vk_token_abc']);
+        $service = new WebhookRegistrationService($settings);
+
+        $result = $service->registerVk();
+
+        $this->assertFalse($result['success']);
+    }
+
+    // ── registerMax() ────────────────────────────────────────────────────────
+
+    public function test_register_max_returns_error_when_token_empty(): void
+    {
+        $settings = $this->makeSettings(['max.token' => '']);
+        $service = new WebhookRegistrationService($settings);
+
+        $result = $service->registerMax();
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('не задан', $result['message']);
+    }
+
+    public function test_register_max_returns_success_on_200_response(): void
+    {
+        Http::fake([
+            'https://platform-api.max.ru/*' => Http::response(['result' => 'ok'], 200),
+        ]);
+
+        $settings = $this->makeSettings(['max.token' => 'max_token']);
+        $service = new WebhookRegistrationService($settings);
+
+        $result = $service->registerMax();
+
+        $this->assertTrue($result['success']);
+        $this->assertStringContainsString('зарегистрирован', $result['message']);
+    }
+
+    public function test_register_max_returns_error_on_non_200_response(): void
+    {
+        Http::fake([
+            'https://platform-api.max.ru/*' => Http::response(['error' => 'invalid token'], 401),
+        ]);
+
+        $settings = $this->makeSettings(['max.token' => 'bad_token']);
+        $service = new WebhookRegistrationService($settings);
+
+        $result = $service->registerMax();
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('401', $result['message']);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /**
+     * @param array<string, mixed> $values
+     */
+    private function makeSettings(array $values): SettingsService
+    {
+        /** @var \Mockery\MockInterface&SettingsService $mock */
+        $mock = Mockery::mock(SettingsService::class);
+
+        foreach ($values as $key => $value) {
+            $mock->shouldReceive('get')->with($key)->andReturn($value);
+        }
+
+        // Keys not in the map return null
+        $mock->shouldReceive('get')->andReturn(null);
+
+        return $mock;
+    }
+}


### PR DESCRIPTION
## Summary

Раздел **«Интеграции»** в админ-панели по дизайну `admin-tg-support-bot.pen` — на кастомном Livewire/Blade поверх дизайн-системы (#153) и `SettingsService` (#150). Список каналов (Telegram/VK/MAX) + форма подключения по каждому каналу с регистрацией вебхука.

> База PR — **`dev`** (ветка `issues-144` от dev; #150 и #153 уже влиты).

## Что сделано
- **Список каналов** (`/admin/settings/integrations`) — `IntegrationsListPage` + вью по макету `x7EQB2`: вертикальные карточки с иконкой, названием, **описанием интеграции**, статусом «Подключено/Не подключён» и кнопкой «Подключить» для неподключённых. «Виджет для сайта» — заглушка «Скоро». На десктопе список показывается так же (без редиректа), на мобайле — нативно.
- **Форма подключения** (`/admin/settings/integrations/{telegram|vk|max}`) — `IntegrationChannelPage` + вью по макету `nrqY1`/`LSbWF`/`aTl2u`: хлебные крошки, карточка с иконкой/заголовком/полями канала, кнопки «Отмена»/«Подключить» (одно действие = сохранение + регистрация вебхука), правая панель **«Инструкция»** с пошаговым гайдом и ссылкой на доки канала (`telegram-bot.html`/`vk-group.html`/`max-bot.html`). VK-инструкция использует реальный домен через `config('app.url')`.
- **Хранение** — через `SettingsService` (#150) и существующие ключи реестра (`telegram.*`/`vk.*`/`max.*`); секреты шифруются, пустые поля не затирают сохранённые значения, в логи токены не пишутся.
- **Сервисы** — `ChannelStatusService` (статус подключения по заполненности ключей) и `WebhookRegistrationService` (регистрация вебхука TG/VK/MAX поверх существующих Api).
- **Доступ** — только админ; пункт «Интеграции» в сайдбаре настроек активен.
- **Тесты** — Feature (`IntegrationsListPageTest`, `IntegrationChannelPageTest`) + Unit (`ChannelStatusServiceTest`, `WebhookRegistrationServiceTest`, `Livewire/Settings/*`). Доки: `rules/domain/admin-panel.md`, `rules/api/endpoints.md`, `rules/process/security.md`, `CLAUDE.md`.

## Решения по ❓ спека
- Тип страниц — кастомный Livewire/Blade (не Filament), консистентно с редизайном #153.
- Хранение — `SettingsService`, без новой таблицы.
- «Подключить» = сохранить + зарегистрировать вебхук одним действием.
- VK: проверка валидности токена; сам Callback URL регистрируется в настройках VK-группы вручную (нет ключа `vk.community_id` — отмечено как возможное расширение).

## ⚠️ Важно (зависимость рантайма)
Раздел сохраняет конфигурацию в таблицу `settings`, но боевые модули пока читают токены из `config('traffic_source.*')` (`.env`). Чтобы введённое здесь реально применялось работающим ботом, нужен перевод рантайм-чтения на `SettingsService` — это отдельная задача **#154**.

## Проверки
Pint — чисто · PHPStan level 6 — 0 ошибок · `php artisan test` — **518 passed (1412 assertions)**.

Closes #144