### PR TITLE
issues-145 | Раздел админ-панели «ИИ-ассистент» и экраны доступа к провайдерам

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,9 @@ app/
 │   └── Settings/     # Custom full-page Livewire components for Settings section
 │       ├── GeneralSettingsPage.php       # /admin/settings/general
 │       ├── IntegrationsListPage.php      # /admin/settings/integrations
-│       └── IntegrationChannelPage.php   # /admin/settings/integrations/{channel}
+│       ├── IntegrationChannelPage.php   # /admin/settings/integrations/{channel}
+│       ├── AiAssistantPage.php          # /admin/settings/ai
+│       └── AiProviderAccessPage.php     # /admin/settings/ai/{provider}
 ├── Platform/         # PlatformChannelRegistry — registry for pluggable platform modules
 ├── DTOs/             # Shared Data Transfer Objects (Ai/, Button/, Redis/)
 ├── Services/
@@ -168,7 +170,9 @@ resources/
 │       └── settings/
 │           ├── general-settings-page.blade.php        # View for GeneralSettingsPage
 │           ├── integrations-list-page.blade.php       # View for IntegrationsListPage
-│           └── integration-channel-page.blade.php    # View for IntegrationChannelPage
+│           ├── integration-channel-page.blade.php    # View for IntegrationChannelPage
+│           ├── ai-assistant-page.blade.php           # View for AiAssistantPage
+│           └── ai-provider-access-page.blade.php    # View for AiProviderAccessPage
 ```
 
 ---
@@ -262,20 +266,22 @@ public static function execute(BotUser $botUser): TelegramAnswerDto
 
 ### AI Assistant
 
-- AI is disabled by default (`AI_ENABLED=false`)
+- AI is disabled by default (`AI_ENABLED=false`); can be toggled from the admin panel at `/admin/settings/ai`
 - AI runs through a **separate Telegram bot** (`TELEGRAM_AI_BOT_TOKEN`) that is added to the same supergroup
 - The AI bot webhook URL is `POST /api/ai-bot/webhook`, protected by `AiBotQuery` middleware (`TELEGRAM_AI_BOT_SECRET`)
 - `AI_AUTO_REPLY=false` (default): AI posts a draft with "Accept / Cancel" inline buttons; manager reviews before sending
-- `AI_AUTO_REPLY=true`: AI posts the reply directly to the topic; it is immediately sent to the user via `SendReplyAction`
+- `AI_AUTO_REPLY=true`: AI posts the reply directly to the topic; it is immediately sent to the user via `SendReplyAction`; enabling via admin panel requires explicit confirmation
 - The AI bot only replies to messages whose `from.id` equals `TELEGRAM_BOT_ID` (forwarded user messages from the main bot)
 - The AI bot does NOT reply when `MANAGER_INTERFACE=admin_panel`
-- Supported providers: OpenAI, DeepSeek, GigaChat (set via `AI_DEFAULT_PROVIDER`)
+- Supported providers: OpenAI, DeepSeek, GigaChat (set via `AI_DEFAULT_PROVIDER` or from `/admin/settings/ai`)
 - Register the AI bot webhook with: `docker exec -it pet php artisan ai-bot:set-webhook`
 - AI conversation history is sourced from the `messages` table (no Redis cache), bounded by `AI_MAX_CONTEXT_TOKENS` (default 3000) using a `mb_strlen / 4` token heuristic with sliding-window trimming
-- AI system prompt lives in `resources/ai/system-prompt.blade.php` (Blade template — variables only, no `@if`/`@foreach`/`@include`/`@php`); path is configured by `config/ai.php @ system_prompt_path`
+- AI system prompt: stored in `settings` DB under key `ai.system_prompt` (editable from `/admin/settings/ai`); the Blade fallback at `resources/ai/system-prompt.blade.php` is NOT overwritten by the admin UI
+- AI provider credentials (API keys, base URLs, models, tokens, cert path) are managed at `/admin/settings/ai/{provider}` and stored encrypted in the `settings` table via `SettingsService`
 - AI drafts NEVER write to `messages` (only to `ai_messages`); a `messages` row appears only when the message is actually sent to the user — this invariant is what makes "any outgoing row = delivered" safe for the chat-history assembler
 - AI runs across all user platforms (`telegram`, `vk`, `max`). Triggers: `TelegramBotController::maybeDispatchAi()` for TG, `VkMessageService::maybeDispatchAi()` for VK, `MaxMessageService::maybeDispatchAi()` for Max. Triggering is text-only — attachments do not start AI. Gating still goes through `ShouldAiReply` (TG-DTO and platform-agnostic variants share the same rules: AI_ENABLED, `MANAGER_INTERFACE=telegram_group`, replyable text, user active)
 - Final delivery of an AI answer to the user (Accept and auto-reply) is routed by `BotUser.platform` through `App\Modules\Ai\Actions\DeliverAiAnswerToUser` → `SendTelegramMessageJob` / `SendVkMessageJob` / `SendMaxMessageJob`. Any other platform is delegated to a `PlatformChannel` registered in `App\Platform\PlatformChannelRegistry` by a pluggable module (e.g. the paid Avito package). The Accept callback still edits the supergroup draft via `SendTelegramMessageJob` using the AI bot token regardless of user platform
+- **Runtime application (deferred):** AI settings saved in the admin panel are persisted to the DB and displayed correctly in the UI. `ShouldAiReply`, `AiAssistantService`, and AI providers still read from `config('ai.*')` at runtime — full DB-based runtime wiring is a follow-up task
 
 ### Settings Persistence Layer
 

--- a/app/Livewire/Settings/AiAssistantPage.php
+++ b/app/Livewire/Settings/AiAssistantPage.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Settings;
+
+use App\Services\Settings\SettingsService;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+/**
+ * AI assistant settings page.
+ *
+ * Manages the master AI toggle, provider selection, auto-reply mode,
+ * context token limit, and system prompt. All values are persisted via
+ * SettingsService (DB → config() fallback, cache-backed).
+ *
+ * Access: authenticated admin only (enforced in route middleware).
+ * Layout: custom dark-sidebar admin layout (layouts.admin-settings).
+ *
+ * Route: GET /admin/settings/ai
+ */
+#[Layout('layouts.admin-settings')]
+class AiAssistantPage extends Component
+{
+    /** @var bool Master AI on/off toggle */
+    public bool $ai_enabled = false;
+
+    /** @var string Active provider: openai|deepseek|gigachat */
+    public string $default_provider = 'openai';
+
+    /** @var bool Auto-reply mode (true = auto, false = draft) */
+    public bool $auto_reply = false;
+
+    /** @var int Maximum context tokens */
+    public int $max_context_tokens = 3000;
+
+    /** @var string System prompt text */
+    public string $system_prompt = '';
+
+    /** @var array<string, bool> Whether each provider has its credentials configured */
+    public array $providerConfigured = [];
+
+    /** @var array<string, string> Configured model name per provider */
+    public array $providerModels = [];
+
+    /** @var bool Show auto-reply warning/confirm */
+    public bool $showAutoReplyWarning = false;
+
+    /** @var bool Pending auto-reply value awaiting confirmation */
+    public bool $pendingAutoReply = false;
+
+    /** @var bool Success banner visible */
+    public bool $saved = false;
+
+    /** @var array<string, string> Validation errors keyed by field name */
+    public array $formErrors = [];
+
+    /**
+     * Load current values from SettingsService on mount.
+     */
+    public function mount(SettingsService $settings): void
+    {
+        $this->loadFields($settings);
+    }
+
+    /**
+     * Called when the auto-reply toggle changes via wire:model.live.
+     *
+     * When enabling auto-reply, show a confirmation warning instead of
+     * saving immediately (BR-002: warn before enabling auto-reply).
+     */
+    public function updatedAutoReply(bool $value): void
+    {
+        if ($value) {
+            // Revert the toggle — wait for user confirmation
+            $this->auto_reply = false;
+            $this->pendingAutoReply = true;
+            $this->showAutoReplyWarning = true;
+        } else {
+            $this->showAutoReplyWarning = false;
+            $this->pendingAutoReply = false;
+        }
+    }
+
+    /**
+     * Confirm auto-reply activation after the user accepted the warning.
+     */
+    public function confirmAutoReply(): void
+    {
+        $this->auto_reply = true;
+        $this->pendingAutoReply = false;
+        $this->showAutoReplyWarning = false;
+    }
+
+    /**
+     * Cancel auto-reply activation — keep draft mode.
+     */
+    public function cancelAutoReply(): void
+    {
+        $this->auto_reply = false;
+        $this->pendingAutoReply = false;
+        $this->showAutoReplyWarning = false;
+    }
+
+    /**
+     * Save all AI settings via SettingsService.
+     */
+    public function save(SettingsService $settings): void
+    {
+        $this->formErrors = [];
+        $this->saved = false;
+
+        // Validation
+        if (! in_array($this->default_provider, ['openai', 'deepseek', 'gigachat'], true)) {
+            $this->formErrors['default_provider'] = 'Выберите допустимый провайдер.';
+        }
+
+        if ($this->max_context_tokens < 1) {
+            $this->formErrors['max_context_tokens'] = 'Лимит контекста должен быть положительным целым числом.';
+        }
+
+        if (! empty($this->formErrors)) {
+            return;
+        }
+
+        $settings->set('ai.enabled', $this->ai_enabled);
+        $settings->set('ai.default_provider', $this->default_provider);
+        $settings->set('ai.auto_reply', $this->auto_reply);
+        $settings->set('ai.max_context_tokens', $this->max_context_tokens);
+        $settings->set('ai.system_prompt', $this->system_prompt);
+
+        $this->saved = true;
+    }
+
+    /**
+     * Reset form to the currently stored values.
+     */
+    public function cancel(SettingsService $settings): void
+    {
+        $this->formErrors = [];
+        $this->saved = false;
+        $this->showAutoReplyWarning = false;
+        $this->pendingAutoReply = false;
+        $this->loadFields($settings);
+    }
+
+    /**
+     * Render the component view.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function render(): \Illuminate\View\View
+    {
+        return view('livewire.settings.ai-assistant-page');
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────────
+
+    /**
+     * Populate component properties from SettingsService.
+     */
+    private function loadFields(SettingsService $settings): void
+    {
+        $this->ai_enabled = (bool) ($settings->get('ai.enabled') ?? false);
+        $this->default_provider = (string) ($settings->get('ai.default_provider') ?? 'openai');
+        $this->auto_reply = (bool) ($settings->get('ai.auto_reply') ?? false);
+        $this->max_context_tokens = (int) ($settings->get('ai.max_context_tokens') ?? 3000);
+        $this->system_prompt = (string) ($settings->get('ai.system_prompt') ?? '');
+
+        $this->providerConfigured = [
+            'openai' => filled($settings->get('ai.openai_api_key')),
+            'deepseek' => filled($settings->get('ai.deepseek_client_secret')),
+            'gigachat' => filled($settings->get('ai.gigachat_client_secret')),
+        ];
+
+        $this->providerModels = [
+            'openai' => (string) ($settings->get('ai.openai_model') ?? ''),
+            'deepseek' => (string) ($settings->get('ai.deepseek_model') ?? ''),
+            'gigachat' => (string) ($settings->get('ai.gigachat_model') ?? ''),
+        ];
+    }
+}

--- a/app/Livewire/Settings/AiProviderAccessPage.php
+++ b/app/Livewire/Settings/AiProviderAccessPage.php
@@ -1,0 +1,277 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Settings;
+
+use App\Services\Settings\SettingsService;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+/**
+ * Per-provider AI credentials configuration page.
+ *
+ * Handles access configuration for OpenAI, DeepSeek, and GigaChat.
+ * Reads/writes via SettingsService (secrets stored encrypted).
+ *
+ * Secret fields (api_key, client_secret) are write-only in the UI:
+ * they are never pre-filled from storage, and an empty value on save
+ * does NOT overwrite the existing stored secret (blank-secret guard).
+ *
+ * Route: GET /admin/settings/ai/{provider}  (provider ∈ {openai, deepseek, gigachat})
+ *
+ * Access: authenticated admin only (enforced in route middleware).
+ * Layout: custom dark-sidebar admin layout (layouts.admin-settings).
+ */
+#[Layout('layouts.admin-settings')]
+class AiProviderAccessPage extends Component
+{
+    /** @var string The current provider slug (openai|deepseek|gigachat) */
+    public string $provider = 'openai';
+
+    // ── OpenAI fields ─────────────────────────────────────────────────────────
+
+    /** @var string|null OpenAI API key (secret — never pre-filled) */
+    public ?string $openai_api_key = null;
+
+    /** @var string|null OpenAI base URL */
+    public ?string $openai_base_url = null;
+
+    /** @var string|null OpenAI model name */
+    public ?string $openai_model = null;
+
+    /** @var int|null OpenAI max tokens */
+    public ?int $openai_max_tokens = null;
+
+    /** @var string|null OpenAI temperature */
+    public ?string $openai_temperature = null;
+
+    // ── DeepSeek fields ───────────────────────────────────────────────────────
+
+    /** @var string|null DeepSeek client ID */
+    public ?string $deepseek_client_id = null;
+
+    /** @var string|null DeepSeek client secret (secret — never pre-filled) */
+    public ?string $deepseek_client_secret = null;
+
+    /** @var string|null DeepSeek base URL */
+    public ?string $deepseek_base_url = null;
+
+    /** @var string|null DeepSeek model name */
+    public ?string $deepseek_model = null;
+
+    /** @var int|null DeepSeek max tokens */
+    public ?int $deepseek_max_tokens = null;
+
+    /** @var string|null DeepSeek temperature */
+    public ?string $deepseek_temperature = null;
+
+    // ── GigaChat fields ───────────────────────────────────────────────────────
+
+    /** @var string|null GigaChat client ID */
+    public ?string $gigachat_client_id = null;
+
+    /** @var string|null GigaChat client secret (secret — never pre-filled) */
+    public ?string $gigachat_client_secret = null;
+
+    /** @var string|null GigaChat base URL */
+    public ?string $gigachat_base_url = null;
+
+    /** @var string|null GigaChat model name */
+    public ?string $gigachat_model = null;
+
+    /** @var int|null GigaChat max tokens */
+    public ?int $gigachat_max_tokens = null;
+
+    /** @var string|null GigaChat temperature */
+    public ?string $gigachat_temperature = null;
+
+    /** @var string|null Path to GigaChat certificate file */
+    public ?string $gigachat_path_cert = null;
+
+    // ── State ─────────────────────────────────────────────────────────────────
+
+    /** @var bool Config persisted successfully */
+    public bool $saved = false;
+
+    /** @var array<string, string> Validation errors keyed by field name */
+    public array $formErrors = [];
+
+    /**
+     * Mount with the provider slug from the route.
+     */
+    public function mount(string $provider, SettingsService $settings): void
+    {
+        $this->provider = $provider;
+        $this->loadFields($settings);
+    }
+
+    /**
+     * Save the current provider's form values via SettingsService.
+     */
+    public function save(SettingsService $settings): void
+    {
+        $this->formErrors = [];
+        $this->saved = false;
+
+        match ($this->provider) {
+            'openai' => $this->saveOpenAi($settings),
+            'deepseek' => $this->saveDeepSeek($settings),
+            'gigachat' => $this->saveGigaChat($settings),
+            default => $this->formErrors['provider'] = 'Неизвестный провайдер.',
+        };
+    }
+
+    /**
+     * Reset form to currently stored values.
+     */
+    public function cancel(SettingsService $settings): void
+    {
+        $this->formErrors = [];
+        $this->saved = false;
+        $this->loadFields($settings);
+    }
+
+    /**
+     * Render the component view.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function render(): \Illuminate\View\View
+    {
+        return view('livewire.settings.ai-provider-access-page');
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────────
+
+    /**
+     * Populate non-secret fields from SettingsService.
+     * Secret fields are intentionally left null (never pre-filled in UI).
+     */
+    private function loadFields(SettingsService $settings): void
+    {
+        // OpenAI non-secrets
+        $this->openai_base_url = (string) ($settings->get('ai.openai_base_url') ?? '');
+        $this->openai_model = (string) ($settings->get('ai.openai_model') ?? '');
+        $rawOpenAiMax = $settings->get('ai.openai_max_tokens');
+        $this->openai_max_tokens = $rawOpenAiMax !== null ? (int) $rawOpenAiMax : null;
+        $this->openai_temperature = (string) ($settings->get('ai.openai_temperature') ?? '');
+
+        // DeepSeek non-secrets
+        $this->deepseek_client_id = (string) ($settings->get('ai.deepseek_client_id') ?? '');
+        $this->deepseek_base_url = (string) ($settings->get('ai.deepseek_base_url') ?? '');
+        $this->deepseek_model = (string) ($settings->get('ai.deepseek_model') ?? '');
+        $rawDeepSeekMax = $settings->get('ai.deepseek_max_tokens');
+        $this->deepseek_max_tokens = $rawDeepSeekMax !== null ? (int) $rawDeepSeekMax : null;
+        $this->deepseek_temperature = (string) ($settings->get('ai.deepseek_temperature') ?? '');
+
+        // GigaChat non-secrets
+        $this->gigachat_client_id = (string) ($settings->get('ai.gigachat_client_id') ?? '');
+        $this->gigachat_base_url = (string) ($settings->get('ai.gigachat_base_url') ?? '');
+        $this->gigachat_model = (string) ($settings->get('ai.gigachat_model') ?? '');
+        $rawGigaMax = $settings->get('ai.gigachat_max_tokens');
+        $this->gigachat_max_tokens = $rawGigaMax !== null ? (int) $rawGigaMax : null;
+        $this->gigachat_temperature = (string) ($settings->get('ai.gigachat_temperature') ?? '');
+        $this->gigachat_path_cert = (string) ($settings->get('ai.gigachat_path_cert') ?? '');
+
+        // Secret fields: intentionally left null — never pre-filled
+        $this->openai_api_key = null;
+        $this->deepseek_client_secret = null;
+        $this->gigachat_client_secret = null;
+    }
+
+    /**
+     * Validate and save OpenAI credentials.
+     */
+    private function saveOpenAi(SettingsService $settings): void
+    {
+        if ($this->openai_max_tokens !== null && $this->openai_max_tokens < 1) {
+            $this->formErrors['openai_max_tokens'] = 'Макс. токенов должно быть положительным числом.';
+        }
+
+        if (! empty($this->formErrors)) {
+            return;
+        }
+
+        // Secret: only overwrite if non-empty
+        if ($this->openai_api_key !== null && $this->openai_api_key !== '') {
+            $settings->set('ai.openai_api_key', $this->openai_api_key);
+        }
+
+        $settings->set('ai.openai_base_url', $this->openai_base_url ?? '');
+        $settings->set('ai.openai_model', $this->openai_model ?? '');
+
+        if ($this->openai_max_tokens !== null) {
+            $settings->set('ai.openai_max_tokens', $this->openai_max_tokens);
+        }
+
+        $settings->set('ai.openai_temperature', $this->openai_temperature ?? '');
+
+        $this->saved = true;
+    }
+
+    /**
+     * Validate and save DeepSeek credentials.
+     */
+    private function saveDeepSeek(SettingsService $settings): void
+    {
+        if ($this->deepseek_max_tokens !== null && $this->deepseek_max_tokens < 1) {
+            $this->formErrors['deepseek_max_tokens'] = 'Макс. токенов должно быть положительным числом.';
+        }
+
+        if (! empty($this->formErrors)) {
+            return;
+        }
+
+        $settings->set('ai.deepseek_client_id', $this->deepseek_client_id ?? '');
+
+        // Secret: only overwrite if non-empty
+        if ($this->deepseek_client_secret !== null && $this->deepseek_client_secret !== '') {
+            $settings->set('ai.deepseek_client_secret', $this->deepseek_client_secret);
+        }
+
+        $settings->set('ai.deepseek_base_url', $this->deepseek_base_url ?? '');
+        $settings->set('ai.deepseek_model', $this->deepseek_model ?? '');
+
+        if ($this->deepseek_max_tokens !== null) {
+            $settings->set('ai.deepseek_max_tokens', $this->deepseek_max_tokens);
+        }
+
+        $settings->set('ai.deepseek_temperature', $this->deepseek_temperature ?? '');
+
+        $this->saved = true;
+    }
+
+    /**
+     * Validate and save GigaChat credentials.
+     */
+    private function saveGigaChat(SettingsService $settings): void
+    {
+        if ($this->gigachat_max_tokens !== null && $this->gigachat_max_tokens < 1) {
+            $this->formErrors['gigachat_max_tokens'] = 'Макс. токенов должно быть положительным числом.';
+        }
+
+        if (! empty($this->formErrors)) {
+            return;
+        }
+
+        $settings->set('ai.gigachat_client_id', $this->gigachat_client_id ?? '');
+
+        // Secret: only overwrite if non-empty
+        if ($this->gigachat_client_secret !== null && $this->gigachat_client_secret !== '') {
+            $settings->set('ai.gigachat_client_secret', $this->gigachat_client_secret);
+        }
+
+        $settings->set('ai.gigachat_base_url', $this->gigachat_base_url ?? '');
+        $settings->set('ai.gigachat_model', $this->gigachat_model ?? '');
+
+        if ($this->gigachat_max_tokens !== null) {
+            $settings->set('ai.gigachat_max_tokens', $this->gigachat_max_tokens);
+        }
+
+        $settings->set('ai.gigachat_temperature', $this->gigachat_temperature ?? '');
+        $settings->set('ai.gigachat_path_cert', $this->gigachat_path_cert ?? '');
+
+        $this->saved = true;
+    }
+}

--- a/app/Modules/Admin/AdminServiceProvider.php
+++ b/app/Modules/Admin/AdminServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Modules\Admin;
 
+use App\Livewire\Settings\AiAssistantPage;
+use App\Livewire\Settings\AiProviderAccessPage;
 use App\Livewire\Settings\GeneralSettingsPage;
 use App\Livewire\Settings\IntegrationChannelPage;
 use App\Livewire\Settings\IntegrationsListPage;
@@ -45,6 +47,14 @@ class AdminServiceProvider extends ServiceProvider
                 Route::get('/integrations/{channel}', IntegrationChannelPage::class)
                     ->name('integrations.channel')
                     ->where('channel', 'telegram|vk|max');
+
+                // AI assistant settings.
+                Route::get('/ai', AiAssistantPage::class)
+                    ->name('ai');
+
+                Route::get('/ai/{provider}', AiProviderAccessPage::class)
+                    ->name('ai.provider')
+                    ->where('provider', 'openai|deepseek|gigachat');
             });
     }
 }

--- a/app/Services/Settings/SettingKeyRegistry.php
+++ b/app/Services/Settings/SettingKeyRegistry.php
@@ -167,6 +167,79 @@ class SettingKeyRegistry
             'config' => 'ai.providers.gigachat.client_secret',
             'is_secret' => true,
         ],
+
+        // ── AI system prompt ─────────────────────────────────────────────────
+        'ai.system_prompt' => [
+            'type' => 'string',
+            'config' => null,
+            'is_secret' => false,
+        ],
+
+        // ── OpenAI extended fields ────────────────────────────────────────────
+        'ai.openai_base_url' => [
+            'type' => 'string',
+            'config' => 'ai.providers.openai.base_url',
+            'is_secret' => false,
+        ],
+        'ai.openai_max_tokens' => [
+            'type' => 'int',
+            'config' => 'ai.providers.openai.max_tokens',
+            'is_secret' => false,
+        ],
+        'ai.openai_temperature' => [
+            'type' => 'string',
+            'config' => 'ai.providers.openai.temperature',
+            'is_secret' => false,
+        ],
+
+        // ── DeepSeek extended fields ──────────────────────────────────────────
+        'ai.deepseek_base_url' => [
+            'type' => 'string',
+            'config' => 'ai.providers.deepseek.base_url',
+            'is_secret' => false,
+        ],
+        'ai.deepseek_model' => [
+            'type' => 'string',
+            'config' => 'ai.providers.deepseek.model',
+            'is_secret' => false,
+        ],
+        'ai.deepseek_max_tokens' => [
+            'type' => 'int',
+            'config' => 'ai.providers.deepseek.max_tokens',
+            'is_secret' => false,
+        ],
+        'ai.deepseek_temperature' => [
+            'type' => 'string',
+            'config' => 'ai.providers.deepseek.temperature',
+            'is_secret' => false,
+        ],
+
+        // ── GigaChat extended fields ──────────────────────────────────────────
+        'ai.gigachat_base_url' => [
+            'type' => 'string',
+            'config' => 'ai.providers.gigachat.base_url',
+            'is_secret' => false,
+        ],
+        'ai.gigachat_model' => [
+            'type' => 'string',
+            'config' => 'ai.providers.gigachat.model',
+            'is_secret' => false,
+        ],
+        'ai.gigachat_max_tokens' => [
+            'type' => 'int',
+            'config' => 'ai.providers.gigachat.max_tokens',
+            'is_secret' => false,
+        ],
+        'ai.gigachat_temperature' => [
+            'type' => 'string',
+            'config' => 'ai.providers.gigachat.temperature',
+            'is_secret' => false,
+        ],
+        'ai.gigachat_path_cert' => [
+            'type' => 'string',
+            'config' => 'ai.providers.gigachat.path_cert',
+            'is_secret' => false,
+        ],
     ];
 
     /**

--- a/resources/views/components/admin/button-primary.blade.php
+++ b/resources/views/components/admin/button-primary.blade.php
@@ -1,6 +1,6 @@
 {{--
     Primary action button — accent background, white text.
 --}}
-<button {{ $attributes->merge(['type' => 'submit', 'class' => 'inline-flex items-center justify-center rounded-lg bg-accent px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 disabled:opacity-60']) }}>
+<button {{ $attributes->merge(['type' => 'submit', 'class' => 'inline-flex items-center justify-center rounded-[10px] bg-accent px-6 py-2.5 text-sm font-medium text-white transition hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 disabled:opacity-60']) }}>
     {{ $slot }}
 </button>

--- a/resources/views/components/admin/toggle.blade.php
+++ b/resources/views/components/admin/toggle.blade.php
@@ -14,7 +14,12 @@
     'label'   => null,
 ])
 
-@php $inputId = $id ?? $name; @endphp
+@php
+    $inputId = $id ?? $name;
+    // When bound via wire:model, Livewire controls the checked state — emitting a
+    // static `checked` attribute conflicts with it and breaks two-way binding.
+    $wireBound = $attributes->whereStartsWith('wire:model')->isNotEmpty();
+@endphp
 
 <label class="inline-flex cursor-pointer items-center gap-3">
     <span class="relative">
@@ -23,10 +28,10 @@
             id="{{ $inputId }}"
             name="{{ $name }}"
             class="peer sr-only"
-            @if ($checked) checked @endif
+            @unless ($wireBound) @checked($checked) @endunless
             {{ $attributes->except(['class']) }}
         />
-        <span class="block h-6 w-11 rounded-full bg-bg-input transition peer-checked:bg-accent"></span>
+        <span class="block h-6 w-11 rounded-full bg-border-light transition peer-checked:bg-accent"></span>
         <span class="absolute left-0.5 top-0.5 h-5 w-5 rounded-full bg-white shadow transition peer-checked:translate-x-5"></span>
     </span>
     @if ($label)

--- a/resources/views/layouts/admin-settings.blade.php
+++ b/resources/views/layouts/admin-settings.blade.php
@@ -54,7 +54,10 @@
                     Интеграции
                 </x-admin.nav-item>
 
-                <x-admin.nav-item disabled>
+                <x-admin.nav-item
+                    href="{{ route('admin.settings.ai') }}"
+                    :active="request()->routeIs('admin.settings.ai') || request()->routeIs('admin.settings.ai.provider')"
+                >
                     <x-slot name="icon">
                         <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17H3a2 2 0 01-2-2V5a2 2 0 012-2h14a2 2 0 012 2v10a2 2 0 01-2 2h-2" />

--- a/resources/views/livewire/settings/ai-assistant-page.blade.php
+++ b/resources/views/livewire/settings/ai-assistant-page.blade.php
@@ -1,0 +1,184 @@
+<div class="p-6 lg:p-8">
+
+    {{-- Page header --}}
+    <div class="mb-6">
+        <h1 class="text-2xl font-bold text-text-primary">ИИ-ассистент</h1>
+        <p class="mt-1 text-sm text-text-secondary">Настройка AI-помощника для автоматических ответов</p>
+    </div>
+
+    {{-- Auto-reply warning --}}
+    @if ($showAutoReplyWarning)
+        <div class="mb-5 rounded-xl border border-yellow-200 bg-yellow-50 p-4">
+            <div class="flex items-start gap-3">
+                <svg xmlns="http://www.w3.org/2000/svg" class="mt-0.5 h-5 w-5 shrink-0 text-yellow-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                </svg>
+                <div class="flex-1">
+                    <p class="text-sm font-semibold text-yellow-800">Включить автоответ?</p>
+                    <p class="mt-1 text-xs text-yellow-700">В режиме автоответа ИИ будет отправлять сообщения пользователям напрямую без проверки менеджером. Убедитесь, что системный промпт настроен корректно.</p>
+                    <div class="mt-3 flex gap-2">
+                        <x-admin.button-primary wire:click="confirmAutoReply" type="button" class="py-1.5 text-xs">
+                            Включить автоответ
+                        </x-admin.button-primary>
+                        <x-admin.button-secondary wire:click="cancelAutoReply" type="button" class="py-1.5 text-xs">
+                            Отмена
+                        </x-admin.button-secondary>
+                    </div>
+                </div>
+            </div>
+        </div>
+    @endif
+
+    {{-- Success banner --}}
+    @if ($saved)
+        <div class="mb-5 flex items-center gap-2 rounded-xl border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-800">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 shrink-0 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+            </svg>
+            Настройки сохранены.
+        </div>
+    @endif
+
+    <form wire:submit="save" novalidate class="space-y-6">
+
+        {{-- ── Master toggle ───────────────────────────────────────────────── --}}
+        <div class="flex items-center justify-between rounded-xl border border-border-light bg-bg-primary p-5 lg:px-6">
+            <div class="flex items-center gap-3.5">
+                <div class="flex h-[42px] w-[42px] shrink-0 items-center justify-center rounded-xl" style="background:#EEF2FF">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-accent" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                    </svg>
+                </div>
+                <div>
+                    <p class="text-[15px] font-semibold text-text-primary">Включить AI помощника</p>
+                    <p class="mt-0.5 text-[13px] text-text-secondary">ИИ будет помогать операторам составлять ответы</p>
+                </div>
+            </div>
+            <x-admin.toggle name="ai_enabled" id="ai_enabled" wire:model.live="ai_enabled" />
+        </div>
+
+        {{-- ── AI provider ─────────────────────────────────────────────────── --}}
+        <div>
+            <h2 class="mb-4 text-base font-semibold text-text-primary">AI-провайдер</h2>
+
+            @if (!empty($formErrors['default_provider']))
+                <p class="mb-3 text-xs text-red-500">{{ $formErrors['default_provider'] }}</p>
+            @endif
+
+            @php
+                $providers = [
+                    'openai' => ['name' => 'OpenAI', 'desc' => 'AI-провайдер от OpenAI с моделями GPT-4o и GPT-4o-mini.', 'bg' => '#ECFDF5', 'color' => '#10A37F'],
+                    'deepseek' => ['name' => 'DeepSeek', 'desc' => 'AI-провайдер от DeepSeek с моделями DeepSeek-V3 и R1.', 'bg' => '#EEF2FF', 'color' => '#4F6EF7'],
+                    'gigachat' => ['name' => 'GigaChat', 'desc' => 'AI-провайдер от Сбера с моделями GigaChat Pro и Lite.', 'bg' => '#FFF3E0', 'color' => '#F57C00'],
+                ];
+            @endphp
+
+            <div class="space-y-4">
+                @foreach ($providers as $slug => $p)
+                    @php $active = $default_provider === $slug; @endphp
+                    <div class="rounded-xl bg-bg-primary p-5 lg:px-6 {{ $active ? 'border-2' : 'border border-border-light' }}"
+                         @if ($active) style="border-color:#10A37F" @endif>
+
+                        {{-- Top row --}}
+                        <div class="flex items-center justify-between">
+                            <div class="flex items-center gap-3">
+                                <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg" style="background:{{ $p['bg'] }}">
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" style="color:{{ $p['color'] }}" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
+                                    </svg>
+                                </div>
+                                <span class="text-sm font-semibold text-text-primary">{{ $p['name'] }}</span>
+                            </div>
+
+                            <div class="flex items-center gap-2">
+                                @if ($active)
+                                    <span class="inline-flex items-center rounded-lg px-2 py-1 text-xs font-medium" style="background:#ECFDF5;color:#10A37F">Активен</span>
+                                @else
+                                    <button type="button" wire:click="$set('default_provider', '{{ $slug }}')"
+                                            class="inline-flex items-center justify-center rounded-lg bg-bg-input px-3.5 py-1.5 text-xs font-medium text-text-primary transition hover:bg-border-light">
+                                        Выбрать
+                                    </button>
+                                @endif
+                                <a href="{{ route('admin.settings.ai.provider', $slug) }}" wire:navigate
+                                   class="flex h-8 w-8 items-center justify-center rounded-lg text-text-secondary transition hover:bg-bg-input hover:text-text-primary"
+                                   aria-label="Настроить доступ {{ $p['name'] }}">
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
+                                        <circle cx="12" cy="5" r="1.6" /><circle cx="12" cy="12" r="1.6" /><circle cx="12" cy="19" r="1.6" />
+                                    </svg>
+                                </a>
+                            </div>
+                        </div>
+
+                        {{-- Description --}}
+                        <p class="mt-4 text-[13px] text-text-secondary">{{ $p['desc'] }}</p>
+
+                        {{-- Details (active only) --}}
+                        @if ($active)
+                            <div class="mt-4 flex gap-6">
+                                <div>
+                                    <p class="text-[11px] text-text-secondary">Модель</p>
+                                    <p class="text-xs font-medium text-text-primary">{{ $providerModels[$slug] ?: '—' }}</p>
+                                </div>
+                                <div>
+                                    <p class="text-[11px] text-text-secondary">Статус</p>
+                                    <p class="text-xs font-medium" style="color:{{ ($providerConfigured[$slug] ?? false) ? '#10A37F' : '#9CA3AF' }}">
+                                        {{ ($providerConfigured[$slug] ?? false) ? 'Подключён' : 'Не настроен' }}
+                                    </p>
+                                </div>
+                            </div>
+                        @endif
+                    </div>
+                @endforeach
+            </div>
+        </div>
+
+        {{-- ── General settings ────────────────────────────────────────────── --}}
+        <div>
+            <h2 class="mb-4 text-base font-semibold text-text-primary">Общие настройки</h2>
+
+            <div class="space-y-5 rounded-xl border border-border-light bg-bg-primary p-6">
+
+                {{-- Auto-reply --}}
+                <div class="flex items-center justify-between">
+                    <div>
+                        <p class="text-sm font-semibold text-text-primary">Включить автоответы</p>
+                        <p class="mt-0.5 text-xs text-text-secondary">ИИ будет автоматически отвечать на первое сообщение пользователя</p>
+                    </div>
+                    <x-admin.toggle name="auto_reply" id="auto_reply" wire:model.live="auto_reply" />
+                </div>
+
+                <div class="h-px bg-border-light"></div>
+
+                {{-- System prompt --}}
+                <div x-data="{ count: $refs.prompt ? $refs.prompt.value.length : {{ mb_strlen($system_prompt) }} }">
+                    <div class="mb-2 flex items-center justify-between">
+                        <label for="system_prompt" class="text-sm font-semibold text-text-primary">Системный промпт</label>
+                        <span class="text-[11px] text-gray-400"><span x-text="count">{{ mb_strlen($system_prompt) }}</span> / 2000 символов</span>
+                    </div>
+                    <textarea
+                        id="system_prompt"
+                        x-ref="prompt"
+                        wire:model="system_prompt"
+                        x-on:input="count = $event.target.value.length"
+                        maxlength="2000"
+                        rows="6"
+                        class="block w-full resize-y rounded-[10px] border border-border-light bg-bg-primary px-3.5 py-3 text-[13px] leading-relaxed text-text-primary placeholder-text-secondary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/20"
+                        placeholder="Ты — помощник службы поддержки. Отвечай вежливо и по существу..."
+                    ></textarea>
+                    <p class="mt-2 text-[11px] text-gray-400">Промпт определяет поведение и стиль ответов ИИ-ассистента</p>
+                </div>
+
+                {{-- Save --}}
+                <div class="flex justify-end">
+                    <x-admin.button-primary type="submit" wire:loading.attr="disabled" wire:target="save">
+                        <span wire:loading.remove wire:target="save">Сохранить настройки</span>
+                        <span wire:loading wire:target="save">Сохранение...</span>
+                    </x-admin.button-primary>
+                </div>
+
+            </div>
+        </div>
+
+    </form>
+
+</div>

--- a/resources/views/livewire/settings/ai-provider-access-page.blade.php
+++ b/resources/views/livewire/settings/ai-provider-access-page.blade.php
@@ -1,0 +1,473 @@
+<div>
+
+    {{-- ── Top bar — breadcrumb ────────────────────────────────────────────────── --}}
+    <div class="flex items-center border-b border-border-light bg-bg-primary px-10 py-0" style="height:64px">
+        <div class="flex items-center gap-3">
+            <a href="{{ route('admin.settings.ai') }}"
+               class="flex items-center gap-1 text-text-secondary transition hover:text-text-primary"
+               aria-label="Назад к ИИ-ассистенту">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24"
+                     stroke="currentColor" stroke-width="2">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M19 12H5m7-7-7 7 7 7" />
+                </svg>
+            </a>
+            <a href="{{ route('admin.settings.ai') }}"
+               class="text-sm text-text-secondary transition hover:text-text-primary">
+                ИИ-ассистент
+            </a>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 text-text-secondary" fill="none"
+                 viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+            </svg>
+            <span class="text-sm font-semibold text-text-primary">
+                Доступ
+                @if ($provider === 'openai') OpenAI
+                @elseif ($provider === 'deepseek') DeepSeek
+                @else GigaChat
+                @endif
+            </span>
+        </div>
+    </div>
+
+    {{-- ── Success notice ───────────────────────────────────────────────────────── --}}
+    @if ($saved)
+        <div class="mx-8 mt-6 flex items-center gap-2 rounded-xl border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-800">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 shrink-0 text-green-500"
+                 fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+            </svg>
+            Настройки доступа сохранены.
+        </div>
+    @endif
+
+    {{-- ── Two-column body ──────────────────────────────────────────────────────── --}}
+    <div class="grid grid-cols-1 gap-7 p-8 lg:grid-cols-[1fr_320px]">
+
+        {{-- ── Form Card ────────────────────────────────────────────────────────── --}}
+        <div class="rounded-2xl border border-border-light bg-bg-primary" style="padding:28px 32px">
+
+            {{-- Card header --}}
+            <div class="flex items-center gap-3.5">
+                @if ($provider === 'openai')
+                    <div class="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl" style="background:#E8F5E9">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" style="color:#2E7D32" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
+                        </svg>
+                    </div>
+                @elseif ($provider === 'deepseek')
+                    <div class="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl" style="background:#E3F2FD">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" style="color:#1565C0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
+                        </svg>
+                    </div>
+                @else
+                    <div class="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl" style="background:#FCE4EC">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" style="color:#C62828" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
+                        </svg>
+                    </div>
+                @endif
+                <div>
+                    <h2 class="text-lg font-bold text-text-primary">
+                        @if ($provider === 'openai') Доступ OpenAI
+                        @elseif ($provider === 'deepseek') Доступ DeepSeek
+                        @else Доступ GigaChat
+                        @endif
+                    </h2>
+                    <p class="mt-0.5 text-xs text-text-secondary">
+                        @if ($provider === 'openai') API-ключ и параметры подключения к OpenAI
+                        @elseif ($provider === 'deepseek') Учётные данные и параметры DeepSeek API
+                        @else Учётные данные и параметры GigaChat API
+                        @endif
+                    </p>
+                </div>
+            </div>
+
+            <div class="my-6 h-px bg-border-light"></div>
+
+            <form wire:submit="save" novalidate>
+                @csrf
+
+                @if ($provider === 'openai')
+
+                    <div class="space-y-5">
+
+                        {{-- API Key --}}
+                        <x-admin.form-field
+                            label="API Key"
+                            for="openai_api_key"
+                            hint="Оставьте пустым, чтобы не изменять сохранённый ключ"
+                            :error="$formErrors['openai_api_key'] ?? null"
+                        >
+                            <input
+                                id="openai_api_key"
+                                type="password"
+                                wire:model="openai_api_key"
+                                autocomplete="new-password"
+                                placeholder="sk-..."
+                                class="block w-full rounded-lg border border-border-light bg-bg-input px-3.5 py-2.5 text-sm text-text-primary placeholder-text-secondary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/20"
+                            />
+                        </x-admin.form-field>
+
+                        {{-- Base URL --}}
+                        <x-admin.form-field
+                            label="Base URL"
+                            for="openai_base_url"
+                            hint="Оставьте пустым для использования стандартного эндпоинта OpenAI"
+                            :error="$formErrors['openai_base_url'] ?? null"
+                        >
+                            <input
+                                id="openai_base_url"
+                                type="text"
+                                wire:model="openai_base_url"
+                                placeholder="https://api.openai.com/v1"
+                                class="block w-full rounded-lg border border-border-light bg-bg-input px-3.5 py-2.5 text-sm text-text-primary placeholder-text-secondary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/20"
+                            />
+                        </x-admin.form-field>
+
+                        {{-- Model --}}
+                        <x-admin.form-field
+                            label="Модель"
+                            for="openai_model"
+                            hint="Например: gpt-4o, gpt-4-turbo"
+                            :error="$formErrors['openai_model'] ?? null"
+                        >
+                            <input
+                                id="openai_model"
+                                type="text"
+                                wire:model="openai_model"
+                                placeholder="gpt-4o"
+                                class="block w-full rounded-lg border border-border-light bg-bg-input px-3.5 py-2.5 text-sm text-text-primary placeholder-text-secondary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/20"
+                            />
+                        </x-admin.form-field>
+
+                        {{-- Max tokens --}}
+                        <x-admin.form-field
+                            label="Макс. токенов ответа"
+                            for="openai_max_tokens"
+                            hint="Максимальное количество токенов в ответе модели"
+                            :error="$formErrors['openai_max_tokens'] ?? null"
+                        >
+                            <input
+                                id="openai_max_tokens"
+                                type="number"
+                                min="1"
+                                wire:model="openai_max_tokens"
+                                placeholder="1000"
+                                class="block w-full rounded-lg border border-border-light bg-bg-input px-3.5 py-2.5 text-sm text-text-primary placeholder-text-secondary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/20
+                                    @if (!empty($formErrors['openai_max_tokens'])) border-red-400 @endif"
+                            />
+                        </x-admin.form-field>
+
+                        {{-- Temperature --}}
+                        <x-admin.form-field
+                            label="Температура"
+                            for="openai_temperature"
+                            hint="Диапазон 0.0–2.0. Меньше — более предсказуемые ответы."
+                            :error="$formErrors['openai_temperature'] ?? null"
+                        >
+                            <input
+                                id="openai_temperature"
+                                type="text"
+                                wire:model="openai_temperature"
+                                placeholder="0.7"
+                                class="block w-full rounded-lg border border-border-light bg-bg-input px-3.5 py-2.5 text-sm text-text-primary placeholder-text-secondary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/20"
+                            />
+                        </x-admin.form-field>
+
+                    </div>
+
+                @elseif ($provider === 'deepseek')
+
+                    <div class="space-y-5">
+
+                        {{-- Client ID --}}
+                        <x-admin.form-field
+                            label="Client ID"
+                            for="deepseek_client_id"
+                            :error="$formErrors['deepseek_client_id'] ?? null"
+                        >
+                            <input
+                                id="deepseek_client_id"
+                                type="text"
+                                wire:model="deepseek_client_id"
+                                placeholder="client-id"
+                                class="block w-full rounded-lg border border-border-light bg-bg-input px-3.5 py-2.5 text-sm text-text-primary placeholder-text-secondary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/20"
+                            />
+                        </x-admin.form-field>
+
+                        {{-- Client Secret --}}
+                        <x-admin.form-field
+                            label="Client Secret"
+                            for="deepseek_client_secret"
+                            hint="Оставьте пустым, чтобы не изменять сохранённый секрет"
+                            :error="$formErrors['deepseek_client_secret'] ?? null"
+                        >
+                            <input
+                                id="deepseek_client_secret"
+                                type="password"
+                                wire:model="deepseek_client_secret"
+                                autocomplete="new-password"
+                                placeholder="••••••••"
+                                class="block w-full rounded-lg border border-border-light bg-bg-input px-3.5 py-2.5 text-sm text-text-primary placeholder-text-secondary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/20"
+                            />
+                        </x-admin.form-field>
+
+                        {{-- Base URL --}}
+                        <x-admin.form-field
+                            label="Base URL"
+                            for="deepseek_base_url"
+                            hint="Оставьте пустым для использования стандартного эндпоинта DeepSeek"
+                            :error="$formErrors['deepseek_base_url'] ?? null"
+                        >
+                            <input
+                                id="deepseek_base_url"
+                                type="text"
+                                wire:model="deepseek_base_url"
+                                placeholder="https://api.deepseek.com"
+                                class="block w-full rounded-lg border border-border-light bg-bg-input px-3.5 py-2.5 text-sm text-text-primary placeholder-text-secondary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/20"
+                            />
+                        </x-admin.form-field>
+
+                        {{-- Model --}}
+                        <x-admin.form-field
+                            label="Модель"
+                            for="deepseek_model"
+                            hint="Например: deepseek-chat, deepseek-reasoner"
+                            :error="$formErrors['deepseek_model'] ?? null"
+                        >
+                            <input
+                                id="deepseek_model"
+                                type="text"
+                                wire:model="deepseek_model"
+                                placeholder="deepseek-chat"
+                                class="block w-full rounded-lg border border-border-light bg-bg-input px-3.5 py-2.5 text-sm text-text-primary placeholder-text-secondary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/20"
+                            />
+                        </x-admin.form-field>
+
+                        {{-- Max tokens --}}
+                        <x-admin.form-field
+                            label="Макс. токенов ответа"
+                            for="deepseek_max_tokens"
+                            hint="Максимальное количество токенов в ответе модели"
+                            :error="$formErrors['deepseek_max_tokens'] ?? null"
+                        >
+                            <input
+                                id="deepseek_max_tokens"
+                                type="number"
+                                min="1"
+                                wire:model="deepseek_max_tokens"
+                                placeholder="1000"
+                                class="block w-full rounded-lg border border-border-light bg-bg-input px-3.5 py-2.5 text-sm text-text-primary placeholder-text-secondary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/20
+                                    @if (!empty($formErrors['deepseek_max_tokens'])) border-red-400 @endif"
+                            />
+                        </x-admin.form-field>
+
+                        {{-- Temperature --}}
+                        <x-admin.form-field
+                            label="Температура"
+                            for="deepseek_temperature"
+                            hint="Диапазон 0.0–1.0."
+                            :error="$formErrors['deepseek_temperature'] ?? null"
+                        >
+                            <input
+                                id="deepseek_temperature"
+                                type="text"
+                                wire:model="deepseek_temperature"
+                                placeholder="0.7"
+                                class="block w-full rounded-lg border border-border-light bg-bg-input px-3.5 py-2.5 text-sm text-text-primary placeholder-text-secondary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/20"
+                            />
+                        </x-admin.form-field>
+
+                    </div>
+
+                @else {{-- gigachat --}}
+
+                    <div class="space-y-5">
+
+                        {{-- Client ID --}}
+                        <x-admin.form-field
+                            label="Client ID"
+                            for="gigachat_client_id"
+                            :error="$formErrors['gigachat_client_id'] ?? null"
+                        >
+                            <input
+                                id="gigachat_client_id"
+                                type="text"
+                                wire:model="gigachat_client_id"
+                                placeholder="client-id"
+                                class="block w-full rounded-lg border border-border-light bg-bg-input px-3.5 py-2.5 text-sm text-text-primary placeholder-text-secondary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/20"
+                            />
+                        </x-admin.form-field>
+
+                        {{-- Client Secret --}}
+                        <x-admin.form-field
+                            label="Client Secret"
+                            for="gigachat_client_secret"
+                            hint="Оставьте пустым, чтобы не изменять сохранённый секрет"
+                            :error="$formErrors['gigachat_client_secret'] ?? null"
+                        >
+                            <input
+                                id="gigachat_client_secret"
+                                type="password"
+                                wire:model="gigachat_client_secret"
+                                autocomplete="new-password"
+                                placeholder="••••••••"
+                                class="block w-full rounded-lg border border-border-light bg-bg-input px-3.5 py-2.5 text-sm text-text-primary placeholder-text-secondary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/20"
+                            />
+                        </x-admin.form-field>
+
+                        {{-- Base URL --}}
+                        <x-admin.form-field
+                            label="Base URL"
+                            for="gigachat_base_url"
+                            hint="Оставьте пустым для использования стандартного эндпоинта GigaChat"
+                            :error="$formErrors['gigachat_base_url'] ?? null"
+                        >
+                            <input
+                                id="gigachat_base_url"
+                                type="text"
+                                wire:model="gigachat_base_url"
+                                placeholder="https://gigachat.devices.sberbank.ru/api/v1"
+                                class="block w-full rounded-lg border border-border-light bg-bg-input px-3.5 py-2.5 text-sm text-text-primary placeholder-text-secondary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/20"
+                            />
+                        </x-admin.form-field>
+
+                        {{-- Model --}}
+                        <x-admin.form-field
+                            label="Модель"
+                            for="gigachat_model"
+                            hint="Например: GigaChat, GigaChat-Pro, GigaChat-Max"
+                            :error="$formErrors['gigachat_model'] ?? null"
+                        >
+                            <input
+                                id="gigachat_model"
+                                type="text"
+                                wire:model="gigachat_model"
+                                placeholder="GigaChat"
+                                class="block w-full rounded-lg border border-border-light bg-bg-input px-3.5 py-2.5 text-sm text-text-primary placeholder-text-secondary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/20"
+                            />
+                        </x-admin.form-field>
+
+                        {{-- Max tokens --}}
+                        <x-admin.form-field
+                            label="Макс. токенов ответа"
+                            for="gigachat_max_tokens"
+                            hint="Максимальное количество токенов в ответе модели"
+                            :error="$formErrors['gigachat_max_tokens'] ?? null"
+                        >
+                            <input
+                                id="gigachat_max_tokens"
+                                type="number"
+                                min="1"
+                                wire:model="gigachat_max_tokens"
+                                placeholder="1000"
+                                class="block w-full rounded-lg border border-border-light bg-bg-input px-3.5 py-2.5 text-sm text-text-primary placeholder-text-secondary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/20
+                                    @if (!empty($formErrors['gigachat_max_tokens'])) border-red-400 @endif"
+                            />
+                        </x-admin.form-field>
+
+                        {{-- Temperature --}}
+                        <x-admin.form-field
+                            label="Температура"
+                            for="gigachat_temperature"
+                            hint="Диапазон 0.0–1.0."
+                            :error="$formErrors['gigachat_temperature'] ?? null"
+                        >
+                            <input
+                                id="gigachat_temperature"
+                                type="text"
+                                wire:model="gigachat_temperature"
+                                placeholder="0.7"
+                                class="block w-full rounded-lg border border-border-light bg-bg-input px-3.5 py-2.5 text-sm text-text-primary placeholder-text-secondary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/20"
+                            />
+                        </x-admin.form-field>
+
+                        {{-- Path to certificate --}}
+                        <x-admin.form-field
+                            label="Путь к сертификату (path_cert)"
+                            for="gigachat_path_cert"
+                            hint="Путь к файлу сертификата на сервере (только текстовый путь, не загрузка файла)"
+                            :error="$formErrors['gigachat_path_cert'] ?? null"
+                        >
+                            <input
+                                id="gigachat_path_cert"
+                                type="text"
+                                wire:model="gigachat_path_cert"
+                                placeholder="/etc/ssl/certs/gigachat.pem"
+                                class="block w-full rounded-lg border border-border-light bg-bg-input px-3.5 py-2.5 text-sm text-text-primary placeholder-text-secondary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/20"
+                            />
+                        </x-admin.form-field>
+
+                    </div>
+
+                @endif
+
+                {{-- Actions row --}}
+                <div class="mt-6 flex items-center justify-end gap-3">
+                    <x-admin.button-secondary wire:click="cancel" type="button">
+                        Отмена
+                    </x-admin.button-secondary>
+                    <x-admin.button-primary type="submit" wire:loading.attr="disabled" wire:target="save">
+                        <span wire:loading.remove wire:target="save">Сохранить</span>
+                        <span wire:loading wire:target="save">Сохранение...</span>
+                    </x-admin.button-primary>
+                </div>
+
+            </form>
+        </div>
+
+        {{-- ── Info panel ────────────────────────────────────────────────────────── --}}
+        <div>
+            <div class="rounded-xl border border-border-light bg-bg-primary p-5 lg:p-6">
+
+                {{-- Panel header --}}
+                <div class="mb-5 flex items-center gap-2">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 text-accent" fill="none"
+                         viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round"
+                              d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    </svg>
+                    <span class="text-sm font-semibold text-text-primary">Безопасность</span>
+                </div>
+
+                <ul class="space-y-3">
+                    <li class="flex items-start gap-3">
+                        <span class="flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-full text-[11px] font-semibold text-accent"
+                              style="background:#EEF2FF">1</span>
+                        <span class="text-[13px] leading-relaxed text-text-secondary">
+                            Секретные ключи хранятся в зашифрованном виде в базе данных.
+                        </span>
+                    </li>
+                    <li class="flex items-start gap-3">
+                        <span class="flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-full text-[11px] font-semibold text-accent"
+                              style="background:#EEF2FF">2</span>
+                        <span class="text-[13px] leading-relaxed text-text-secondary">
+                            Поля секретов не предзаполняются — оставьте поле пустым, чтобы сохранить текущий ключ.
+                        </span>
+                    </li>
+                    <li class="flex items-start gap-3">
+                        <span class="flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-full text-[11px] font-semibold text-accent"
+                              style="background:#EEF2FF">3</span>
+                        <span class="text-[13px] leading-relaxed text-text-secondary">
+                            Ключи никогда не выводятся в открытом виде и не логируются.
+                        </span>
+                    </li>
+                </ul>
+
+                @if ($provider === 'gigachat')
+                    <div class="mt-5 rounded-lg border border-border-light bg-bg-secondary p-3">
+                        <p class="text-[12px] leading-relaxed text-text-secondary">
+                            <strong class="font-semibold text-text-primary">path_cert</strong> — путь к CA-сертификату
+                            GigaChat на сервере. Укажите абсолютный путь, например
+                            <code class="rounded bg-bg-input px-1 font-mono text-[11px]">/etc/ssl/certs/russian_trusted_root_ca.pem</code>.
+                        </p>
+                    </div>
+                @endif
+
+            </div>
+        </div>
+
+    </div>
+
+</div>

--- a/rules/domain/admin-panel.md
+++ b/rules/domain/admin-panel.md
@@ -2,7 +2,7 @@
 
 > **Purpose:** Define business rules, key concepts, and invariants for the Admin module (`app/Modules/Admin/`). This module implements the `admin_panel` mode of the `ManagerInterfaceContract`.
 > **Context:** Read this file before modifying anything inside `app/Modules/Admin/`, Filament resources, Livewire pages, or the `SendReplyAction`.
-> **Version:** 1.3
+> **Version:** 1.4
 
 ---
 
@@ -10,7 +10,7 @@
 
 The Admin Panel domain provides an alternative manager interface for the support team. Instead of working through a Telegram supergroup with forum topics, managers can use the `/admin` web panel (built with Filament 3) to view conversations and send replies.
 
-**This domain owns:** `ConversationResource`, `BotUserResource`, `ExternalSourceResource`, `FeedbackResource`, `ConversationPage` (Livewire, Filament-hosted), `GeneralSettingsPage` (custom Livewire full-page at `/admin/settings/general`), `IntegrationsListPage` (custom Livewire full-page at `/admin/settings/integrations`), `IntegrationChannelPage` (custom Livewire full-page at `/admin/settings/integrations/{channel}`), admin design system (`resources/views/components/admin/`, `resources/views/layouts/admin-settings.blade.php`), `SendReplyAction`, `AdminPanelInterface`, `ChannelStatusService`, `WebhookRegistrationService`.
+**This domain owns:** `ConversationResource`, `BotUserResource`, `ExternalSourceResource`, `FeedbackResource`, `ConversationPage` (Livewire, Filament-hosted), `GeneralSettingsPage` (custom Livewire full-page at `/admin/settings/general`), `IntegrationsListPage` (custom Livewire full-page at `/admin/settings/integrations`), `IntegrationChannelPage` (custom Livewire full-page at `/admin/settings/integrations/{channel}`), `AiAssistantPage` (custom Livewire full-page at `/admin/settings/ai`), `AiProviderAccessPage` (custom Livewire full-page at `/admin/settings/ai/{provider}`), admin design system (`resources/views/components/admin/`, `resources/views/layouts/admin-settings.blade.php`), `SendReplyAction`, `AdminPanelInterface`, `ChannelStatusService`, `WebhookRegistrationService`.
 
 > **Stage 1 transition note:** The admin is in the process of being redesigned. Filament resources (Chats, Users, External Sources, Feedback) remain on default Filament chrome. `GeneralSettingsPage` is the first screen rebuilt as a fully custom Livewire/Blade component outside Filament's chrome. During this coexistence period the two UIs deliberately have different styling — this is expected until the migration completes.
 
@@ -94,6 +94,15 @@ _Enforced in:_ `IntegrationChannelPage::saveTelegram/Vk/Max()` — `if ($field !
 **BR-016** — The «Виджет для сайта» card on the Integrations list is a disabled placeholder («Скоро»). It must not be a clickable link and must not have a route. It is rendered as a `<div>` with `cursor-not-allowed opacity-50`.
 _Enforced in:_ `resources/views/livewire/settings/integrations-list-page.blade.php`
 
+**BR-017** — AI assistant settings (master toggle, provider, auto-reply, context limit, system prompt) are managed at `/admin/settings/ai` via `AiAssistantPage`. Values are persisted via `SettingsService`. The `ИИ-ассистент` sidebar item must link to `admin.settings.ai` and be marked active on both `admin.settings.ai` and `admin.settings.ai.provider` routes.
+_Enforced in:_ `resources/views/layouts/admin-settings.blade.php @ nav-item ИИ-ассистент`; `AdminServiceProvider::boot()` route `admin.settings.ai`
+
+**BR-018** — AI provider credentials (API keys, client IDs/secrets, base URLs, models, max tokens, temperature, cert path) are managed at `/admin/settings/ai/{provider}` via `AiProviderAccessPage`. Route constraint: `provider` ∈ `openai|deepseek|gigachat`. Secrets are encrypted in the `settings` DB table and never pre-filled in the UI form. Blank secret submission does NOT overwrite the existing stored secret.
+_Enforced in:_ `AiProviderAccessPage::saveOpenAi/DeepSeek/GigaChat()` — blank-secret guard identical to `IntegrationChannelPage` (BR-015)
+
+**BR-019** — Enabling auto-reply from `AiAssistantPage` requires an explicit user confirmation. The toggle triggers a yellow warning dialog; the user must call `confirmAutoReply()` before the setting is applied. Dismissing the dialog (`cancelAutoReply()`) leaves auto-reply disabled.
+_Enforced in:_ `AiAssistantPage::updatedAutoReply()`, `confirmAutoReply()`, `cancelAutoReply()`
+
 ---
 
 ## 4. Architecture Flow (admin_panel mode)
@@ -150,7 +159,7 @@ The binding is resolved at container boot time from `config()`. The binding does
 
 **Layout**: `resources/views/layouts/admin-settings.blade.php` — two-column layout with a dark sidebar (280px) + right content area (`bg-bg-secondary`).
 
-**Sidebar navigation**: 7 items. «Основные» and «Интеграции» are active/linked; the rest (ИИ-ассистент, Уведомления, API и вебхуки, Команда, Автоответы) are disabled placeholders (`disabled` prop on `<x-admin.nav-item>`). They become real links as their respective tasks are implemented.
+**Sidebar navigation**: 7 items. «Основные», «Интеграции», and «ИИ-ассистент» are active/linked; the rest (Уведомления, API и вебхуки, Команда, Автоответы) are disabled placeholders (`disabled` prop on `<x-admin.nav-item>`). They become real links as their respective tasks are implemented.
 
 **Form fields** (all persisted via `SettingsService`):
 | Field | Setting key | Validation |
@@ -206,6 +215,35 @@ The binding is resolved at container boot time from `config()`. The binding does
 
 ---
 
+## 6c. AI Assistant Screens (custom Livewire, `/admin/settings/ai`)
+
+### AiAssistantPage (`GET /admin/settings/ai`)
+
+`app/Livewire/Settings/AiAssistantPage.php` — main AI settings screen.
+
+**Form fields** (all persisted via `SettingsService`):
+| Field | Setting key | Validation |
+|---|---|---|
+| ИИ-ассистент (master toggle) | `ai.enabled` | bool |
+| Провайдер по умолчанию | `ai.default_provider` | required, in:openai,deepseek,gigachat |
+| Автоответ (toggle) | `ai.auto_reply` | bool, confirm dialog required |
+| Лимит контекста | `ai.max_context_tokens` | int > 0 |
+| Системный промпт | `ai.system_prompt` | string (stored in `settings` table, not Blade file) |
+
+**Auto-reply confirmation**: enabling auto-reply shows a yellow warning banner with «Включить автоответ» / «Отмена» buttons. The toggle reverts to `false` until `confirmAutoReply()` is called.
+
+**Routes**: `GET /admin/settings/ai` → name `admin.settings.ai`; `GET /admin/settings/ai/{provider}` → name `admin.settings.ai.provider` (provider ∈ openai|deepseek|gigachat). Registered in `AdminServiceProvider::boot()`.
+
+**Tests**:
+- `tests/Unit/Livewire/Settings/AiAssistantPageTest.php` — unit (12 cases)
+- `tests/Unit/Livewire/Settings/AiProviderAccessPageTest.php` — unit (17 cases)
+- `tests/Feature/Settings/AiAssistantPageTest.php` — integration (13 cases)
+- `tests/Feature/Settings/AiProviderAccessPageTest.php` — integration (14 cases)
+
+**Runtime application status**: `AiAssistantPage` and `AiProviderAccessPage` persist values to the `settings` DB table. The form reads back from `SettingsService` correctly. Full runtime wiring (AI providers / `ShouldAiReply` / `AiAssistantService` reading from `SettingsService`) is deferred to a follow-up task — those classes still read from `config('ai.*')` at runtime.
+
+---
+
 ## 7. Forbidden Behaviors
 
 - ❌ Calling `SendReplyAction::execute()` synchronously from a Livewire component without `Queue::fake()` in tests
@@ -221,7 +259,7 @@ The binding is resolved at container boot time from `config()`. The binding does
 
 ## Checklist
 
-- [ ] `BR-001` through `BR-016` read and understood
+- [ ] `BR-001` through `BR-019` read and understood
 - [ ] `shouldShowReplyForm()` returns `false` in `telegram_group` mode
 - [ ] `SendReplyAction` uses queue jobs, not synchronous API calls
 - [ ] New Filament resources have feature tests in `tests/Feature/Admin/`

--- a/rules/domain/ai-assistant.md
+++ b/rules/domain/ai-assistant.md
@@ -41,17 +41,17 @@ This domain does not own: actual message sending to the end user (see `domain/me
 
 ## 3. Business Rules
 
-**BR-001** — The AI assistant is globally disabled by default (`AI_ENABLED=false`). It must be explicitly enabled via environment configuration.
-_Enforced in:_ `config/ai.php @ enabled`
+**BR-001** — The AI assistant is globally disabled by default (`AI_ENABLED=false`). It must be explicitly enabled via the admin panel (`/admin/settings/ai`) or via `.env`. The DB-persisted value (via `SettingsService`) takes priority over `.env` on runtime reads from the admin UI form. Note: `ShouldAiReply` and `AiAssistantService` still read from `config('ai.*')` at runtime (no live DB re-read) — a container restart is not required for the *UI form* to store and display the new value, but runtime AI-flow wiring to `SettingsService` is deferred (see follow-up task).
+_Enforced in:_ `config/ai.php @ enabled`; `app/Livewire/Settings/AiAssistantPage.php`; `app/Services/Settings/SettingKeyRegistry.php @ ai.enabled`
 
-**BR-002** — Auto-reply mode (`AI_AUTO_REPLY=true`) must not be enabled in production unless explicitly approved. In auto-reply mode, AI drafts are sent to users without manager review.
-_Enforced in:_ `config/ai.php @ auto_reply`
+**BR-002** — Auto-reply mode (`AI_AUTO_REPLY=true`) must not be enabled in production unless explicitly approved. In auto-reply mode, AI drafts are sent to users without manager review. The admin panel (`/admin/settings/ai`) shows a confirmation warning before enabling auto-reply; the user must explicitly confirm.
+_Enforced in:_ `config/ai.php @ auto_reply`; `AiAssistantPage::updatedAutoReply()` — reverts toggle and shows confirmation dialog; `AiAssistantPage::confirmAutoReply()` / `cancelAutoReply()`
 
 **BR-003** — An AI draft (`AiMessage`) must be created before any response is sent from the AI path. The draft must include both `text_ai` and optionally `text_manager`.
 _Enforced in:_ `app/Actions/Ai/AiAction.php`
 
-**BR-004** — The AI provider used for a request is determined by `AI_DEFAULT_PROVIDER` config. Supported values: `openai`, `deepseek`, `gigachat`.
-_Enforced in:_ `config/ai.php @ default_provider`
+**BR-004** — The AI provider used for a request is determined by `AI_DEFAULT_PROVIDER` config. Supported values: `openai`, `deepseek`, `gigachat`. The active provider can be changed via the admin panel (`/admin/settings/ai`) without a code change; the value is persisted in the `settings` table and displayed in the UI. Runtime wiring of `AiAssistantService` to `SettingsService` is deferred.
+_Enforced in:_ `config/ai.php @ default_provider`; `app/Livewire/Settings/AiAssistantPage.php`; `app/Services/Settings/SettingKeyRegistry.php @ ai.default_provider`
 
 **BR-005** — An `AiCondition` record must exist and have `active = true` for a given `BotUser` before AI processing starts.
 _Enforced in:_ `app/Actions/Ai/AiAction.php`
@@ -65,8 +65,8 @@ _Enforced in:_ `config/ai.php @ disable_timeout` (timeout applied in AiAction fl
 **BR-008** — AI responses must never exceed the token limits defined per provider in config.
 _Enforced in:_ `config/ai.php @ providers.*.max_tokens`
 
-**BR-009** — The AI conversation context is sourced from the `messages` table by `bot_user_id` (incoming → `role: user` excluding slash-commands; any outgoing → `role: assistant`). The window is bounded by `max_context_tokens` (token budget) using a `mb_strlen / 4` heuristic with a sliding window from the newest entries; older entries that would exceed the budget are dropped. Redis-backed context (`ai_context_*`) is no longer used.
-_Enforced in:_ `app/Modules/Ai/Services/AiChatHistoryService.php`; `config/ai.php @ max_context_tokens` (default: 3000)
+**BR-009** — The AI conversation context is sourced from the `messages` table by `bot_user_id` (incoming → `role: user` excluding slash-commands; any outgoing → `role: assistant`). The window is bounded by `max_context_tokens` (token budget) using a `mb_strlen / 4` heuristic with a sliding window from the newest entries; older entries that would exceed the budget are dropped. Redis-backed context (`ai_context_*`) is no longer used. The `max_context_tokens` limit is editable from the admin panel (`/admin/settings/ai`) and persisted via `SettingsService`. Runtime wiring of `AiChatHistoryService` to `SettingsService` for this value is deferred.
+_Enforced in:_ `app/Modules/Ai/Services/AiChatHistoryService.php`; `config/ai.php @ max_context_tokens` (default: 3000); `app/Services/Settings/SettingKeyRegistry.php @ ai.max_context_tokens`
 
 **BR-010** — If AI confidence is below `confidence_threshold`, the message must be escalated to a human manager.
 _Enforced in:_ `config/ai.php @ confidence_threshold` (default: 0.8)
@@ -100,7 +100,57 @@ _Enforced in:_ `app/Modules/Ai/Jobs/SendAiDraftJob.php`, `app/Modules/Ai/Jobs/Se
 
 ---
 
-## 4. AI Response State Machine
+## 4. AI Settings Admin UI (`/admin/settings/ai`)
+
+The AI assistant settings are managed via custom Livewire/Blade pages at `/admin/settings/ai`.
+
+### Page: AiAssistantPage (`GET /admin/settings/ai`)
+
+`app/Livewire/Settings/AiAssistantPage.php` — main AI settings screen.
+
+**Fields** (all persisted via `SettingsService`):
+| Field | Setting key | Type | Validation |
+|---|---|---|---|
+| ИИ-ассистент (master toggle) | `ai.enabled` | bool | — |
+| Провайдер по умолчанию | `ai.default_provider` | string | in:openai,deepseek,gigachat |
+| Автоответ (toggle) | `ai.auto_reply` | bool | confirm dialog required |
+| Лимит контекста | `ai.max_context_tokens` | int | > 0 |
+| Системный промпт | `ai.system_prompt` | string | — |
+
+**Auto-reply guard**: enabling auto-reply via the toggle triggers `updatedAutoReply(true)`, which reverts the toggle to `false` and shows a yellow confirmation dialog. The user must call `confirmAutoReply()` to accept, or `cancelAutoReply()` to dismiss.
+
+**Provider cards**: provider selection rendered as 3 clickable cards (OpenAI / DeepSeek / GigaChat). Each card has a «Настроить доступ» link to the corresponding provider access page.
+
+**Runtime application (deferred)**: `ShouldAiReply`, `AiAssistantService`, `AiChatHistoryService` still read from `config('ai.*')` at runtime. The admin UI persists values to `settings` DB (displayed correctly next page load). Full runtime wiring is tracked as a follow-up task.
+
+### Pages: AiProviderAccessPage (`GET /admin/settings/ai/{provider}`)
+
+`app/Livewire/Settings/AiProviderAccessPage.php` — per-provider credentials screen. Route constraint: `provider` ∈ `openai|deepseek|gigachat`.
+
+**Fields by provider** (all persisted via `SettingsService`):
+| Provider | Fields |
+|---|---|
+| OpenAI | `ai.openai_api_key`(secret), `ai.openai_base_url`, `ai.openai_model`, `ai.openai_max_tokens`, `ai.openai_temperature` |
+| DeepSeek | `ai.deepseek_client_id`, `ai.deepseek_client_secret`(secret), `ai.deepseek_base_url`, `ai.deepseek_model`, `ai.deepseek_max_tokens`, `ai.deepseek_temperature` |
+| GigaChat | `ai.gigachat_client_id`, `ai.gigachat_client_secret`(secret), `ai.gigachat_base_url`, `ai.gigachat_model`, `ai.gigachat_max_tokens`, `ai.gigachat_temperature`, `ai.gigachat_path_cert` |
+
+**Secret fields**: rendered as `type="password"` inputs. Secret fields are never pre-filled (always `null`). Saving an empty secret field does NOT overwrite the existing stored secret (blank-secret guard, mirrors BR-015 from admin-panel.md).
+
+**System prompt storage**: the system prompt is stored in `SettingsService` under key `ai.system_prompt` (non-secret, plain text). The Blade template `resources/ai/system-prompt.blade.php` is NOT overwritten — that file is the production fallback.
+
+**Routes**: registered in `AdminServiceProvider::boot()` under `admin/settings/` prefix, names `admin.settings.ai` and `admin.settings.ai.provider`. Middleware: `['web', Filament\Http\Middleware\Authenticate::class]`.
+
+**Sidebar**: `ИИ-ассистент` nav item in `resources/views/layouts/admin-settings.blade.php` is active/linked to `admin.settings.ai`; marked active on both `admin.settings.ai` and `admin.settings.ai.provider` routes.
+
+**Tests**:
+- `tests/Unit/Livewire/Settings/AiAssistantPageTest.php` — unit tests with mocked SettingsService
+- `tests/Unit/Livewire/Settings/AiProviderAccessPageTest.php` — unit tests with mocked SettingsService
+- `tests/Feature/Settings/AiAssistantPageTest.php` — integration: access control, mount, save, auto-reply confirm flow, cancel
+- `tests/Feature/Settings/AiProviderAccessPageTest.php` — integration: access control, mount, save per provider, blank-secret guard
+
+---
+
+## 5. AI Response State Machine (was §4)
 
 ```mermaid
 stateDiagram-v2
@@ -121,7 +171,7 @@ stateDiagram-v2
 
 ---
 
-## 5. Provider Configuration
+## 6. Provider Configuration (was §5)
 
 | Provider | Env Prefix | Model Config Key | Default Model |
 |---|---|---|---|
@@ -141,7 +191,7 @@ $provider = 'openai';
 
 ---
 
-## 6. AI Bot Webhook Flow
+## 7. AI Bot Webhook Flow (was §6)
 
 ### AI Bot Controllers
 
@@ -183,7 +233,7 @@ The AI bot replies **only** when all of the following are true:
 
 ---
 
-## 7. Responsible Classes
+## 8. Responsible Classes (was §7)
 
 | Class | Responsibility |
 |---|---|
@@ -206,7 +256,7 @@ The AI bot replies **only** when all of the following are true:
 
 ---
 
-## 8. Forbidden Behaviors
+## 9. Forbidden Behaviors (was §8)
 
 - ❌ Sending AI-generated text directly to users without manager review (when auto-reply is disabled)
 - ❌ Hardcoding AI provider names outside of config

--- a/tests/Feature/Settings/AiAssistantPageTest.php
+++ b/tests/Feature/Settings/AiAssistantPageTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Settings;
+
+use App\Enums\UserRole;
+use App\Livewire\Settings\AiAssistantPage;
+use App\Models\User;
+use App\Services\Settings\SettingsService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class AiAssistantPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // ── Access control ────────────────────────────────────────────────────────
+
+    public function test_guest_is_redirected_to_login(): void
+    {
+        $response = $this->get(route('admin.settings.ai'));
+
+        $response->assertRedirectContains('/admin/login');
+    }
+
+    public function test_authenticated_admin_can_render_ai_assistant_page(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        Livewire::test(AiAssistantPage::class)
+            ->assertSuccessful();
+    }
+
+    // ── Route registration ────────────────────────────────────────────────────
+
+    public function test_route_admin_settings_ai_is_registered(): void
+    {
+        $this->assertTrue(\Illuminate\Support\Facades\Route::has('admin.settings.ai'));
+    }
+
+    // ── Mount / initial state ────────────────────────────────────────────────
+
+    public function test_mount_loads_values_from_settings_service(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        /** @var SettingsService $settings */
+        $settings = app(SettingsService::class);
+        $settings->set('ai.enabled', true);
+        $settings->set('ai.default_provider', 'deepseek');
+        $settings->set('ai.auto_reply', false);
+        $settings->set('ai.max_context_tokens', 4000);
+        $settings->set('ai.system_prompt', 'Be helpful.');
+
+        Livewire::test(AiAssistantPage::class)
+            ->assertSet('ai_enabled', true)
+            ->assertSet('default_provider', 'deepseek')
+            ->assertSet('auto_reply', false)
+            ->assertSet('max_context_tokens', 4000)
+            ->assertSet('system_prompt', 'Be helpful.');
+    }
+
+    public function test_mount_uses_defaults_when_no_settings_stored(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        config([
+            'ai.enabled' => false,
+            'ai.default_provider' => 'openai',
+            'ai.auto_reply' => false,
+            'ai.max_context_tokens' => 3000,
+        ]);
+
+        Livewire::test(AiAssistantPage::class)
+            ->assertSet('ai_enabled', false)
+            ->assertSet('default_provider', 'openai')
+            ->assertSet('auto_reply', false)
+            ->assertSet('max_context_tokens', 3000);
+    }
+
+    // ── Save ─────────────────────────────────────────────────────────────────
+
+    public function test_save_persists_all_ai_settings(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        Livewire::test(AiAssistantPage::class)
+            ->set('ai_enabled', true)
+            ->set('default_provider', 'gigachat')
+            ->set('auto_reply', false)
+            ->set('max_context_tokens', 5000)
+            ->set('system_prompt', 'My prompt')
+            ->call('save')
+            ->assertSet('saved', true)
+            ->assertHasNoErrors();
+
+        /** @var SettingsService $settings */
+        $settings = app(SettingsService::class);
+        $this->assertTrue((bool) $settings->get('ai.enabled'));
+        $this->assertSame('gigachat', (string) $settings->get('ai.default_provider'));
+        $this->assertSame(5000, (int) $settings->get('ai.max_context_tokens'));
+        $this->assertSame('My prompt', (string) $settings->get('ai.system_prompt'));
+    }
+
+    public function test_save_rejects_invalid_provider(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        $component = Livewire::test(AiAssistantPage::class)
+            ->set('default_provider', 'anthropic')
+            ->call('save')
+            ->assertSet('saved', false);
+
+        $this->assertArrayHasKey('default_provider', $component->get('formErrors'));
+    }
+
+    public function test_save_rejects_zero_max_context_tokens(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        Livewire::test(AiAssistantPage::class)
+            ->set('max_context_tokens', 0)
+            ->call('save')
+            ->assertSet('saved', false);
+    }
+
+    // ── Auto-reply confirm flow ───────────────────────────────────────────────
+
+    public function test_auto_reply_toggle_shows_warning_instead_of_saving(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        // Setting auto_reply to true triggers the updatedAutoReply lifecycle hook
+        Livewire::test(AiAssistantPage::class)
+            ->set('auto_reply', true)
+            ->assertSet('auto_reply', false)
+            ->assertSet('showAutoReplyWarning', true);
+    }
+
+    public function test_confirm_auto_reply_enables_auto_reply(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        Livewire::test(AiAssistantPage::class)
+            ->set('auto_reply', true)
+            ->call('confirmAutoReply')
+            ->assertSet('auto_reply', true)
+            ->assertSet('showAutoReplyWarning', false);
+    }
+
+    public function test_cancel_auto_reply_keeps_auto_reply_disabled(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        Livewire::test(AiAssistantPage::class)
+            ->set('auto_reply', true)
+            ->call('cancelAutoReply')
+            ->assertSet('auto_reply', false)
+            ->assertSet('showAutoReplyWarning', false);
+    }
+
+    // ── Cancel ───────────────────────────────────────────────────────────────
+
+    public function test_cancel_resets_to_stored_values(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        /** @var SettingsService $settings */
+        $settings = app(SettingsService::class);
+        $settings->set('ai.default_provider', 'openai');
+        $settings->set('ai.system_prompt', 'Original prompt');
+
+        Livewire::test(AiAssistantPage::class)
+            ->set('default_provider', 'gigachat')
+            ->set('system_prompt', 'Changed')
+            ->call('cancel')
+            ->assertSet('default_provider', 'openai')
+            ->assertSet('system_prompt', 'Original prompt')
+            ->assertSet('saved', false);
+    }
+}

--- a/tests/Feature/Settings/AiProviderAccessPageTest.php
+++ b/tests/Feature/Settings/AiProviderAccessPageTest.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Settings;
+
+use App\Enums\UserRole;
+use App\Livewire\Settings\AiProviderAccessPage;
+use App\Models\User;
+use App\Services\Settings\SettingsService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class AiProviderAccessPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // ── Access control ────────────────────────────────────────────────────────
+
+    public function test_guest_is_redirected_to_login_on_provider_page(): void
+    {
+        $response = $this->get(route('admin.settings.ai.provider', ['provider' => 'openai']));
+
+        $response->assertRedirectContains('/admin/login');
+    }
+
+    public function test_authenticated_admin_can_render_openai_page(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        Livewire::test(AiProviderAccessPage::class, ['provider' => 'openai'])
+            ->assertSuccessful();
+    }
+
+    public function test_authenticated_admin_can_render_deepseek_page(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        Livewire::test(AiProviderAccessPage::class, ['provider' => 'deepseek'])
+            ->assertSuccessful();
+    }
+
+    public function test_authenticated_admin_can_render_gigachat_page(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        Livewire::test(AiProviderAccessPage::class, ['provider' => 'gigachat'])
+            ->assertSuccessful();
+    }
+
+    // ── Route registration ────────────────────────────────────────────────────
+
+    public function test_route_admin_settings_ai_provider_is_registered(): void
+    {
+        $this->assertTrue(\Illuminate\Support\Facades\Route::has('admin.settings.ai.provider'));
+    }
+
+    // ── Mount / initial state ────────────────────────────────────────────────
+
+    public function test_mount_loads_openai_non_secret_fields(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        /** @var SettingsService $settings */
+        $settings = app(SettingsService::class);
+        $settings->set('ai.openai_model', 'gpt-4o');
+        $settings->set('ai.openai_base_url', 'https://api.openai.com/v1');
+
+        Livewire::test(AiProviderAccessPage::class, ['provider' => 'openai'])
+            ->assertSet('openai_model', 'gpt-4o')
+            ->assertSet('openai_base_url', 'https://api.openai.com/v1')
+            ->assertSet('openai_api_key', null);
+    }
+
+    public function test_mount_does_not_prefill_secret_fields(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        Livewire::test(AiProviderAccessPage::class, ['provider' => 'openai'])
+            ->assertSet('openai_api_key', null);
+
+        Livewire::test(AiProviderAccessPage::class, ['provider' => 'deepseek'])
+            ->assertSet('deepseek_client_secret', null);
+
+        Livewire::test(AiProviderAccessPage::class, ['provider' => 'gigachat'])
+            ->assertSet('gigachat_client_secret', null);
+    }
+
+    // ── Save — OpenAI ─────────────────────────────────────────────────────────
+
+    public function test_save_openai_persists_non_secret_fields(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        Livewire::test(AiProviderAccessPage::class, ['provider' => 'openai'])
+            ->set('openai_model', 'gpt-4-turbo')
+            ->set('openai_base_url', 'https://api.openai.com/v1')
+            ->set('openai_temperature', '0.5')
+            ->call('save')
+            ->assertSet('saved', true);
+
+        /** @var SettingsService $settings */
+        $settings = app(SettingsService::class);
+        $this->assertSame('gpt-4-turbo', (string) $settings->get('ai.openai_model'));
+        $this->assertSame('https://api.openai.com/v1', (string) $settings->get('ai.openai_base_url'));
+    }
+
+    public function test_save_openai_does_not_store_blank_api_key(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        // Pre-store a key
+        /** @var SettingsService $settings */
+        $settings = app(SettingsService::class);
+        $settings->set('ai.openai_api_key', 'sk-original');
+
+        Livewire::test(AiProviderAccessPage::class, ['provider' => 'openai'])
+            ->set('openai_api_key', '')
+            ->call('save')
+            ->assertSet('saved', true);
+
+        // Original key must not be overwritten
+        $this->assertSame('sk-original', (string) $settings->get('ai.openai_api_key'));
+    }
+
+    public function test_save_openai_stores_non_blank_api_key(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        Livewire::test(AiProviderAccessPage::class, ['provider' => 'openai'])
+            ->set('openai_api_key', 'sk-new-key')
+            ->call('save')
+            ->assertSet('saved', true);
+
+        /** @var SettingsService $settings */
+        $settings = app(SettingsService::class);
+        $this->assertSame('sk-new-key', (string) $settings->get('ai.openai_api_key'));
+    }
+
+    public function test_save_openai_rejects_zero_max_tokens(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        Livewire::test(AiProviderAccessPage::class, ['provider' => 'openai'])
+            ->set('openai_max_tokens', 0)
+            ->call('save')
+            ->assertSet('saved', false);
+    }
+
+    // ── Save — DeepSeek ───────────────────────────────────────────────────────
+
+    public function test_save_deepseek_does_not_overwrite_blank_client_secret(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        /** @var SettingsService $settings */
+        $settings = app(SettingsService::class);
+        $settings->set('ai.deepseek_client_secret', 'original-secret');
+
+        Livewire::test(AiProviderAccessPage::class, ['provider' => 'deepseek'])
+            ->set('deepseek_client_secret', '')
+            ->call('save')
+            ->assertSet('saved', true);
+
+        $this->assertSame('original-secret', (string) $settings->get('ai.deepseek_client_secret'));
+    }
+
+    public function test_save_deepseek_persists_non_blank_client_secret(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        Livewire::test(AiProviderAccessPage::class, ['provider' => 'deepseek'])
+            ->set('deepseek_client_id', 'my-client')
+            ->set('deepseek_client_secret', 'new-secret')
+            ->call('save')
+            ->assertSet('saved', true);
+
+        /** @var SettingsService $settings */
+        $settings = app(SettingsService::class);
+        $this->assertSame('new-secret', (string) $settings->get('ai.deepseek_client_secret'));
+    }
+
+    // ── Save — GigaChat ───────────────────────────────────────────────────────
+
+    public function test_save_gigachat_persists_path_cert(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        Livewire::test(AiProviderAccessPage::class, ['provider' => 'gigachat'])
+            ->set('gigachat_path_cert', '/etc/ssl/certs/giga.pem')
+            ->call('save')
+            ->assertSet('saved', true);
+
+        /** @var SettingsService $settings */
+        $settings = app(SettingsService::class);
+        $this->assertSame('/etc/ssl/certs/giga.pem', (string) $settings->get('ai.gigachat_path_cert'));
+    }
+
+    public function test_save_gigachat_does_not_overwrite_blank_client_secret(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        /** @var SettingsService $settings */
+        $settings = app(SettingsService::class);
+        $settings->set('ai.gigachat_client_secret', 'gc-original');
+
+        Livewire::test(AiProviderAccessPage::class, ['provider' => 'gigachat'])
+            ->set('gigachat_client_secret', '')
+            ->call('save')
+            ->assertSet('saved', true);
+
+        $this->assertSame('gc-original', (string) $settings->get('ai.gigachat_client_secret'));
+    }
+
+    // ── Cancel ───────────────────────────────────────────────────────────────
+
+    public function test_cancel_resets_openai_fields_to_stored_values(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        /** @var SettingsService $settings */
+        $settings = app(SettingsService::class);
+        $settings->set('ai.openai_model', 'gpt-4o');
+
+        Livewire::test(AiProviderAccessPage::class, ['provider' => 'openai'])
+            ->set('openai_model', 'changed-model')
+            ->call('cancel')
+            ->assertSet('openai_model', 'gpt-4o')
+            ->assertSet('saved', false)
+            ->assertSet('openai_api_key', null);
+    }
+}

--- a/tests/Unit/Livewire/Settings/AiAssistantPageTest.php
+++ b/tests/Unit/Livewire/Settings/AiAssistantPageTest.php
@@ -1,0 +1,260 @@
+<?php
+
+namespace Tests\Unit\Livewire\Settings;
+
+use App\Livewire\Settings\AiAssistantPage;
+use App\Services\Settings\SettingsService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Tests\TestCase;
+
+/**
+ * Unit-level tests for AiAssistantPage Livewire component.
+ *
+ * Focuses on business logic: mount(), save(), cancel(),
+ * updatedAutoReply(), confirmAutoReply(), cancelAutoReply()
+ * using a mocked SettingsService.
+ */
+class AiAssistantPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        Mockery::close();
+    }
+
+    // ── mount ────────────────────────────────────────────────────────────────────
+
+    public function test_mount_populates_properties_from_settings_service(): void
+    {
+        /** @var \Mockery\MockInterface&SettingsService $mock */
+        $mock = Mockery::mock(SettingsService::class);
+        $mock->shouldReceive('get')->with('ai.enabled')->andReturn(true);
+        $mock->shouldReceive('get')->with('ai.default_provider')->andReturn('deepseek');
+        $mock->shouldReceive('get')->with('ai.auto_reply')->andReturn(true);
+        $mock->shouldReceive('get')->with('ai.max_context_tokens')->andReturn(5000);
+        $mock->shouldReceive('get')->with('ai.system_prompt')->andReturn('Be helpful');
+        $mock->shouldReceive('get')->with('ai.openai_api_key')->andReturn(null);
+        $mock->shouldReceive('get')->with('ai.deepseek_client_secret')->andReturn(null);
+        $mock->shouldReceive('get')->with('ai.gigachat_client_secret')->andReturn(null);
+        $mock->shouldReceive('get')->with('ai.openai_model')->andReturn(null);
+        $mock->shouldReceive('get')->with('ai.deepseek_model')->andReturn(null);
+        $mock->shouldReceive('get')->with('ai.gigachat_model')->andReturn(null);
+
+        $component = new AiAssistantPage();
+        $component->mount($mock);
+
+        $this->assertTrue($component->ai_enabled);
+        $this->assertSame('deepseek', $component->default_provider);
+        $this->assertTrue($component->auto_reply);
+        $this->assertSame(5000, $component->max_context_tokens);
+        $this->assertSame('Be helpful', $component->system_prompt);
+    }
+
+    public function test_mount_uses_defaults_when_settings_return_null(): void
+    {
+        /** @var \Mockery\MockInterface&SettingsService $mock */
+        $mock = Mockery::mock(SettingsService::class);
+        $mock->shouldReceive('get')->with('ai.enabled')->andReturn(null);
+        $mock->shouldReceive('get')->with('ai.default_provider')->andReturn(null);
+        $mock->shouldReceive('get')->with('ai.auto_reply')->andReturn(null);
+        $mock->shouldReceive('get')->with('ai.max_context_tokens')->andReturn(null);
+        $mock->shouldReceive('get')->with('ai.system_prompt')->andReturn(null);
+        $mock->shouldReceive('get')->with('ai.openai_api_key')->andReturn(null);
+        $mock->shouldReceive('get')->with('ai.deepseek_client_secret')->andReturn(null);
+        $mock->shouldReceive('get')->with('ai.gigachat_client_secret')->andReturn(null);
+        $mock->shouldReceive('get')->with('ai.openai_model')->andReturn(null);
+        $mock->shouldReceive('get')->with('ai.deepseek_model')->andReturn(null);
+        $mock->shouldReceive('get')->with('ai.gigachat_model')->andReturn(null);
+
+        $component = new AiAssistantPage();
+        $component->mount($mock);
+
+        $this->assertFalse($component->ai_enabled);
+        $this->assertSame('openai', $component->default_provider);
+        $this->assertFalse($component->auto_reply);
+        $this->assertSame(3000, $component->max_context_tokens);
+        $this->assertSame('', $component->system_prompt);
+    }
+
+    // ── save ─────────────────────────────────────────────────────────────────────
+
+    public function test_save_persists_all_fields(): void
+    {
+        /** @var \Mockery\MockInterface&SettingsService $mock */
+        $mock = Mockery::mock(SettingsService::class);
+        $mock->shouldReceive('get')->andReturn(null);
+        $mock->shouldReceive('set')->with('ai.enabled', false)->once();
+        $mock->shouldReceive('set')->with('ai.default_provider', 'gigachat')->once();
+        $mock->shouldReceive('set')->with('ai.auto_reply', true)->once();
+        $mock->shouldReceive('set')->with('ai.max_context_tokens', 2000)->once();
+        $mock->shouldReceive('set')->with('ai.system_prompt', 'Be concise')->once();
+
+        $component = new AiAssistantPage();
+        $component->mount($mock);
+        $component->default_provider = 'gigachat';
+        $component->auto_reply = true;
+        $component->max_context_tokens = 2000;
+        $component->system_prompt = 'Be concise';
+        $component->save($mock);
+
+        $this->assertTrue($component->saved);
+        $this->assertEmpty($component->formErrors);
+    }
+
+    public function test_save_rejects_invalid_provider(): void
+    {
+        /** @var \Mockery\MockInterface&SettingsService $mock */
+        $mock = Mockery::mock(SettingsService::class);
+        $mock->shouldReceive('get')->andReturn(null);
+        $mock->shouldNotReceive('set');
+
+        $component = new AiAssistantPage();
+        $component->mount($mock);
+        $component->default_provider = 'anthropic';
+        $component->save($mock);
+
+        $this->assertFalse($component->saved);
+        $this->assertArrayHasKey('default_provider', $component->formErrors);
+    }
+
+    public function test_save_rejects_zero_max_context_tokens(): void
+    {
+        /** @var \Mockery\MockInterface&SettingsService $mock */
+        $mock = Mockery::mock(SettingsService::class);
+        $mock->shouldReceive('get')->andReturn(null);
+        $mock->shouldNotReceive('set');
+
+        $component = new AiAssistantPage();
+        $component->mount($mock);
+        $component->max_context_tokens = 0;
+        $component->save($mock);
+
+        $this->assertFalse($component->saved);
+        $this->assertArrayHasKey('max_context_tokens', $component->formErrors);
+    }
+
+    public function test_save_rejects_negative_max_context_tokens(): void
+    {
+        /** @var \Mockery\MockInterface&SettingsService $mock */
+        $mock = Mockery::mock(SettingsService::class);
+        $mock->shouldReceive('get')->andReturn(null);
+        $mock->shouldNotReceive('set');
+
+        $component = new AiAssistantPage();
+        $component->mount($mock);
+        $component->max_context_tokens = -100;
+        $component->save($mock);
+
+        $this->assertFalse($component->saved);
+        $this->assertArrayHasKey('max_context_tokens', $component->formErrors);
+    }
+
+    public function test_save_accepts_all_valid_providers(): void
+    {
+        foreach (['openai', 'deepseek', 'gigachat'] as $provider) {
+            /** @var \Mockery\MockInterface&SettingsService $mock */
+            $mock = Mockery::mock(SettingsService::class);
+            $mock->shouldReceive('get')->andReturn(null);
+            $mock->shouldReceive('set')->with(Mockery::any(), Mockery::any());
+
+            $component = new AiAssistantPage();
+            $component->mount($mock);
+            $component->default_provider = $provider;
+            $component->save($mock);
+
+            $this->assertTrue($component->saved, "Provider {$provider} should be valid.");
+            Mockery::close();
+        }
+    }
+
+    // ── cancel ───────────────────────────────────────────────────────────────────
+
+    public function test_cancel_resets_to_stored_values(): void
+    {
+        /** @var \Mockery\MockInterface&SettingsService $mock */
+        $mock = Mockery::mock(SettingsService::class);
+        $mock->shouldReceive('get')->with('ai.enabled')->andReturn(true);
+        $mock->shouldReceive('get')->with('ai.default_provider')->andReturn('openai');
+        $mock->shouldReceive('get')->with('ai.auto_reply')->andReturn(false);
+        $mock->shouldReceive('get')->with('ai.max_context_tokens')->andReturn(3000);
+        $mock->shouldReceive('get')->with('ai.system_prompt')->andReturn('Original');
+        $mock->shouldReceive('get')->with('ai.openai_api_key')->andReturn(null);
+        $mock->shouldReceive('get')->with('ai.deepseek_client_secret')->andReturn(null);
+        $mock->shouldReceive('get')->with('ai.gigachat_client_secret')->andReturn(null);
+        $mock->shouldReceive('get')->with('ai.openai_model')->andReturn(null);
+        $mock->shouldReceive('get')->with('ai.deepseek_model')->andReturn(null);
+        $mock->shouldReceive('get')->with('ai.gigachat_model')->andReturn(null);
+
+        $component = new AiAssistantPage();
+        $component->mount($mock);
+        // Simulate in-flight changes
+        $component->default_provider = 'gigachat';
+        $component->saved = true;
+        $component->formErrors = ['default_provider' => 'Error'];
+        $component->showAutoReplyWarning = true;
+
+        $component->cancel($mock);
+
+        $this->assertSame('openai', $component->default_provider);
+        $this->assertFalse($component->saved);
+        $this->assertEmpty($component->formErrors);
+        $this->assertFalse($component->showAutoReplyWarning);
+    }
+
+    // ── auto-reply confirm flow ───────────────────────────────────────────────────
+
+    public function test_updated_auto_reply_true_shows_warning_and_reverts_toggle(): void
+    {
+        $component = new AiAssistantPage();
+        $component->auto_reply = false;
+
+        $component->updatedAutoReply(true);
+
+        $this->assertFalse($component->auto_reply);
+        $this->assertTrue($component->showAutoReplyWarning);
+        $this->assertTrue($component->pendingAutoReply);
+    }
+
+    public function test_updated_auto_reply_false_clears_warning(): void
+    {
+        $component = new AiAssistantPage();
+        $component->showAutoReplyWarning = true;
+        $component->pendingAutoReply = true;
+
+        $component->updatedAutoReply(false);
+
+        $this->assertFalse($component->showAutoReplyWarning);
+        $this->assertFalse($component->pendingAutoReply);
+    }
+
+    public function test_confirm_auto_reply_enables_and_clears_warning(): void
+    {
+        $component = new AiAssistantPage();
+        $component->auto_reply = false;
+        $component->showAutoReplyWarning = true;
+        $component->pendingAutoReply = true;
+
+        $component->confirmAutoReply();
+
+        $this->assertTrue($component->auto_reply);
+        $this->assertFalse($component->showAutoReplyWarning);
+        $this->assertFalse($component->pendingAutoReply);
+    }
+
+    public function test_cancel_auto_reply_keeps_disabled_and_clears_warning(): void
+    {
+        $component = new AiAssistantPage();
+        $component->auto_reply = false;
+        $component->showAutoReplyWarning = true;
+        $component->pendingAutoReply = true;
+
+        $component->cancelAutoReply();
+
+        $this->assertFalse($component->auto_reply);
+        $this->assertFalse($component->showAutoReplyWarning);
+        $this->assertFalse($component->pendingAutoReply);
+    }
+}

--- a/tests/Unit/Livewire/Settings/AiProviderAccessPageTest.php
+++ b/tests/Unit/Livewire/Settings/AiProviderAccessPageTest.php
@@ -1,0 +1,366 @@
+<?php
+
+namespace Tests\Unit\Livewire\Settings;
+
+use App\Livewire\Settings\AiProviderAccessPage;
+use App\Services\Settings\SettingsService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Tests\TestCase;
+
+/**
+ * Unit-level tests for AiProviderAccessPage Livewire component.
+ *
+ * Covers mount(), save(), and cancel() for all three providers
+ * (openai, deepseek, gigachat). Secret fields are never pre-filled
+ * and blank values do not overwrite existing secrets.
+ */
+class AiProviderAccessPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        Mockery::close();
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────────
+
+    /**
+     * Build a mock SettingsService that returns empty strings for all non-secret
+     * ai.* keys and null for integer keys (no stored value).
+     *
+     * @return \Mockery\MockInterface&SettingsService
+     */
+    private function makeEmptySettingsMock(): mixed
+    {
+        /** @var \Mockery\MockInterface&SettingsService $mock */
+        $mock = Mockery::mock(SettingsService::class);
+        $mock->shouldReceive('get')->andReturn(null);
+
+        return $mock;
+    }
+
+    // ── mount ────────────────────────────────────────────────────────────────────
+
+    public function test_mount_populates_openai_non_secret_fields(): void
+    {
+        /** @var \Mockery\MockInterface&SettingsService $mock */
+        $mock = Mockery::mock(SettingsService::class);
+        $mock->shouldReceive('get')->with('ai.openai_base_url')->andReturn('https://api.openai.com/v1');
+        $mock->shouldReceive('get')->with('ai.openai_model')->andReturn('gpt-4o');
+        $mock->shouldReceive('get')->with('ai.openai_max_tokens')->andReturn(500);
+        $mock->shouldReceive('get')->with('ai.openai_temperature')->andReturn('0.5');
+        // DeepSeek fields
+        $mock->shouldReceive('get')->with('ai.deepseek_client_id')->andReturn('');
+        $mock->shouldReceive('get')->with('ai.deepseek_base_url')->andReturn('');
+        $mock->shouldReceive('get')->with('ai.deepseek_model')->andReturn('');
+        $mock->shouldReceive('get')->with('ai.deepseek_max_tokens')->andReturn(null);
+        $mock->shouldReceive('get')->with('ai.deepseek_temperature')->andReturn('');
+        // GigaChat fields
+        $mock->shouldReceive('get')->with('ai.gigachat_client_id')->andReturn('');
+        $mock->shouldReceive('get')->with('ai.gigachat_base_url')->andReturn('');
+        $mock->shouldReceive('get')->with('ai.gigachat_model')->andReturn('');
+        $mock->shouldReceive('get')->with('ai.gigachat_max_tokens')->andReturn(null);
+        $mock->shouldReceive('get')->with('ai.gigachat_temperature')->andReturn('');
+        $mock->shouldReceive('get')->with('ai.gigachat_path_cert')->andReturn('');
+
+        $component = new AiProviderAccessPage();
+        $component->mount('openai', $mock);
+
+        $this->assertSame('https://api.openai.com/v1', $component->openai_base_url);
+        $this->assertSame('gpt-4o', $component->openai_model);
+        $this->assertSame(500, $component->openai_max_tokens);
+        $this->assertSame('0.5', $component->openai_temperature);
+        // Secret field must be null
+        $this->assertNull($component->openai_api_key);
+    }
+
+    public function test_mount_sets_provider_from_argument(): void
+    {
+        $component = new AiProviderAccessPage();
+        $component->mount('deepseek', $this->makeEmptySettingsMock());
+
+        $this->assertSame('deepseek', $component->provider);
+    }
+
+    public function test_mount_secret_fields_are_always_null(): void
+    {
+        $component = new AiProviderAccessPage();
+        $component->mount('gigachat', $this->makeEmptySettingsMock());
+
+        $this->assertNull($component->gigachat_client_secret);
+        $this->assertNull($component->openai_api_key);
+        $this->assertNull($component->deepseek_client_secret);
+    }
+
+    // ── save — OpenAI ─────────────────────────────────────────────────────────────
+
+    public function test_save_openai_persists_non_secret_fields(): void
+    {
+        /** @var \Mockery\MockInterface&SettingsService $mock */
+        $mock = Mockery::mock(SettingsService::class);
+        $mock->shouldReceive('get')->andReturn(null);
+        $mock->shouldReceive('set')->with('ai.openai_base_url', 'https://api.openai.com/v1')->once();
+        $mock->shouldReceive('set')->with('ai.openai_model', 'gpt-4o')->once();
+        $mock->shouldReceive('set')->with('ai.openai_temperature', '0.7')->once();
+
+        $component = new AiProviderAccessPage();
+        $component->mount('openai', $mock);
+        $component->openai_base_url = 'https://api.openai.com/v1';
+        $component->openai_model = 'gpt-4o';
+        $component->openai_temperature = '0.7';
+        $component->openai_max_tokens = null;
+        $component->save($mock);
+
+        $this->assertTrue($component->saved);
+    }
+
+    public function test_save_openai_persists_api_key_when_non_empty(): void
+    {
+        /** @var \Mockery\MockInterface&SettingsService $mock */
+        $mock = Mockery::mock(SettingsService::class);
+        $mock->shouldReceive('get')->andReturn(null);
+        $mock->shouldReceive('set')->with('ai.openai_api_key', 'sk-test123')->once();
+        $mock->shouldReceive('set')->with(Mockery::not('ai.openai_api_key'), Mockery::any());
+
+        $component = new AiProviderAccessPage();
+        $component->mount('openai', $mock);
+        $component->openai_api_key = 'sk-test123';
+        $component->openai_max_tokens = null;
+        $component->save($mock);
+
+        $this->assertTrue($component->saved);
+    }
+
+    public function test_save_openai_does_not_overwrite_api_key_when_empty(): void
+    {
+        /** @var \Mockery\MockInterface&SettingsService $mock */
+        $mock = Mockery::mock(SettingsService::class);
+        $mock->shouldReceive('get')->andReturn(null);
+        $mock->shouldNotReceive('set')->with('ai.openai_api_key', Mockery::any());
+        $mock->shouldReceive('set')->with(Mockery::not('ai.openai_api_key'), Mockery::any());
+
+        $component = new AiProviderAccessPage();
+        $component->mount('openai', $mock);
+        $component->openai_api_key = '';
+        $component->openai_max_tokens = null;
+        $component->save($mock);
+
+        $this->assertTrue($component->saved);
+    }
+
+    public function test_save_openai_rejects_zero_max_tokens(): void
+    {
+        /** @var \Mockery\MockInterface&SettingsService $mock */
+        $mock = Mockery::mock(SettingsService::class);
+        $mock->shouldReceive('get')->andReturn(null);
+        $mock->shouldNotReceive('set');
+
+        $component = new AiProviderAccessPage();
+        $component->mount('openai', $mock);
+        $component->openai_max_tokens = 0;
+        $component->save($mock);
+
+        $this->assertFalse($component->saved);
+        $this->assertArrayHasKey('openai_max_tokens', $component->formErrors);
+    }
+
+    // ── save — DeepSeek ───────────────────────────────────────────────────────────
+
+    public function test_save_deepseek_persists_non_secret_fields(): void
+    {
+        /** @var \Mockery\MockInterface&SettingsService $mock */
+        $mock = Mockery::mock(SettingsService::class);
+        $mock->shouldReceive('get')->andReturn(null);
+        $mock->shouldReceive('set')->with('ai.deepseek_client_id', 'my-client')->once();
+        $mock->shouldReceive('set')->with('ai.deepseek_base_url', 'https://api.deepseek.com')->once();
+        $mock->shouldReceive('set')->with('ai.deepseek_model', 'deepseek-chat')->once();
+        $mock->shouldReceive('set')->with('ai.deepseek_temperature', '0.8')->once();
+
+        $component = new AiProviderAccessPage();
+        $component->mount('deepseek', $mock);
+        $component->deepseek_client_id = 'my-client';
+        $component->deepseek_base_url = 'https://api.deepseek.com';
+        $component->deepseek_model = 'deepseek-chat';
+        $component->deepseek_temperature = '0.8';
+        $component->deepseek_max_tokens = null;
+        $component->save($mock);
+
+        $this->assertTrue($component->saved);
+    }
+
+    public function test_save_deepseek_does_not_overwrite_client_secret_when_empty(): void
+    {
+        /** @var \Mockery\MockInterface&SettingsService $mock */
+        $mock = Mockery::mock(SettingsService::class);
+        $mock->shouldReceive('get')->andReturn(null);
+        $mock->shouldNotReceive('set')->with('ai.deepseek_client_secret', Mockery::any());
+        $mock->shouldReceive('set')->with(Mockery::not('ai.deepseek_client_secret'), Mockery::any());
+
+        $component = new AiProviderAccessPage();
+        $component->mount('deepseek', $mock);
+        $component->deepseek_client_secret = '';
+        $component->deepseek_max_tokens = null;
+        $component->save($mock);
+
+        $this->assertTrue($component->saved);
+    }
+
+    public function test_save_deepseek_persists_client_secret_when_non_empty(): void
+    {
+        /** @var \Mockery\MockInterface&SettingsService $mock */
+        $mock = Mockery::mock(SettingsService::class);
+        $mock->shouldReceive('get')->andReturn(null);
+        $mock->shouldReceive('set')->with('ai.deepseek_client_secret', 'secret-value')->once();
+        $mock->shouldReceive('set')->with(Mockery::not('ai.deepseek_client_secret'), Mockery::any());
+
+        $component = new AiProviderAccessPage();
+        $component->mount('deepseek', $mock);
+        $component->deepseek_client_secret = 'secret-value';
+        $component->deepseek_max_tokens = null;
+        $component->save($mock);
+
+        $this->assertTrue($component->saved);
+    }
+
+    public function test_save_deepseek_rejects_zero_max_tokens(): void
+    {
+        /** @var \Mockery\MockInterface&SettingsService $mock */
+        $mock = Mockery::mock(SettingsService::class);
+        $mock->shouldReceive('get')->andReturn(null);
+        $mock->shouldNotReceive('set');
+
+        $component = new AiProviderAccessPage();
+        $component->mount('deepseek', $mock);
+        $component->deepseek_max_tokens = 0;
+        $component->save($mock);
+
+        $this->assertFalse($component->saved);
+        $this->assertArrayHasKey('deepseek_max_tokens', $component->formErrors);
+    }
+
+    // ── save — GigaChat ───────────────────────────────────────────────────────────
+
+    public function test_save_gigachat_persists_all_non_secret_fields_including_path_cert(): void
+    {
+        /** @var \Mockery\MockInterface&SettingsService $mock */
+        $mock = Mockery::mock(SettingsService::class);
+        $mock->shouldReceive('get')->andReturn(null);
+        $mock->shouldReceive('set')->with('ai.gigachat_client_id', 'gc-id')->once();
+        $mock->shouldReceive('set')->with('ai.gigachat_base_url', 'https://gigachat.sber.ru')->once();
+        $mock->shouldReceive('set')->with('ai.gigachat_model', 'GigaChat-Pro')->once();
+        $mock->shouldReceive('set')->with('ai.gigachat_temperature', '0.6')->once();
+        $mock->shouldReceive('set')->with('ai.gigachat_path_cert', '/etc/ssl/certs/giga.pem')->once();
+
+        $component = new AiProviderAccessPage();
+        $component->mount('gigachat', $mock);
+        $component->gigachat_client_id = 'gc-id';
+        $component->gigachat_base_url = 'https://gigachat.sber.ru';
+        $component->gigachat_model = 'GigaChat-Pro';
+        $component->gigachat_temperature = '0.6';
+        $component->gigachat_path_cert = '/etc/ssl/certs/giga.pem';
+        $component->gigachat_max_tokens = null;
+        $component->save($mock);
+
+        $this->assertTrue($component->saved);
+    }
+
+    public function test_save_gigachat_does_not_overwrite_client_secret_when_empty(): void
+    {
+        /** @var \Mockery\MockInterface&SettingsService $mock */
+        $mock = Mockery::mock(SettingsService::class);
+        $mock->shouldReceive('get')->andReturn(null);
+        $mock->shouldNotReceive('set')->with('ai.gigachat_client_secret', Mockery::any());
+        $mock->shouldReceive('set')->with(Mockery::not('ai.gigachat_client_secret'), Mockery::any());
+
+        $component = new AiProviderAccessPage();
+        $component->mount('gigachat', $mock);
+        $component->gigachat_client_secret = '';
+        $component->gigachat_max_tokens = null;
+        $component->save($mock);
+
+        $this->assertTrue($component->saved);
+    }
+
+    public function test_save_gigachat_persists_client_secret_when_non_empty(): void
+    {
+        /** @var \Mockery\MockInterface&SettingsService $mock */
+        $mock = Mockery::mock(SettingsService::class);
+        $mock->shouldReceive('get')->andReturn(null);
+        $mock->shouldReceive('set')->with('ai.gigachat_client_secret', 'gc-secret')->once();
+        $mock->shouldReceive('set')->with(Mockery::not('ai.gigachat_client_secret'), Mockery::any());
+
+        $component = new AiProviderAccessPage();
+        $component->mount('gigachat', $mock);
+        $component->gigachat_client_secret = 'gc-secret';
+        $component->gigachat_max_tokens = null;
+        $component->save($mock);
+
+        $this->assertTrue($component->saved);
+    }
+
+    public function test_save_gigachat_rejects_zero_max_tokens(): void
+    {
+        /** @var \Mockery\MockInterface&SettingsService $mock */
+        $mock = Mockery::mock(SettingsService::class);
+        $mock->shouldReceive('get')->andReturn(null);
+        $mock->shouldNotReceive('set');
+
+        $component = new AiProviderAccessPage();
+        $component->mount('gigachat', $mock);
+        $component->gigachat_max_tokens = 0;
+        $component->save($mock);
+
+        $this->assertFalse($component->saved);
+        $this->assertArrayHasKey('gigachat_max_tokens', $component->formErrors);
+    }
+
+    // ── save — unknown provider ───────────────────────────────────────────────────
+
+    public function test_save_sets_error_for_unknown_provider(): void
+    {
+        /** @var \Mockery\MockInterface&SettingsService $mock */
+        $mock = Mockery::mock(SettingsService::class);
+        $mock->shouldReceive('get')->andReturn(null);
+        $mock->shouldNotReceive('set');
+
+        $component = new AiProviderAccessPage();
+        $component->mount('openai', $mock);
+        // Forcibly override provider after mount
+        $component->provider = 'unknown';
+        $component->save($mock);
+
+        $this->assertFalse($component->saved);
+        $this->assertArrayHasKey('provider', $component->formErrors);
+    }
+
+    // ── cancel ───────────────────────────────────────────────────────────────────
+
+    public function test_cancel_resets_to_stored_non_secret_values(): void
+    {
+        /** @var \Mockery\MockInterface&SettingsService $mock */
+        $mock = Mockery::mock(SettingsService::class);
+        $mock->shouldReceive('get')->with('ai.openai_base_url')->andReturn('https://stored.url');
+        $mock->shouldReceive('get')->with('ai.openai_model')->andReturn('gpt-4-turbo');
+        $mock->shouldReceive('get')->with('ai.openai_max_tokens')->andReturn(null);
+        $mock->shouldReceive('get')->with('ai.openai_temperature')->andReturn('0.5');
+        $mock->shouldReceive('get')->andReturn(null);
+
+        $component = new AiProviderAccessPage();
+        $component->mount('openai', $mock);
+        // Simulate unsaved changes
+        $component->openai_base_url = 'https://changed.url';
+        $component->saved = true;
+        $component->formErrors = ['openai_model' => 'Error'];
+
+        $component->cancel($mock);
+
+        $this->assertSame('https://stored.url', $component->openai_base_url);
+        $this->assertFalse($component->saved);
+        $this->assertEmpty($component->formErrors);
+        // Secret must remain null after cancel
+        $this->assertNull($component->openai_api_key);
+    }
+}


### PR DESCRIPTION
## Summary

Раздел **«ИИ-ассистент»** в админ-панели по дизайну `admin-tg-support-bot.pen` (фрейм `KOqLc`) — на кастомном Livewire/Blade поверх дизайн-системы (#153) и `SettingsService` (#150). Плюс отдельные экраны доступа к провайдерам OpenAI/DeepSeek/GigaChat.

> База PR — **`dev`** (ветка `issues-145` от dev; #150/#153/#144 уже влиты).

## Что сделано
- **`/admin/settings/ai`** (`AiAssistantPage`) по фрейму `KOqLc`: мастер-тумблер «Включить AI помощника»; секция **«AI-провайдер»** — вертикальный список карточек (активная: зелёная рамка + бейдж «Активен» + «Модель/Статус»; остальные: «Выбрать» + «⋮» на экран доступа); секция **«Общие настройки»** — автоответы (с confirm-диалогом, BR-002), системный промпт со счётчиком `N / 2000`, кнопка «Сохранить настройки».
- **`/admin/settings/ai/{provider}`** (`AiProviderAccessPage`) — формы доступа OpenAI (api_key/base_url/model/max_tokens/temperature), DeepSeek и GigaChat (client_id/client_secret/…/+path_cert для GigaChat). Секреты masked/encrypted, пустые поля не затирают сохранённые.
- **Хранение** — через `SettingsService` (#150); +14 ключей `ai.*` в `SettingKeyRegistry` (модели/URL/токены/температуры/промпт/сертификат).
- **Дизайн-система** выровнена под `.pen`: тумблер (off `#E5E7EB`) и primary-кнопка (`rounded:10`, `padding [0,24]`, font-weight 500, без тени) — применяется единообразно ко всем экранам.
- Пункт «ИИ-ассистент» в сайдбаре настроек активен; доступ — только админ.
- Тесты: Unit\Livewire (29) + Feature (27). Доки: `rules/domain/ai-assistant.md`, `rules/domain/admin-panel.md`, `CLAUDE.md`.

## Решения по ❓ спека
- Тип страниц — кастомный Livewire/Blade (не Filament), консистентно с #153.
- Хранение — `SettingsService`, без новой таблицы.
- Системный промпт — в ключ `ai.system_prompt` (не в Blade-файл).
- DeepSeek/GigaChat — client_id/client_secret (не единый api_key).
- Поле «лимит контекста» в UI не выводится (его нет в макете `KOqLc`); свойство/сохранение `ai.max_context_tokens` сохранены.

## ⚠️ Важно (зависимость рантайма)
Настройки и ключи сохраняются в таблицу `settings`, но боевые AI-флоу (`ShouldAiReply`, `AiAssistantService`, провайдеры) пока читают из `config('ai.*')` — то есть введённое в админке **ещё не применяется** на лету. Перевод чтения на `SettingsService` — та же тема, что **#154** (сейчас про каналы); логично расширить #154 на AI-ключи.

## Проверки
Pint — чисто · PHPStan level 6 — 0 ошибок · `php artisan test` — все зелёные (включая 56 новых AI-тестов). Ассеты пересобраны на Node 20.

Closes #145