### PR TITLE
issues-163 | Admin panel redesign: Livewire workspace, settings layer, AI & API screens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,7 +301,7 @@ public static function execute(BotUser $botUser): TelegramAnswerDto
 - Cache: values cached forever in the default store (Redis); invalidated on `set()` / `forget()`
 - Known keys and their types/fallbacks/secret flags are registered in `SettingKeyRegistry::$keys`
 - In-scope keys with `config => null`: all `telegram.*`, `telegram_ai.*`, `vk.*`, `max.*`, all `ai.*` credentials and behaviour settings. Infrastructure keys (`app.manager_interface`) retain their `config()` fallback.
-- The General Settings screen (`/admin/settings/general`, `app/Livewire/Settings/GeneralSettingsPage.php`) provides a custom Livewire/Blade UI (NOT Filament chrome) for editing `app.bot_name`, `app.bot_description`, `telegram.template_topic_name` (Telegram topic-name template) and `app.manager_interface`. Uses the admin design system (Tailwind v4 tokens + `<x-admin.*>` Blade components)
+- The General Settings screen (`/admin/settings/general`, `app/Livewire/Settings/GeneralSettingsPage.php`) provides a custom Livewire/Blade UI (NOT Filament chrome) for editing only `telegram.template_topic_name` (Telegram topic-name template). Bot name (`app.bot_name`), description (`app.bot_description`), and the manager-interface radio (`app.manager_interface`) were removed from this screen. Uses the admin design system (Tailwind v4 tokens + `<x-admin.*>` Blade components)
 
 ### Channel Integrations (Settings)
 
@@ -334,6 +334,7 @@ public static function execute(BotUser $botUser): TelegramAnswerDto
 - Token length: 64 characters (`Str::random(64)` in `ExternalSourceTokensService::generateToken()`)
 - Token active flag: `external_source_access_tokens.active` — inactive tokens (`active=false`) are rejected by `ApiQuery` middleware with 401
 - Token values are never logged or displayed in full — only a one-time reveal after regeneration, followed by dismissal
+- IP allowlist: `external_sources.allowed_ips` (JSON, editable on the per-source page `/admin/settings/api-webhooks/{source}`) restricts which IPs may call the API. Non-empty → `ApiQuery` rejects (403) requests whose IP isn't listed; empty/NULL → no restriction (`ExternalSource::isIpAllowed()`). The per-source edit page no longer has the secret-key/events design placeholders.
 - See `rules/domain/admin-panel.md` (BR-023, BR-024, BR-025) and `rules/domain/external-sources.md`
 
 ### Feedback Form
@@ -350,8 +351,7 @@ public static function execute(BotUser $botUser): TelegramAnswerDto
 
 - `MANAGER_INTERFACE=telegram_group` (default) — managers work via Telegram supergroup with forum topics
 - `MANAGER_INTERFACE=admin_panel` — managers work via the `/admin/chats` workspace (full-screen, chrome-free, `App\Livewire\Chat\ConversationPage`)
-- Switching via `.env`: change `MANAGER_INTERFACE` + `docker compose restart app`
-- Switching via admin panel: save via General Settings screen (`/admin/settings/general`, `GeneralSettingsPage`) → value written to `settings` DB table via `SettingsService` (overrides `.env` on next read); container restart still required for DI binding to take effect (`docker compose restart app`) — screen shows a persistent yellow warning notice
+- Switching via `.env` only: change `MANAGER_INTERFACE` + `docker compose restart app`. **This is no longer editable from the admin panel** — the General Settings screen's manager-interface radio was removed.
 - The `ManagerInterfaceContract` DI binding in `AppServiceProvider::register()` reads from `config('app.manager_interface')` at boot, NOT from `SettingsService` — this is intentional to avoid DB dependency at container startup
 - Does not require `php artisan migrate` or any DB changes (for mode switching itself)
 - See `rules/domain/admin-panel.md` for full rules (BR-001 through BR-025)

--- a/app/Livewire/Chat/ConversationPage.php
+++ b/app/Livewire/Chat/ConversationPage.php
@@ -7,12 +7,16 @@ namespace App\Livewire\Chat;
 use App\Models\BotUser;
 use App\Models\Message;
 use App\Models\MessageAttachment;
+use App\Modules\Admin\Actions\BanBotUser;
 use App\Modules\Admin\Actions\SendReplyAction;
+use App\Modules\Admin\Actions\UnbanBotUser;
+use App\Modules\Telegram\Actions\CloseTopic;
 use Filament\Notifications\Notification;
 use Illuminate\Support\Collection;
 use Livewire\Attributes\Layout;
 use Livewire\Attributes\Locked;
 use Livewire\Component;
+use Livewire\WithFileUploads;
 
 /**
  * Full-screen manager chat workspace (standalone Livewire route).
@@ -27,6 +31,8 @@ use Livewire\Component;
 #[Layout('layouts.admin-chat')]
 class ConversationPage extends Component
 {
+    use WithFileUploads;
+
     // ── Dialog list ────────────────────────────────────────────────────────────
 
     public string $search = '';
@@ -46,6 +52,16 @@ class ConversationPage extends Component
     public Collection $chatMessages;
 
     public string $replyText = '';
+
+    /**
+     * Optional file to attach to the manager reply.
+     *
+     * Only honoured for platforms whose SendReplyAction branch handles files
+     * (telegram, vk) — see supportsAttachments().
+     *
+     * @var \Livewire\Features\SupportFileUploads\TemporaryUploadedFile|null
+     */
+    public $attachment = null;
 
     // ── Lifecycle ──────────────────────────────────────────────────────────────
 
@@ -104,6 +120,38 @@ class ConversationPage extends Component
     }
 
     /**
+     * Whether a dialog should show the "new message" indicator.
+     *
+     * True only when the user wrote the last message (incoming) in an open
+     * conversation that is not banned, is not the one currently being viewed,
+     * AND that message arrived after the manager last opened the dialog
+     * (`manager_last_read_at`). The read timestamp makes the indicator survive
+     * page reloads — opening a dialog marks it read (see selectChat()).
+     *
+     * @param BotUser $user
+     *
+     * @return bool
+     */
+    public function hasUnread(BotUser $user): bool
+    {
+        /** @var Message|null $last */
+        $last = $user->lastMessage;
+
+        if (
+            $last?->message_type !== 'incoming'
+            || $user->is_closed
+            || $user->is_banned
+            || $this->activeBotUserId === $user->id
+        ) {
+            return false;
+        }
+
+        $readAt = $user->manager_last_read_at;
+
+        return $readAt === null || $last->created_at?->gt($readAt);
+    }
+
+    /**
      * Triggered when the search field changes (wire:model.live.debounce).
      *
      * @return void
@@ -142,13 +190,52 @@ class ConversationPage extends Component
 
         $this->activeBotUserId = $botUserId;
         $this->activeBotUser = BotUser::with(['externalUser'])->find($botUserId);
+
+        // Mark the conversation read so the unread indicator stays cleared
+        // across page reloads (persisted, not just session state).
+        $this->activeBotUser?->update(['manager_last_read_at' => now()]);
+
         $this->loadMessages();
+        $this->loadDialogList();
+
+        // Always scroll to the bottom when opening a dialog.
+        $this->dispatch('messages-updated');
+    }
+
+    /**
+     * Combined 5 s poll entry point (wire:poll): refresh the dialog list and,
+     * when a dialog is open, the message thread too.
+     *
+     * Only scrolls to the bottom and bumps the read marker when new messages
+     * actually arrived — so a manager scrolled up reading history is not yanked
+     * down on every tick.
+     *
+     * @return void
+     */
+    public function pollUpdates(): void
+    {
+        $this->loadDialogList();
+
+        if (! $this->activeBotUser) {
+            return;
+        }
+
+        $previousCount = $this->chatMessages->count();
+        $this->loadMessages();
+
+        if ($this->chatMessages->count() > $previousCount) {
+            $this->activeBotUser->update(['manager_last_read_at' => now()]);
+            $this->dispatch('messages-updated');
+        }
     }
 
     // ── Chat area ──────────────────────────────────────────────────────────────
 
     /**
      * Load messages for the active conversation.
+     *
+     * Pure loader — callers decide when to scroll the thread (via the
+     * `messages-updated` browser event) so polling does not force-scroll.
      *
      * @return void
      */
@@ -164,12 +251,14 @@ class ConversationPage extends Component
             ->with(['externalMessage', 'attachments'])
             ->orderBy('created_at')
             ->get();
-
-        $this->dispatch('messages-updated');
     }
 
     /**
-     * Send a manager reply to the active bot user.
+     * Send a manager reply (text and/or a file attachment) to the active bot user.
+     *
+     * Text is required only when no file is attached, so a file-only message is
+     * allowed. The attachment is ignored for platforms that cannot deliver files
+     * (see supportsAttachments()).
      *
      * @return void
      */
@@ -179,15 +268,20 @@ class ConversationPage extends Component
             return;
         }
 
+        $file = $this->supportsAttachments() ? $this->attachment : null;
+
         $this->validate([
-            'replyText' => ['required', 'string', 'max:4096'],
+            'replyText' => [$file ? 'nullable' : 'required', 'string', 'max:4096'],
+            'attachment' => ['nullable', 'file', 'max:20480'],
         ]);
 
-        SendReplyAction::execute($this->activeBotUser, $this->replyText);
+        SendReplyAction::execute($this->activeBotUser, $this->replyText, $file);
 
         $this->replyText = '';
+        $this->attachment = null;
         $this->loadMessages();
         $this->loadDialogList();
+        $this->dispatch('messages-updated');
 
         Notification::make()
             ->title('Сообщение отправлено')
@@ -196,13 +290,118 @@ class ConversationPage extends Component
     }
 
     /**
-     * Show reply form only in admin_panel mode.
+     * Whether file attachments can be delivered for the active dialog.
+     *
+     * Only telegram and vk have a file-aware branch in SendReplyAction;
+     * external/max replies are text-only, so the attach control is hidden there.
+     *
+     * @return bool
+     */
+    public function supportsAttachments(): bool
+    {
+        return in_array($this->activeBotUser?->platform, ['telegram', 'vk'], true);
+    }
+
+    /**
+     * Discard the currently selected attachment.
+     *
+     * @return void
+     */
+    public function removeAttachment(): void
+    {
+        $this->attachment = null;
+        $this->resetValidation('attachment');
+    }
+
+    /**
+     * Close the active conversation via the canonical CloseTopic flow:
+     * notifies the user, closes the Telegram forum topic (when present),
+     * marks the BotUser as closed, and triggers the feedback form.
+     *
+     * No-op when there is no active dialog or it is already closed.
+     *
+     * @return void
+     */
+    public function closeDialog(): void
+    {
+        if (empty($this->activeBotUser) || $this->activeBotUser->isClosed()) {
+            return;
+        }
+
+        app(CloseTopic::class)->execute($this->activeBotUser);
+
+        $this->activeBotUser->refresh();
+        $this->loadMessages();
+        $this->loadDialogList();
+
+        Notification::make()
+            ->title('Диалог закрыт')
+            ->success()
+            ->send();
+    }
+
+    /**
+     * Ban the active bot user (mark banned + closed, close the Telegram topic).
+     *
+     * No-op when there is no active dialog or it is already banned.
+     *
+     * @return void
+     */
+    public function banUser(): void
+    {
+        if (empty($this->activeBotUser) || $this->activeBotUser->isBanned()) {
+            return;
+        }
+
+        app(BanBotUser::class)->execute($this->activeBotUser);
+
+        $this->activeBotUser->refresh();
+        $this->loadMessages();
+        $this->loadDialogList();
+
+        Notification::make()
+            ->title('Пользователь заблокирован')
+            ->success()
+            ->send();
+    }
+
+    /**
+     * Lift the ban from the active bot user.
+     *
+     * No-op when there is no active dialog or the user is not banned.
+     *
+     * @return void
+     */
+    public function unbanUser(): void
+    {
+        if (empty($this->activeBotUser) || ! $this->activeBotUser->isBanned()) {
+            return;
+        }
+
+        app(UnbanBotUser::class)->execute($this->activeBotUser);
+
+        $this->activeBotUser->refresh();
+        $this->loadMessages();
+        $this->loadDialogList();
+
+        Notification::make()
+            ->title('Пользователь разблокирован')
+            ->success()
+            ->send();
+    }
+
+    /**
+     * Whether the reply form should be rendered in the chat workspace.
+     *
+     * Always true: SendReplyAction routes the reply by BotUser platform
+     * (telegram/vk/external) and does not depend on MANAGER_INTERFACE, so the
+     * manager can reply from the workspace regardless of the active mode.
      *
      * @return bool
      */
     public function shouldShowReplyForm(): bool
     {
-        return config('app.manager_interface') === 'admin_panel';
+        return true;
     }
 
     // ── Quick replies ──────────────────────────────────────────────────────────

--- a/app/Livewire/Settings/ApiWebhookSourcePage.php
+++ b/app/Livewire/Settings/ApiWebhookSourcePage.php
@@ -43,6 +43,12 @@ class ApiWebhookSourcePage extends Component
     /** @var string Webhook URL being edited */
     public string $webhookUrl = '';
 
+    /** @var string Allowed request IPs, one per line (textarea-bound) */
+    public string $allowedIps = '';
+
+    /** @var string|null Validation error for the allowed-IPs field */
+    public ?string $allowedIpsError = null;
+
     /** @var string|null One-time reveal: raw new token after regeneration */
     public ?string $newToken = null;
 
@@ -82,6 +88,7 @@ class ApiWebhookSourcePage extends Component
         $this->sourceId = $externalSource->id;
         $this->sourceName = $externalSource->name;
         $this->webhookUrl = (string) ($externalSource->webhook_url ?? '');
+        $this->allowedIps = implode("\n", $externalSource->allowed_ips ?? []);
 
         $this->loadToken();
     }
@@ -117,14 +124,17 @@ class ApiWebhookSourcePage extends Component
     }
 
     /**
-     * Save the webhook URL for this External Source.
+     * Save the webhook URL and allowed-IPs allowlist for this External Source.
      *
-     * Empty string is accepted (clears the stored URL).
-     * A non-empty value must pass FILTER_VALIDATE_URL.
+     * Empty webhook URL is accepted (clears the stored URL); a non-empty value
+     * must pass FILTER_VALIDATE_URL. The allowed-IPs textarea (one entry per
+     * line) is parsed into a deduplicated list; every entry must be a valid IP.
+     * An empty allowlist means requests are allowed from any IP.
      */
     public function saveWebhookUrl(): void
     {
         $this->webhookError = null;
+        $this->allowedIpsError = null;
         $this->saved = false;
 
         $url = trim($this->webhookUrl);
@@ -132,6 +142,12 @@ class ApiWebhookSourcePage extends Component
         if ($url !== '' && ! filter_var($url, FILTER_VALIDATE_URL)) {
             $this->webhookError = 'Введите корректный URL (например: https://example.com/webhook).';
 
+            return;
+        }
+
+        $ips = $this->parseAllowedIps();
+
+        if ($ips === null) {
             return;
         }
 
@@ -143,7 +159,10 @@ class ApiWebhookSourcePage extends Component
             return;
         }
 
-        $externalSource->update(['webhook_url' => $url !== '' ? $url : null]);
+        $externalSource->update([
+            'webhook_url' => $url !== '' ? $url : null,
+            'allowed_ips' => ! empty($ips) ? $ips : null,
+        ]);
 
         $this->saved = true;
     }
@@ -155,12 +174,47 @@ class ApiWebhookSourcePage extends Component
     {
         $this->saved = false;
         $this->webhookError = null;
+        $this->allowedIpsError = null;
 
         $externalSource = ExternalSource::find($this->sourceId);
 
         if ($externalSource) {
             $this->webhookUrl = (string) ($externalSource->webhook_url ?? '');
+            $this->allowedIps = implode("\n", $externalSource->allowed_ips ?? []);
         }
+    }
+
+    /**
+     * Parse and validate the allowed-IPs textarea.
+     *
+     * Returns a deduplicated list of valid IPs, or null when a line is not a
+     * valid IP (in which case $allowedIpsError is set).
+     *
+     * @return array<int, string>|null
+     */
+    private function parseAllowedIps(): ?array
+    {
+        $lines = preg_split('/[\r\n,]+/', $this->allowedIps) ?: [];
+
+        $ips = [];
+
+        foreach ($lines as $line) {
+            $ip = trim($line);
+
+            if ($ip === '') {
+                continue;
+            }
+
+            if (! filter_var($ip, FILTER_VALIDATE_IP)) {
+                $this->allowedIpsError = "Некорректный IP-адрес: {$ip}";
+
+                return null;
+            }
+
+            $ips[] = $ip;
+        }
+
+        return array_values(array_unique($ips));
     }
 
     /**

--- a/app/Livewire/Settings/GeneralSettingsPage.php
+++ b/app/Livewire/Settings/GeneralSettingsPage.php
@@ -18,20 +18,8 @@ use Livewire\Component;
 #[Layout('layouts.admin-settings')]
 class GeneralSettingsPage extends Component
 {
-    /** @var string|null */
-    public ?string $bot_name = null;
-
-    /** @var string|null */
-    public ?string $bot_description = null;
-
-    /** @var string */
-    public string $manager_interface = 'telegram_group';
-
     /** @var string|null Telegram forum topic name template */
     public ?string $template_topic_name = null;
-
-    /** @var bool Show the restart-required notice */
-    public bool $showRestartNotice = false;
 
     /** @var bool Show success banner */
     public bool $saved = false;
@@ -44,15 +32,11 @@ class GeneralSettingsPage extends Component
      */
     public function mount(SettingsService $settings): void
     {
-        $this->bot_name = (string) ($settings->get('app.bot_name') ?? '');
-        $this->bot_description = (string) ($settings->get('app.bot_description') ?? '');
-        $this->manager_interface = (string) ($settings->get('app.manager_interface') ?? 'telegram_group');
         $this->template_topic_name = (string) ($settings->get('telegram.template_topic_name') ?? '');
     }
 
     /**
      * Save the form values via SettingsService.
-     * Shows a restart notice when MANAGER_INTERFACE changes.
      */
     public function save(SettingsService $settings): void
     {
@@ -60,38 +44,18 @@ class GeneralSettingsPage extends Component
         $this->saved = false;
 
         // ── Validation ────────────────────────────────────────────────────────
-        if (strlen((string) $this->bot_name) > 255) {
-            $this->formErrors['bot_name'] = 'Максимальная длина — 255 символов.';
-        }
-
-        if (strlen((string) $this->bot_description) > 1000) {
-            $this->formErrors['bot_description'] = 'Максимальная длина — 1000 символов.';
-        }
-
         if (strlen((string) $this->template_topic_name) > 255) {
             $this->formErrors['template_topic_name'] = 'Максимальная длина — 255 символов.';
-        }
-
-        if (! in_array($this->manager_interface, ['telegram_group', 'admin_panel'], true)) {
-            $this->formErrors['manager_interface'] = 'Выберите допустимое значение.';
         }
 
         if (! empty($this->formErrors)) {
             return;
         }
 
-        // ── Detect interface change before saving ─────────────────────────────
-        $previous = (string) ($settings->get('app.manager_interface') ?? 'telegram_group');
-        $interfaceChanged = $previous !== $this->manager_interface;
-
         // ── Persist ───────────────────────────────────────────────────────────
-        $settings->set('app.bot_name', $this->bot_name ?? '');
-        $settings->set('app.bot_description', $this->bot_description ?? '');
-        $settings->set('app.manager_interface', $this->manager_interface);
         $settings->set('telegram.template_topic_name', $this->template_topic_name ?? '');
 
         $this->saved = true;
-        $this->showRestartNotice = $interfaceChanged;
     }
 
     /**
@@ -101,10 +65,6 @@ class GeneralSettingsPage extends Component
     {
         $this->formErrors = [];
         $this->saved = false;
-        $this->showRestartNotice = false;
-        $this->bot_name = (string) ($settings->get('app.bot_name') ?? '');
-        $this->bot_description = (string) ($settings->get('app.bot_description') ?? '');
-        $this->manager_interface = (string) ($settings->get('app.manager_interface') ?? 'telegram_group');
         $this->template_topic_name = (string) ($settings->get('telegram.template_topic_name') ?? '');
     }
 

--- a/app/Models/BotUser.php
+++ b/app/Models/BotUser.php
@@ -12,16 +12,17 @@ use Illuminate\Support\Facades\Log;
 use phpDocumentor\Reflection\Exception;
 
 /**
- * @property int               $id
- * @property int               $topic_id
- * @property int               $chat_id
- * @property string            $platform
- * @property mixed             $aiCondition
- * @property mixed             $lastMessageManager
- * @property ExternalUser|null $externalUser
- * @property bool              $is_banned
- * @property bool              $is_closed
- * @property string|null       $closed_at
+ * @property int                             $id
+ * @property int                             $topic_id
+ * @property int                             $chat_id
+ * @property string                          $platform
+ * @property mixed                           $aiCondition
+ * @property mixed                           $lastMessageManager
+ * @property ExternalUser|null               $externalUser
+ * @property bool                            $is_banned
+ * @property bool                            $is_closed
+ * @property string|null                     $closed_at
+ * @property \Illuminate\Support\Carbon|null $manager_last_read_at
  */
 class BotUser extends Model
 {
@@ -37,6 +38,11 @@ class BotUser extends Model
         'banned_at',
         'is_closed',
         'closed_at',
+        'manager_last_read_at',
+    ];
+
+    protected $casts = [
+        'manager_last_read_at' => 'datetime',
     ];
 
     /**

--- a/app/Models/ExternalSource.php
+++ b/app/Models/ExternalSource.php
@@ -8,10 +8,11 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
- * @property int    $id
- * @property string $name
- * @property string $webhook_url
- * @property int    $user_id
+ * @property int                     $id
+ * @property string                  $name
+ * @property string                  $webhook_url
+ * @property int                     $user_id
+ * @property array<int, string>|null $allowed_ips
  * @property-read User $user
  */
 class ExternalSource extends Model
@@ -22,6 +23,11 @@ class ExternalSource extends Model
         'name',
         'webhook_url',
         'user_id',
+        'allowed_ips',
+    ];
+
+    protected $casts = [
+        'allowed_ips' => 'array',
     ];
 
     /**
@@ -30,6 +36,26 @@ class ExternalSource extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Whether the given request IP is allowed for this source.
+     *
+     * An empty/NULL allowlist means no restriction — any IP is allowed.
+     *
+     * @param string|null $ip
+     *
+     * @return bool
+     */
+    public function isIpAllowed(?string $ip): bool
+    {
+        $allowed = array_values(array_filter(array_map('trim', $this->allowed_ips ?? [])));
+
+        if (empty($allowed)) {
+            return true;
+        }
+
+        return $ip !== null && in_array($ip, $allowed, true);
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,6 +3,8 @@
 namespace App\Models;
 
 use App\Enums\UserRole;
+use Filament\Models\Contracts\FilamentUser;
+use Filament\Panel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -10,11 +12,28 @@ use Illuminate\Notifications\Notifiable;
 /**
  * @property UserRole $role
  */
-class User extends Authenticatable
+class User extends Authenticatable implements FilamentUser
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
     use HasFactory;
     use Notifiable;
+
+    /**
+     * Whether this user may access the admin panel.
+     *
+     * Every record in the `users` table is an operator (admin or manager),
+     * so all of them may sign in to the panel. Without this method Filament
+     * grants access only in the `local` environment, which is why login
+     * succeeded but the panel 403'd on production/staging.
+     *
+     * @param Panel $panel
+     *
+     * @return bool
+     */
+    public function canAccessPanel(Panel $panel): bool
+    {
+        return in_array($this->role, [UserRole::Admin, UserRole::Manager], true);
+    }
 
     /**
      * The attributes that are mass assignable.

--- a/app/Modules/Admin/Actions/BanBotUser.php
+++ b/app/Modules/Admin/Actions/BanBotUser.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Modules\Admin\Actions;
+
+use App\Models\BotUser;
+use App\Modules\Telegram\DTOs\TGTextMessageDto;
+use App\Modules\Telegram\Jobs\SendTelegramSimpleQueryJob;
+use App\Services\Settings\SettingsService;
+
+class BanBotUser
+{
+    /**
+     * Ban a bot user from the admin workspace.
+     *
+     * Marks the user as banned (`is_banned`/`banned_at`) and terminal
+     * (`is_closed`/`closed_at`), and closes the user's Telegram forum topic
+     * when present (telegram_group mode). No feedback form is sent.
+     *
+     * Future messages from a banned user are rejected by the platform webhook
+     * controllers via `BotUser::isBanned()`.
+     *
+     * @param BotUser $botUser
+     *
+     * @return void
+     */
+    public function execute(BotUser $botUser): void
+    {
+        if ($botUser->isBanned()) {
+            return;
+        }
+
+        $botUser->update([
+            'is_banned' => true,
+            'banned_at' => now(),
+            'is_closed' => true,
+            'closed_at' => $botUser->closed_at ?? now(),
+        ]);
+
+        if ($botUser->platform === 'telegram' && !empty($botUser->topic_id)) {
+            $groupId = (string) app(SettingsService::class)->get('telegram.group_id');
+
+            if ($groupId !== '') {
+                SendTelegramSimpleQueryJob::dispatch(TGTextMessageDto::from([
+                    'methodQuery' => 'editForumTopic',
+                    'chat_id' => $groupId,
+                    'message_thread_id' => $botUser->topic_id,
+                    'icon_custom_emoji_id' => __('icons.outgoing'),
+                ]));
+
+                SendTelegramSimpleQueryJob::dispatch(TGTextMessageDto::from([
+                    'methodQuery' => 'closeForumTopic',
+                    'chat_id' => $groupId,
+                    'message_thread_id' => $botUser->topic_id,
+                ]));
+            }
+        }
+    }
+}

--- a/app/Modules/Admin/Actions/SendReplyAction.php
+++ b/app/Modules/Admin/Actions/SendReplyAction.php
@@ -28,6 +28,11 @@ class SendReplyAction
      */
     public static function execute(BotUser $botUser, string $text, ?UploadedFile $file = null): void
     {
+        // A new reply re-opens a previously closed conversation.
+        if ($botUser->isClosed()) {
+            $botUser->update(['is_closed' => false, 'closed_at' => null]);
+        }
+
         $message = Message::create([
             'bot_user_id' => $botUser->id,
             'platform' => $botUser->platform,

--- a/app/Modules/Admin/Actions/UnbanBotUser.php
+++ b/app/Modules/Admin/Actions/UnbanBotUser.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Modules\Admin\Actions;
+
+use App\Models\BotUser;
+
+class UnbanBotUser
+{
+    /**
+     * Lift a ban from the admin workspace.
+     *
+     * Clears `is_banned`/`banned_at` so the user's messages are accepted again.
+     * Does NOT change `is_closed` — the conversation stays closed until a new
+     * message re-opens it (see SendReplyAction).
+     *
+     * No-op when the user is not banned.
+     *
+     * @param BotUser $botUser
+     *
+     * @return void
+     */
+    public function execute(BotUser $botUser): void
+    {
+        if (! $botUser->isBanned()) {
+            return;
+        }
+
+        $botUser->update([
+            'is_banned' => false,
+            'banned_at' => null,
+        ]);
+    }
+}

--- a/app/Modules/Admin/AdminPanelProvider.php
+++ b/app/Modules/Admin/AdminPanelProvider.php
@@ -30,7 +30,7 @@ class AdminPanelProvider extends PanelProvider
             ->default()
             ->id('admin')
             ->path('admin')
-            ->login()
+            ->login(\App\Modules\Admin\Filament\Pages\Auth\Login::class)
             ->homeUrl(fn (): string => route('admin.chats'))
             ->colors([
                 'primary' => Color::Amber,

--- a/app/Modules/Admin/Filament/Pages/Auth/Login.php
+++ b/app/Modules/Admin/Filament/Pages/Auth/Login.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Admin\Filament\Pages\Auth;
+
+use Filament\Pages\Auth\Login as BaseLogin;
+
+/**
+ * Custom admin panel login page.
+ *
+ * Keeps Filament's authentication logic (validation, throttling, session
+ * regeneration, redirect to the panel home) but renders a fully custom
+ * two-panel view matching the Pencil design (brand panel + login form).
+ *
+ * The form state lives under the `data` state path (Filament default), so the
+ * custom inputs bind via wire:model="data.email" / wire:model="data.password"
+ * and submission calls authenticate().
+ *
+ * Registered via AdminPanelProvider::panel()->login(self::class).
+ */
+class Login extends BaseLogin
+{
+    /**
+     * Custom Blade view for the login screen.
+     *
+     * @var view-string
+     */
+    protected static string $view = 'filament.pages.auth.login';
+}

--- a/app/Modules/External/Middleware/ApiQuery.php
+++ b/app/Modules/External/Middleware/ApiQuery.php
@@ -29,8 +29,14 @@ class ApiQuery
                 throw new Exception('Bearer Token is invalid!');
             }
 
+            $externalSource = $itemAccessToken->external_source;
+
+            if (!$externalSource->isIpAllowed($request->ip())) {
+                throw new Exception('Request IP is not allowed for this source!');
+            }
+
             $request->merge([
-                'source' => $itemAccessToken->external_source->name,
+                'source' => $externalSource->name,
                 'external_id' => $request->route('external_id') ?? null,
             ]);
 

--- a/app/Modules/Feedback/Actions/HandleFeedbackRating.php
+++ b/app/Modules/Feedback/Actions/HandleFeedbackRating.php
@@ -2,9 +2,12 @@
 
 namespace App\Modules\Feedback\Actions;
 
+use App\Models\BotUser;
 use App\Models\Feedback;
+use App\Models\Message;
 use App\Modules\Telegram\DTOs\TGTextMessageDto;
 use App\Modules\Telegram\Jobs\SendTelegramSimpleQueryJob;
+use App\Services\Settings\SettingsService;
 use Illuminate\Support\Facades\Log;
 
 /**
@@ -64,6 +67,9 @@ class HandleFeedbackRating
             'bot_user_id' => $feedback->bot_user_id,
         ]);
 
+        // Surface the rating in the conversation (chat workspace history + group topic)
+        $this->postRatingToChat($feedback, $score);
+
         // Edit the original feedback form message to a thank-you text if Telegram message context is available
         if ($messageId !== null && $chatId !== null) {
             // TODO: move text to lang/ru/messages.php when i18n infrastructure is added
@@ -77,6 +83,54 @@ class HandleFeedbackRating
                 'parse_mode' => 'html',
                 'reply_markup' => ['inline_keyboard' => []],
             ]));
+        }
+    }
+
+    /**
+     * Record the user's rating as a chat message.
+     *
+     * Always writes an incoming `messages` row so the rating shows in the
+     * conversation history (admin chat workspace). In telegram_group mode it
+     * additionally posts the rating into the user's forum topic so managers
+     * working in the supergroup see it as well.
+     *
+     * @param Feedback $feedback
+     * @param int      $score
+     *
+     * @return void
+     */
+    private function postRatingToChat(Feedback $feedback, int $score): void
+    {
+        /** @var BotUser|null $botUser */
+        $botUser = $feedback->botUser;
+        if ($botUser === null) {
+            return;
+        }
+
+        $text = 'Оценка обращения: ' . str_repeat('⭐', $score) . " ({$score}/5)";
+
+        Message::create([
+            'bot_user_id' => $botUser->id,
+            'platform' => $botUser->platform,
+            'message_type' => 'incoming',
+            'from_id' => 0,
+            'to_id' => 0,
+            'text' => $text,
+        ]);
+
+        // telegram_group mode: mirror the rating into the user's forum topic.
+        if ($botUser->platform === 'telegram' && !empty($botUser->topic_id)) {
+            $groupId = (string) app(SettingsService::class)->get('telegram.group_id');
+
+            if ($groupId !== '') {
+                SendTelegramSimpleQueryJob::dispatch(TGTextMessageDto::from([
+                    'methodQuery' => 'sendMessage',
+                    'chat_id' => $groupId,
+                    'message_thread_id' => $botUser->topic_id,
+                    'text' => $text,
+                    'parse_mode' => 'html',
+                ]));
+            }
         }
     }
 

--- a/app/Modules/Telegram/Jobs/SendTelegramMessageJob.php
+++ b/app/Modules/Telegram/Jobs/SendTelegramMessageJob.php
@@ -141,7 +141,11 @@ class SendTelegramMessageJob extends AbstractSendMessageJob
             'message_type' => $this->typeMessage,
             'from_id' => $this->updateDto->messageId,
             'to_id' => $resultQuery->message_id,
-            'text' => $this->typeMessage === 'incoming' ? ($this->updateDto->text ?? null) : ($this->queryParams->text ?? null),
+            // Photos/documents carry their text in `caption`, not `text` —
+            // fall back to it so the caption is persisted (and shown in the admin).
+            'text' => $this->typeMessage === 'incoming'
+                ? ($this->updateDto->text ?? $this->updateDto->caption ?? null)
+                : ($this->queryParams->text ?? $this->queryParams->caption ?? null),
         ]);
 
         if ($this->typeMessage === 'incoming' && !empty($this->updateDto->fileId)) {

--- a/database/migrations/2026_06_04_000001_add_manager_last_read_at_to_bot_users_table.php
+++ b/database/migrations/2026_06_04_000001_add_manager_last_read_at_to_bot_users_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('bot_users', function (Blueprint $table) {
+            $table->timestamp('manager_last_read_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('bot_users', function (Blueprint $table) {
+            $table->dropColumn('manager_last_read_at');
+        });
+    }
+};

--- a/database/migrations/2026_06_04_000002_add_allowed_ips_to_external_sources_table.php
+++ b/database/migrations/2026_06_04_000002_add_allowed_ips_to_external_sources_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('external_sources', function (Blueprint $table) {
+            // Allowlist of IP addresses the API will accept requests from.
+            // NULL / empty = no restriction (any IP allowed).
+            $table->json('allowed_ips')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('external_sources', function (Blueprint $table) {
+            $table->dropColumn('allowed_ips');
+        });
+    }
+};

--- a/resources/views/components/admin/sidebar.blade.php
+++ b/resources/views/components/admin/sidebar.blade.php
@@ -38,6 +38,24 @@
         {{ $slot }}
     </nav>
 
+    {{-- Logout --}}
+    <div class="px-3 pb-2">
+        <form method="POST" action="{{ route('filament.admin.auth.logout') }}">
+            @csrf
+            <button
+                type="submit"
+                class="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium text-text-sidebar-secondary transition hover:bg-sidebar-hover hover:text-text-sidebar"
+            >
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-[18px] w-[18px] shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+                    <polyline points="16 17 21 12 16 7" />
+                    <line x1="21" x2="9" y1="12" y2="12" />
+                </svg>
+                Выйти
+            </button>
+        </form>
+    </div>
+
     {{-- Footer --}}
     <div class="border-t border-border-sidebar px-4 py-4 text-xs text-text-sidebar-secondary">
         <span>{{ $version }}</span>

--- a/resources/views/components/chat-item.blade.php
+++ b/resources/views/components/chat-item.blade.php
@@ -39,6 +39,9 @@
         : 'Нет сообщений';
 
     $timestamp = $botUser->lastMessage?->created_at?->format('H:i') ?? null;
+
+    $isClosed = (bool) $botUser->is_closed;
+    $isBanned = (bool) $botUser->is_banned;
 @endphp
 
 {{--
@@ -61,7 +64,7 @@
     {{-- Design: node STtU2 — cornerRadius 22, fill = avatar color; Lqpcy — initials text --}}
     <div
         class="relative flex shrink-0 items-center justify-center rounded-full text-white select-none"
-        style="width:44px; height:44px; background:{{ $avatarColor }}; font-size:15px; font-weight:600; border-radius:22px;"
+        style="width:44px; height:44px; background:{{ $avatarColor }}; font-size:15px; font-weight:600; border-radius:22px; {{ ($isClosed || $isBanned) ? 'opacity:0.5;' : '' }}"
         aria-hidden="true"
     >{{ $initials }}</div>
 
@@ -85,6 +88,31 @@
                     class="shrink-0 text-white"
                     style="background:{{ $platformBgHex }}; border-radius:3px; padding:2px 5px; font-size:10px; font-weight:600; white-space:nowrap;"
                 >{{ $platformShort }}</span>
+
+                {{-- Status badge — banned takes priority over closed --}}
+                @if($isBanned)
+                    <span
+                        class="shrink-0 inline-flex items-center"
+                        style="background:#3A2A33; color:#F87171; border-radius:3px; padding:2px 5px; font-size:10px; font-weight:600; white-space:nowrap; gap:3px;"
+                        title="Пользователь заблокирован"
+                    >
+                        <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                            <circle cx="12" cy="12" r="10"/><path d="m4.9 4.9 14.2 14.2"/>
+                        </svg>
+                        Заблокирован
+                    </span>
+                @elseif($isClosed)
+                    <span
+                        class="shrink-0 inline-flex items-center text-text-sidebar-secondary"
+                        style="background:#2D3348; border-radius:3px; padding:2px 5px; font-size:10px; font-weight:600; white-space:nowrap; gap:3px;"
+                        title="Обращение закрыто"
+                    >
+                        <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                            <polyline points="20 6 9 17 4 12"/>
+                        </svg>
+                        Закрыт
+                    </span>
+                @endif
             </div>
 
             {{-- Timestamp --}}

--- a/resources/views/filament/pages/auth/login.blade.php
+++ b/resources/views/filament/pages/auth/login.blade.php
@@ -1,0 +1,122 @@
+{{-- Custom admin login screen — matches the Pencil "Авторизация" design.
+     Self-contained styles (the Filament login layout does not load the
+     app design-system CSS), so colours/sizes are inlined here.
+
+     NOTE: Livewire 3 requires a SINGLE root element. The style tag and both
+     panels must live inside the one root div below — do not add siblings. --}}
+
+<div class="tglogin">
+<style>
+    .tglogin{position:fixed;inset:0;display:flex;background:#FFFFFF;font-family:'Inter',ui-sans-serif,system-ui,sans-serif;z-index:50;}
+    .tglogin__brand{flex:0 0 560px;background:#1B1F2E;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:24px;padding:60px 48px;}
+    .tglogin__bot{width:80px;height:80px;border-radius:20px;background:#4F6EF7;display:flex;align-items:center;justify-content:center;}
+    .tglogin__brand-title{margin:0;color:#FFFFFF;font-size:28px;font-weight:700;line-height:1.2;}
+    .tglogin__brand-desc{margin:0;max-width:360px;color:#8B92A5;font-size:15px;line-height:1.5;text-align:center;}
+    .tglogin__features{display:flex;flex-direction:column;gap:16px;width:320px;margin-top:8px;}
+    .tglogin__feature{display:flex;align-items:center;gap:12px;}
+    .tglogin__feature span{color:#8B92A5;font-size:13px;}
+    .tglogin__feature svg{color:#4F6EF7;flex:0 0 auto;}
+    .tglogin__form-panel{flex:1;display:flex;align-items:center;justify-content:center;padding:60px 80px;background:#FFFFFF;}
+    .tglogin__form{display:flex;flex-direction:column;gap:32px;width:400px;max-width:100%;}
+    .tglogin__header{display:flex;flex-direction:column;gap:8px;}
+    .tglogin__title{margin:0;color:#1A1D26;font-size:24px;font-weight:700;}
+    .tglogin__subtitle{margin:0;color:#6B7280;font-size:14px;line-height:1.45;}
+    .tglogin__fields{display:flex;flex-direction:column;gap:20px;}
+    .tglogin__field{display:flex;flex-direction:column;gap:8px;}
+    .tglogin__label{color:#1A1D26;font-size:13px;font-weight:500;}
+    .tglogin__input{width:100%;box-sizing:border-box;height:44px;padding:0 14px;border:1px solid #E5E7EB;border-radius:10px;background:#FFFFFF;color:#1A1D26;font-size:14px;outline:none;transition:border-color .15s,box-shadow .15s;}
+    .tglogin__input::placeholder{color:#9CA3AF;}
+    .tglogin__input:focus{border-color:#4F6EF7;box-shadow:0 0 0 3px rgba(79,110,247,.18);}
+    .tglogin__input--error{border-color:#EF4444;}
+    .tglogin__error{margin:0;color:#EF4444;font-size:12px;}
+    .tglogin__btn{height:48px;border:none;border-radius:10px;background:#4F6EF7;color:#FFFFFF;font-size:15px;font-weight:600;cursor:pointer;transition:background .15s,opacity .15s;}
+    .tglogin__btn:hover{background:#4360e6;}
+    .tglogin__btn:disabled{opacity:.7;cursor:default;}
+    @media (max-width:1023px){
+        .tglogin__brand{display:none;}
+        .tglogin__form-panel{padding:32px 24px;}
+        .tglogin__form{width:100%;max-width:400px;}
+    }
+</style>
+
+    {{-- ── Brand panel ─────────────────────────────────────────────── --}}
+    <aside class="tglogin__brand">
+        <div class="tglogin__bot">
+            <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 24 24" fill="none"
+                 stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M12 8V4H8"/><rect width="16" height="12" x="4" y="8" rx="2"/>
+                <path d="M2 14h2"/><path d="M20 14h2"/><path d="M15 13v2"/><path d="M9 13v2"/>
+            </svg>
+        </div>
+
+        <h1 class="tglogin__brand-title">TG Support Bot</h1>
+        <p class="tglogin__brand-desc">Панель управления мультиплатформенным ботом поддержки</p>
+
+        <div class="tglogin__features">
+            @php
+                $features = [
+                    ['<path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z"/>', 'Чаты из Telegram, VK и MAX'],
+                    ['<path d="M12 8V4H8"/><rect width="16" height="12" x="4" y="8" rx="2"/><path d="M2 14h2"/><path d="M20 14h2"/><path d="M15 13v2"/><path d="M9 13v2"/>', 'ИИ-ассистент на базе GPT и GigaChat'],
+                    ['<path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/>', 'Командная работа и роли'],
+                    ['<polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>', 'Автоответы на частые вопросы'],
+                ];
+            @endphp
+            @foreach ($features as [$icon, $label])
+                <div class="tglogin__feature">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none"
+                         stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">{!! $icon !!}</svg>
+                    <span>{{ $label }}</span>
+                </div>
+            @endforeach
+        </div>
+    </aside>
+
+    {{-- ── Login form panel ────────────────────────────────────────── --}}
+    <main class="tglogin__form-panel">
+        <form class="tglogin__form" wire:submit="authenticate">
+            <div class="tglogin__header">
+                <h2 class="tglogin__title">Вход в систему</h2>
+                <p class="tglogin__subtitle">Введите свои данные для доступа к панели управления</p>
+            </div>
+
+            <div class="tglogin__fields">
+                <div class="tglogin__field">
+                    <label class="tglogin__label" for="tglogin-email">Email</label>
+                    <input
+                        id="tglogin-email"
+                        type="email"
+                        autocomplete="email"
+                        autofocus
+                        wire:model="data.email"
+                        placeholder="admin@example.com"
+                        class="tglogin__input @error('data.email') tglogin__input--error @enderror"
+                    />
+                    @error('data.email')
+                        <p class="tglogin__error">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <div class="tglogin__field">
+                    <label class="tglogin__label" for="tglogin-password">Пароль</label>
+                    <input
+                        id="tglogin-password"
+                        type="password"
+                        autocomplete="current-password"
+                        wire:model="data.password"
+                        placeholder="••••••••"
+                        class="tglogin__input @error('data.password') tglogin__input--error @enderror"
+                    />
+                    @error('data.password')
+                        <p class="tglogin__error">{{ $message }}</p>
+                    @enderror
+                </div>
+            </div>
+
+            <button type="submit" class="tglogin__btn" wire:loading.attr="disabled" wire:target="authenticate">
+                <span wire:loading.remove wire:target="authenticate">Войти</span>
+                <span wire:loading wire:target="authenticate">Вход…</span>
+            </button>
+        </form>
+    </main>
+
+</div>

--- a/resources/views/layouts/admin-chat.blade.php
+++ b/resources/views/layouts/admin-chat.blade.php
@@ -10,6 +10,8 @@
     @vite(['resources/css/app.css', 'resources/js/app.js'])
     @livewireStyles
     @filamentStyles
+
+    <style>[x-cloak]{display:none !important;}</style>
 </head>
 <body class="h-full overflow-hidden bg-bg-primary font-sans text-text-primary antialiased">
 

--- a/resources/views/livewire/chat/conversation-page.blade.php
+++ b/resources/views/livewire/chat/conversation-page.blade.php
@@ -8,13 +8,13 @@
     Tablet   [Left 360px | Center flex-1 ]   (right panel hidden < lg)
     Mobile   list-only ↔ chat screen  (toggled by activeBotUserId)
     ─────────────────────────────────────────────────────────────────────────────
-    Polling: 5 s (wire:poll.5s calls loadDialogList + loadMessages)
+    Polling: 5 s (wire:poll.5s → pollUpdates: refresh list + active thread)
 --}}
 
 <div
     class="flex h-screen overflow-hidden"
-    wire:poll.5s="loadDialogList"
-    x-data="{ lightboxSrc: '', lightboxOpen: false }"
+    wire:poll.5s="pollUpdates"
+    x-data="{ lightboxSrc: '', lightboxOpen: false, infoPanelOpen: false }"
     x-on:open-lightbox.window="lightboxSrc = $event.detail.src; lightboxOpen = true"
     x-on:messages-updated.window="$nextTick(() => {
         const thread = document.getElementById('chat-thread');
@@ -64,6 +64,7 @@
         {{-- Design: node AQ4LA — space-between, white 20/700 + settings icon #8B92A5 --}}
         <div class="flex items-center justify-between w-full shrink-0">
             <span class="text-text-sidebar font-bold" style="font-size:20px; line-height:1.2;">TG Support</span>
+            <div class="flex items-center shrink-0" style="gap:4px;">
             <a
                 href="{{ route('admin.settings.general') }}"
                 wire:navigate
@@ -86,6 +87,22 @@
                     <circle cx="12" cy="12" r="3"/>
                 </svg>
             </a>
+            <form method="POST" action="{{ route('filament.admin.auth.logout') }}">
+                @csrf
+                <button
+                    type="submit"
+                    class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-text-sidebar-secondary transition hover:bg-sidebar-active hover:text-text-sidebar"
+                    aria-label="Выйти"
+                    title="Выйти"
+                >
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                        <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+                        <polyline points="16 17 21 12 16 7" />
+                        <line x1="21" x2="9" y1="12" y2="12" />
+                    </svg>
+                </button>
+            </form>
+            </div>
         </div>
 
         {{-- Search bar: bg-sidebar-active #2D3348, rounded-8, search icon + placeholder --}}
@@ -122,7 +139,7 @@
             @foreach(['all' => 'Все', 'open' => 'Открытые', 'closed' => 'Закрытые'] as $value => $label)
                 <button
                     wire:click="$set('statusFilter', '{{ $value }}')"
-                    class="rounded-md transition-colors"
+                    class="rounded-md transition-colors cursor-pointer"
                     style="padding: 6px 12px; font-size:13px; font-weight: {{ $statusFilter === $value ? '600' : '400' }}; {{ $statusFilter === $value ? 'background:#4F6EF7; color:#FFFFFF;' : 'background:transparent; color:#8B92A5;' }}"
                     type="button"
                 >{{ $label }}</button>
@@ -136,9 +153,6 @@
         {{-- Dialog list --}}
         <div class="flex-1 overflow-y-auto -mx-4 pb-4">
             @forelse($dialogList as $user)
-                @php
-                    $hasUnread = $user->lastMessage?->message_type === 'incoming';
-                @endphp
                 <div
                     wire:click="selectChat({{ $user->id }})"
                     wire:key="dialog-{{ $user->id }}"
@@ -147,7 +161,7 @@
                     <x-chat-item
                         :bot-user="$user"
                         :is-active="$activeBotUserId === $user->id"
-                        :has-unread="$hasUnread"
+                        :has-unread="$this->hasUnread($user)"
                     />
                 </div>
             @empty
@@ -224,24 +238,42 @@
                             <circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/>
                         </svg>
                     </div>
-                    <div class="flex items-center justify-center rounded-lg text-text-secondary" style="width:36px; height:36px;" aria-hidden="true">
+                    <button
+                        type="button"
+                        x-on:click="infoPanelOpen = !infoPanelOpen"
+                        :class="infoPanelOpen ? 'bg-bg-secondary text-accent' : 'text-text-secondary hover:bg-bg-secondary'"
+                        :aria-pressed="infoPanelOpen"
+                        class="flex items-center justify-center rounded-lg transition"
+                        style="width:36px; height:36px; border:none; cursor:pointer; background:transparent;"
+                        aria-label="Сведения о клиенте"
+                        title="Сведения о клиенте"
+                    >
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                             <circle cx="12" cy="5" r="1"/><circle cx="12" cy="12" r="1"/><circle cx="12" cy="19" r="1"/>
                         </svg>
-                    </div>
+                    </button>
                 </div>
             </div>
 
             {{-- Message thread --}}
-            {{-- Design: node bCcH9 — bg-secondary, padding [24,32], gap 16, justify-end (stack bottom), fill_container --}}
+            {{-- Design: node bCcH9 — bg-secondary, padding [24,32], gap 16, bottom-stacked via inner mt-auto, fill_container --}}
             <div
                 id="chat-thread"
-                class="flex flex-col flex-1 overflow-y-auto bg-bg-secondary justify-end"
-                style="gap:16px; padding:24px 32px;"
+                class="flex flex-col flex-1 overflow-y-auto bg-bg-secondary"
+                style="padding:24px 32px;"
                 x-data
                 x-init="$el.scrollTop = $el.scrollHeight"
             >
-                @forelse($chatMessages as $message)
+                @if($chatMessages->isEmpty())
+                    <div class="flex flex-1 items-center justify-center">
+                        <p class="text-sm text-text-secondary">Нет сообщений</p>
+                    </div>
+                @else
+                {{-- mt-auto pins messages to the bottom when they don't fill the
+                     viewport, while keeping the container a plain top-anchored
+                     scroll area so overflow stays reachable (justify-end clips it). --}}
+                <div class="flex flex-col mt-auto w-full" style="gap:16px;">
+                @foreach($chatMessages as $message)
                     @php
                         $msgDate   = $message->created_at?->toDateString();
                         $prevDate  = $loop->first ? null : $chatMessages[$loop->index - 1]->created_at?->toDateString();
@@ -279,16 +311,16 @@
                         {{-- Design: node uduZU / Bubble Out --}}
                         <div class="flex w-full" style="justify-content:flex-end;">
                             <div class="flex flex-col" style="border-radius:16px 16px 4px 16px; background:#4F6EF7; padding:10px 14px; gap:4px; max-width:70%;">
-                                @if($messageText)
-                                    <p class="text-sm text-white" style="font-size:14px; line-height:1.4;">{{ $messageText }}</p>
-                                @endif
                                 @if($message->attachments->isNotEmpty())
                                     <x-message-attachments
                                         :attachments="$message->attachments"
                                         :platform="$message->platform"
                                         :is-outgoing="true"
                                     />
-                                @elseif(!$messageText)
+                                @endif
+                                @if($messageText)
+                                    <p class="text-sm text-white" style="font-size:14px; line-height:1.4;">{{ $messageText }}</p>
+                                @elseif($message->attachments->isEmpty())
                                     <p class="text-xs text-white opacity-70 italic">{{ $message->platform }} · {{ $message->message_type }}</p>
                                 @endif
                                 <p class="text-right text-white opacity-70" style="font-size:11px;">
@@ -308,16 +340,16 @@
                             >{{ $hdrInitials }}</div>
                             {{-- Bubble --}}
                             <div class="flex flex-col" style="border-radius:16px 16px 16px 4px; background:#FFFFFF; border:1px solid #E5E7EB; padding:10px 14px; gap:4px; max-width:70%;">
-                                @if($messageText)
-                                    <p class="text-sm text-text-primary" style="font-size:14px; line-height:1.4;">{{ $messageText }}</p>
-                                @endif
                                 @if($message->attachments->isNotEmpty())
                                     <x-message-attachments
                                         :attachments="$message->attachments"
                                         :platform="$message->platform"
                                         :is-outgoing="false"
                                     />
-                                @elseif(!$messageText)
+                                @endif
+                                @if($messageText)
+                                    <p class="text-sm text-text-primary" style="font-size:14px; line-height:1.4;">{{ $messageText }}</p>
+                                @elseif($message->attachments->isEmpty())
                                     <p class="text-xs text-text-secondary italic opacity-60">{{ $message->platform }} · {{ $message->message_type }}</p>
                                 @endif
                                 <p class="text-text-secondary opacity-70" style="font-size:11px;">
@@ -326,11 +358,9 @@
                             </div>
                         </div>
                     @endif
-                @empty
-                    <div class="flex flex-1 items-center justify-center">
-                        <p class="text-sm text-text-secondary">Нет сообщений</p>
-                    </div>
-                @endforelse
+                @endforeach
+                </div>
+                @endif
             </div>
 
             {{-- Input area --}}
@@ -354,16 +384,64 @@
                         </div>
                     @endif
 
+                    {{-- Selected attachment preview / upload progress (telegram + vk only) --}}
+                    @if($this->supportsAttachments())
+                        {{-- Uploading spinner --}}
+                        <div
+                            wire:loading.flex
+                            wire:target="attachment"
+                            class="items-center mb-2"
+                            style="gap:8px;"
+                        >
+                            <svg class="animate-spin text-accent" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                <path d="M21 12a9 9 0 1 1-6.219-8.56"/>
+                            </svg>
+                            <span class="text-text-secondary" style="font-size:12px;">Загрузка файла…</span>
+                        </div>
+
+                        {{-- Selected file chip --}}
+                        @if($attachment)
+                            <div wire:loading.remove wire:target="attachment" class="flex items-center mb-2" style="gap:8px;">
+                                <div class="flex items-center max-w-full" style="gap:8px; background:#EEF1FE; border:1px solid #D5DBF9; border-radius:8px; padding:6px 10px;">
+                                    <svg class="shrink-0 text-accent" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                        <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><polyline points="14 2 14 8 20 8"/>
+                                    </svg>
+                                    <span class="truncate text-text-primary" style="font-size:12px; max-width:220px;">{{ $attachment->getClientOriginalName() }}</span>
+                                    <button
+                                        type="button"
+                                        wire:click="removeAttachment"
+                                        class="flex shrink-0 items-center justify-center text-text-secondary transition hover:text-red-500"
+                                        style="width:16px; height:16px; border:none; background:transparent; cursor:pointer; line-height:1; font-size:16px;"
+                                        aria-label="Убрать файл"
+                                        title="Убрать файл"
+                                    >&times;</button>
+                                </div>
+                            </div>
+                        @endif
+
+                        @error('attachment')
+                            <p class="mb-2 text-xs text-red-500">{{ $message }}</p>
+                        @enderror
+                    @endif
+
                     {{-- Input row: attach + textarea + send --}}
                     {{-- Design: FEYxe (attach 40×40) + Euru3 (input, fill, bg-input, rounded-12) + K6yaRa (send 44×44 bg-accent rounded-12) --}}
                     <form wire:submit.prevent="sendReply" class="flex items-center" style="gap:12px;">
 
-                        {{-- Attach icon (visual only) --}}
-                        <div class="flex items-center justify-center shrink-0 text-text-secondary" style="width:40px; height:40px; border-radius:10px;" aria-hidden="true">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                <path d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l8.57-8.57A4 4 0 1 1 18 8.84l-8.59 8.57a2 2 0 0 1-2.83-2.83l8.49-8.48"/>
-                            </svg>
-                        </div>
+                        {{-- Attach button (telegram + vk only) --}}
+                        @if($this->supportsAttachments())
+                            <label
+                                class="flex items-center justify-center shrink-0 text-text-secondary cursor-pointer transition hover:text-accent hover:bg-bg-secondary"
+                                style="width:40px; height:40px; border-radius:10px;"
+                                title="Прикрепить файл"
+                                aria-label="Прикрепить файл"
+                            >
+                                <input type="file" wire:model="attachment" class="hidden" aria-hidden="true">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                    <path d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l8.57-8.57A4 4 0 1 1 18 8.84l-8.59 8.57a2 2 0 0 1-2.83-2.83l8.49-8.48"/>
+                                </svg>
+                            </label>
+                        @endif
 
                         {{-- Text input --}}
                         <div class="relative flex-1">
@@ -385,7 +463,7 @@
                         <button
                             type="submit"
                             wire:loading.attr="disabled"
-                            wire:target="sendReply"
+                            wire:target="sendReply,attachment"
                             class="flex shrink-0 items-center justify-center text-white transition hover:opacity-90 disabled:opacity-50"
                             style="width:44px; height:44px; border-radius:12px; background:#4F6EF7; border:none; cursor:pointer;"
                             aria-label="Отправить"
@@ -413,7 +491,12 @@
     {{-- Design: node VdLTH — width 300, padding [24,20], gap 20, bg-primary, border-left --}}
     @if($activeBotUser)
         <aside
-            class="hidden lg:flex shrink-0 flex-col bg-bg-primary overflow-y-auto border-l border-border-light"
+            x-show="infoPanelOpen"
+            x-cloak
+            x-transition:enter="transition ease-out duration-200"
+            x-transition:enter-start="opacity-0"
+            x-transition:enter-end="opacity-100"
+            class="flex shrink-0 flex-col bg-bg-primary overflow-y-auto border-l border-border-light"
             style="width:300px; gap:20px; padding:24px 20px;"
         >
 
@@ -457,32 +540,62 @@
                 {{-- Design: node uYnHt — gap 8 --}}
                 {{-- Block = bg #FEE2E2 text #DC2626; Close = bg bg-input text-primary --}}
                 <div class="flex" style="gap:8px;">
-                    {{-- Блок button (visual — ban logic is handled by existing CloseTopic/BanMessage flow, wiring to a Filament action is outside scope) --}}
-                    <button
-                        type="button"
-                        class="flex items-center transition hover:opacity-90"
-                        style="background:#FEE2E2; color:#DC2626; border-radius:8px; padding:6px 14px; font-size:12px; font-weight:500; gap:6px; border:none; cursor:pointer;"
-                        aria-label="Заблокировать пользователя"
-                        title="Блокировка пользователя"
-                    >
-                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                            <circle cx="12" cy="12" r="10"/><path d="m4.9 4.9 14.2 14.2"/>
-                        </svg>
-                        Блок
-                    </button>
+                    {{-- Блок / Разблокировать — toggles via banUser()/unbanUser() --}}
+                    @php $isBanned = (bool) $activeBotUser->is_banned; @endphp
+                    @if($isBanned)
+                        <button
+                            type="button"
+                            wire:click="unbanUser"
+                            wire:confirm="Разблокировать пользователя? Он снова сможет писать в поддержку."
+                            wire:loading.attr="disabled"
+                            wire:target="unbanUser"
+                            class="flex items-center transition hover:opacity-90 disabled:opacity-50"
+                            style="background:#DCFCE7; color:#16A34A; border-radius:8px; padding:6px 14px; font-size:12px; font-weight:500; gap:6px; border:none; cursor:pointer;"
+                            aria-label="Разблокировать пользователя"
+                            title="Разблокировать пользователя"
+                        >
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                <rect width="18" height="11" x="3" y="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 9.9-1"/>
+                            </svg>
+                            Разблокировать
+                        </button>
+                    @else
+                        <button
+                            type="button"
+                            wire:click="banUser"
+                            wire:confirm="Заблокировать пользователя? Его сообщения перестанут приниматься, а диалог будет закрыт."
+                            wire:loading.attr="disabled"
+                            wire:target="banUser"
+                            class="flex items-center transition hover:opacity-90 disabled:opacity-50"
+                            style="background:#FEE2E2; color:#DC2626; border-radius:8px; padding:6px 14px; font-size:12px; font-weight:500; gap:6px; border:none; cursor:pointer;"
+                            aria-label="Заблокировать пользователя"
+                            title="Блокировка пользователя"
+                        >
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                <circle cx="12" cy="12" r="10"/><path d="m4.9 4.9 14.2 14.2"/>
+                            </svg>
+                            Блок
+                        </button>
+                    @endif
 
-                    {{-- Закрыть button (visual — close logic unchanged) --}}
+                    {{-- Закрыть button — runs the canonical CloseTopic flow via closeDialog() --}}
+                    @php $isClosed = (bool) $activeBotUser->is_closed; @endphp
                     <button
                         type="button"
-                        class="flex items-center transition hover:opacity-90"
+                        wire:click="closeDialog"
+                        wire:confirm="Закрыть диалог? Пользователю придёт уведомление о закрытии и форма оценки."
+                        wire:loading.attr="disabled"
+                        wire:target="closeDialog"
+                        @disabled($isClosed)
+                        class="flex items-center transition hover:opacity-90 disabled:opacity-50 disabled:cursor-default"
                         style="background:#F1F3F5; color:#1A1D26; border-radius:8px; padding:6px 14px; font-size:12px; font-weight:500; gap:6px; border:none; cursor:pointer;"
                         aria-label="Закрыть диалог"
-                        title="Закрыть тикет"
+                        title="{{ $isClosed ? 'Диалог уже закрыт' : 'Закрыть тикет' }}"
                     >
                         <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                             <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><path d="m9 11 3 3L22 4"/>
                         </svg>
-                        Закрыть
+                        {{ $isClosed ? 'Закрыто' : 'Закрыть' }}
                     </button>
                 </div>
             </div>
@@ -540,35 +653,6 @@
                     </div>
                 </div>
 
-                {{-- Обращений — message-circle icon --}}
-                {{-- Design: node Kdzjz --}}
-                <div class="flex items-center w-full" style="gap:10px;">
-                    <svg class="shrink-0 text-text-secondary" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                        <path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z"/>
-                    </svg>
-                    <div class="flex flex-col" style="gap:2px;">
-                        <span class="text-text-secondary" style="font-size:11px;">Обращений</span>
-                        <span class="text-text-primary" style="font-size:13px;">{{ $chatMessages->count() }}</span>
-                    </div>
-                </div>
-
-                {{-- Язык — globe icon --}}
-                {{-- Design: node jED9J --}}
-                <div class="flex items-center w-full" style="gap:10px;">
-                    <svg class="shrink-0 text-text-secondary" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                        <circle cx="12" cy="12" r="10"/><path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20"/><path d="M2 12h20"/>
-                    </svg>
-                    <div class="flex flex-col" style="gap:2px;">
-                        <span class="text-text-secondary" style="font-size:11px;">Язык</span>
-                        <span class="text-text-primary" style="font-size:13px;">
-                            @if(isset($activeBotUser->language_code) && $activeBotUser->language_code)
-                                {{ strtoupper($activeBotUser->language_code) }}
-                            @else
-                                —
-                            @endif
-                        </span>
-                    </div>
-                </div>
             </div>
 
             {{-- Divider --}}

--- a/resources/views/livewire/settings/api-webhook-source-page.blade.php
+++ b/resources/views/livewire/settings/api-webhook-source-page.blade.php
@@ -153,38 +153,23 @@
                     />
                 </x-admin.form-field>
 
-                {{-- Секретный ключ — design placeholder, no backend yet --}}
+                {{-- Разрешённые IP — allowlist of sources permitted to call the API --}}
                 <x-admin.form-field
-                    label="Секретный ключ"
-                    for="secret_key_placeholder"
-                    hint="Для верификации входящих запросов · скоро"
+                    label="Разрешённые IP-адреса"
+                    for="allowed_ips"
+                    hint="Источники, с которых разрешены запросы. По одному IP в строке. Пусто — без ограничений."
+                    :error="$allowedIpsError"
                 >
-                    <input
-                        id="secret_key_placeholder"
-                        type="text"
-                        disabled
-                        placeholder="whsec_xxxxxxxxxxxxxxxx"
-                        class="block w-full cursor-not-allowed rounded-lg border border-border-light bg-bg-input px-3.5 py-2.5 text-sm text-text-secondary placeholder-text-secondary opacity-70 outline-none"
-                    />
+                    <textarea
+                        id="allowed_ips"
+                        wire:model="allowedIps"
+                        rows="4"
+                        placeholder="203.0.113.10&#10;198.51.100.0&#10;2001:db8::1"
+                        class="block w-full resize-y rounded-lg border border-border-light bg-bg-input px-3.5 py-2.5 font-mono text-sm text-text-primary placeholder-text-secondary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/20
+                            @if ($allowedIpsError) border-red-400 @endif"
+                    ></textarea>
                 </x-admin.form-field>
 
-            </div>
-
-            {{-- ── События — design placeholder toggles, no backend yet ──────── --}}
-            <div class="mt-5 flex flex-col gap-3 opacity-70">
-                <span class="text-[13px] font-medium text-text-primary">
-                    События <span class="font-normal text-text-secondary">· скоро</span>
-                </span>
-
-                @foreach ([['Новое сообщение', true], ['Закрытие обращения', true], ['Новый клиент', false], ['Ошибка доставки', false]] as [$eventLabel, $eventOn])
-                    <div class="flex items-center justify-between">
-                        <span class="text-[13px] text-text-primary">{{ $eventLabel }}</span>
-                        <span aria-disabled="true"
-                              class="relative flex h-6 w-10 shrink-0 cursor-not-allowed items-center rounded-full border-2 border-transparent p-0.5 {{ $eventOn ? 'bg-accent' : 'bg-border-light' }}">
-                            <span class="h-5 w-5 rounded-full bg-white shadow {{ $eventOn ? 'translate-x-4' : 'translate-x-0' }}"></span>
-                        </span>
-                    </div>
-                @endforeach
             </div>
 
             {{-- Actions row — right-aligned: «Отмена» + «Сохранить» --}}
@@ -228,31 +213,6 @@
                 {{-- Base URL --}}
                 <p class="mb-3 text-xs text-text-secondary">Базовый URL:</p>
                 <code class="mb-4 block break-all rounded bg-bg-input px-2.5 py-1.5 font-mono text-xs text-text-primary">{{ rtrim(config('app.url'), '/') }}</code>
-
-                {{-- Endpoint list --}}
-                <div class="space-y-2">
-                    @foreach ([
-                        ['GET',    "/api/external/{$sourceId}/messages",  'Список сообщений'],
-                        ['POST',   "/api/external/{$sourceId}/messages",  'Отправить сообщение'],
-                        ['PUT',    "/api/external/{$sourceId}/messages",  'Обновить'],
-                        ['DELETE', "/api/external/{$sourceId}/messages",  'Удалить'],
-                        ['POST',   "/api/external/{$sourceId}/files",     'Загрузить файл'],
-                    ] as [$method, $path, $label])
-                        <div class="flex items-start gap-2">
-                            <span class="mt-0.5 shrink-0 rounded px-1.5 py-0.5 font-mono text-[10px] font-bold
-                                @if ($method === 'GET') bg-blue-100 text-blue-700
-                                @elseif ($method === 'POST') bg-green-100 text-green-700
-                                @elseif ($method === 'PUT') bg-yellow-100 text-yellow-700
-                                @else bg-red-100 text-red-700 @endif">
-                                {{ $method }}
-                            </span>
-                            <div class="min-w-0">
-                                <code class="block break-all font-mono text-[11px] text-text-primary">{{ $path }}</code>
-                                <span class="text-[11px] text-text-secondary">{{ $label }}</span>
-                            </div>
-                        </div>
-                    @endforeach
-                </div>
 
                 {{-- Auth note --}}
                 <div class="mt-4 rounded-lg bg-bg-input px-3 py-2.5">

--- a/resources/views/livewire/settings/api-webhooks-page.blade.php
+++ b/resources/views/livewire/settings/api-webhooks-page.blade.php
@@ -11,7 +11,7 @@
         <h2 class="mb-4 text-base font-semibold text-text-primary">Добавить источник</h2>
 
         {{-- Form row: name + button — desktop side-by-side, mobile stacked --}}
-        <div class="flex flex-col gap-4 sm:flex-row sm:items-end">
+        <div class="flex flex-col gap-4 sm:flex-row sm:items-center">
             {{-- Name field --}}
             <div class="flex-1 space-y-1.5">
                 <label for="newSourceName" class="block text-[13px] font-medium text-text-primary">Название источника</label>

--- a/resources/views/livewire/settings/general-settings-page.blade.php
+++ b/resources/views/livewire/settings/general-settings-page.blade.php
@@ -6,44 +6,12 @@
         <p class="mt-1 text-sm text-text-secondary">Общие настройки бота и параметры работы</p>
     </div>
 
-    {{-- Card: Bot info --}}
-    <x-admin.card title="Информация о боте">
+    {{-- Card: Conversation settings --}}
+    <x-admin.card title="Обращения">
         <form wire:submit="save" novalidate>
             @csrf
 
             <div class="space-y-5">
-
-                {{-- Bot name --}}
-                <x-admin.form-field
-                    label="Название бота"
-                    for="bot_name"
-                    :error="$formErrors['bot_name'] ?? null"
-                >
-                    <input
-                        id="bot_name"
-                        type="text"
-                        wire:model="bot_name"
-                        maxlength="255"
-                        placeholder="TG Support Bot"
-                        class="block w-full rounded-lg border border-border-light bg-bg-input px-3.5 py-2.5 text-sm text-text-primary placeholder-text-secondary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/20 @if (!empty($formErrors['bot_name'])) border-red-400 @endif"
-                    />
-                </x-admin.form-field>
-
-                {{-- Description --}}
-                <x-admin.form-field
-                    label="Описание"
-                    for="bot_description"
-                    hint="Отображается в настройках клиента"
-                    :error="$formErrors['bot_description'] ?? null"
-                >
-                    <textarea
-                        id="bot_description"
-                        wire:model="bot_description"
-                        maxlength="1000"
-                        rows="3"
-                        class="block w-full resize-none rounded-lg border border-border-light bg-bg-input px-3.5 py-2.5 text-sm text-text-primary placeholder-text-secondary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/20 @if (!empty($formErrors['bot_description'])) border-red-400 @endif"
-                    ></textarea>
-                </x-admin.form-field>
 
                 {{-- Topic name template --}}
                 <x-admin.form-field
@@ -62,36 +30,6 @@
                     />
                 </x-admin.form-field>
 
-                {{-- Manager interface --}}
-                <x-admin.form-field
-                    label="Интерфейс менеджера"
-                    for="manager_interface"
-                    :error="$formErrors['manager_interface'] ?? null"
-                >
-                    <div class="flex gap-3">
-                        <label class="flex flex-1 cursor-pointer items-center gap-2.5 rounded-lg border px-4 py-3 transition
-                            @if ($manager_interface === 'telegram_group') border-accent bg-accent/5 @else border-border-light bg-bg-input hover:border-accent/50 @endif">
-                            <input
-                                type="radio"
-                                wire:model.live="manager_interface"
-                                value="telegram_group"
-                                class="accent-accent"
-                            />
-                            <span class="text-sm font-medium text-text-primary">telegram_group</span>
-                        </label>
-                        <label class="flex flex-1 cursor-pointer items-center gap-2.5 rounded-lg border px-4 py-3 transition
-                            @if ($manager_interface === 'admin_panel') border-accent bg-accent/5 @else border-border-light bg-bg-input hover:border-accent/50 @endif">
-                            <input
-                                type="radio"
-                                wire:model.live="manager_interface"
-                                value="admin_panel"
-                                class="accent-accent"
-                            />
-                            <span class="text-sm font-medium text-text-primary">admin_panel</span>
-                        </label>
-                    </div>
-                </x-admin.form-field>
-
             </div>
 
             {{-- Action row --}}
@@ -104,21 +42,8 @@
                 </x-admin.button-primary>
             </div>
 
-            {{-- Restart notice --}}
-            @if ($showRestartNotice)
-                <div class="mt-4 flex items-start gap-3 rounded-xl border border-yellow-200 bg-yellow-50 px-4 py-3 text-sm text-yellow-800">
-                    <svg xmlns="http://www.w3.org/2000/svg" class="mt-0.5 h-4 w-4 shrink-0 text-yellow-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-                    </svg>
-                    <span>
-                        Изменение применится после перезапуска контейнера:
-                        <code class="rounded bg-yellow-100 px-1 py-0.5 font-mono text-xs">docker compose restart app</code>
-                    </span>
-                </div>
-            @endif
-
             {{-- Success banner --}}
-            @if ($saved && ! $showRestartNotice)
+            @if ($saved)
                 <div class="mt-4 flex items-center gap-2 rounded-xl border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-800">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 shrink-0 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />

--- a/rules/database/schema.md
+++ b/rules/database/schema.md
@@ -170,6 +170,9 @@ Core table. Stores every user that has interacted with the bot across all platfo
 | `external_source_id` | `string` | Yes | NULL | External source identifier (for `external_source` platform) |
 | `is_banned` | `boolean` | No | `false` | Whether user is banned from sending messages |
 | `banned_at` | `timestamp` | Yes | NULL | When the user was banned |
+| `is_closed` | `boolean` | No | `false` | Whether the conversation is closed |
+| `closed_at` | `timestamp` | Yes | NULL | When the conversation was closed |
+| `manager_last_read_at` | `timestamp` | Yes | NULL | When a manager last opened the dialog in the chat workspace; drives the unread indicator (BR-003e) |
 | `created_at` | `timestamp` | Yes | NULL | First interaction time |
 | `updated_at` | `timestamp` | Yes | NULL | Last update time |
 
@@ -263,6 +266,7 @@ Registry of all external integrations. Each source has a unique name and optiona
 | `id` | `bigint` | No | auto | Primary key |
 | `name` | `string` | No | — | Unique source identifier |
 | `webhook_url` | `string` | Yes | NULL | URL to call when the support team sends a reply |
+| `allowed_ips` | `json` | Yes | NULL | Allowlist of IPs the API accepts requests from; NULL/empty = no restriction (enforced by `ApiQuery` middleware) |
 | `created_at` | `timestamp` | Yes | NULL | Creation time |
 | `updated_at` | `timestamp` | Yes | NULL | Last update time |
 

--- a/rules/domain/admin-panel.md
+++ b/rules/domain/admin-panel.md
@@ -24,7 +24,7 @@ The Admin Panel domain provides an alternative manager interface for the support
 |---|---|
 | `ManagerInterfaceContract` | Interface that decouples manager UI from business logic. Implementations: `TelegramGroupInterface`, `AdminPanelInterface` |
 | `AdminPanelInterface` | Implementation of `ManagerInterfaceContract` for `admin_panel` mode. Both methods are no-ops — messages arrive via DB, UI updates via Livewire polling |
-| `App\Livewire\Chat\ConversationPage` | **Primary manager workspace** — standalone full-page Livewire component at `GET /admin/chats`. Full-screen, chrome-free (no Filament top-nav/sidebar). Uses `layouts.admin-chat` layout. 3-column layout: left sidebar 360px dark (header + search + pill-filter tabs + dialog list), center chat area (header + message thread + input bar with quick-reply chips), right user info panel 300px (profile + Блок/Закрыть buttons + ИНФОРМАЦИЯ rows + МЕДИАФАЙЛЫ grid). Self-contained — no `botUserId` route param. Dialog selection via `selectChat(int $botUserId)`. Protected by `Filament\Http\Middleware\Authenticate` |
+| `App\Livewire\Chat\ConversationPage` | **Primary manager workspace** — standalone full-page Livewire component at `GET /admin/chats`. Full-screen, chrome-free (no Filament top-nav/sidebar). Uses `layouts.admin-chat` layout. 3-column layout: left sidebar 360px dark (header + search + pill-filter tabs + dialog list), center chat area (header + message thread + input bar with quick-reply chips + optional file attachment for telegram/vk), right user info panel 300px (profile + Блок/Закрыть buttons + ИНФОРМАЦИЯ rows + МЕДИАФАЙЛЫ grid) — **hidden by default, toggled by the 3-dots button in the chat header** via the Alpine `infoPanelOpen` flag (client-side only, no Livewire round-trip). Self-contained — no `botUserId` route param. Dialog selection via `selectChat(int $botUserId)`. Protected by `Filament\Http\Middleware\Authenticate` |
 | Filament navigation | The Filament panel keeps no resources, pages, widgets or dashboard — it serves only login. Links to the custom screens are registered in `AdminPanelProvider::navigationItems()`: «Диалоги» → `route('admin.chats')` (sort 1) and «Настройки» → `route('admin.settings.general')` (sort 2). `->homeUrl()` and the first nav item both point at `/admin/chats`, so `/admin` and post-login both land on «Диалоги» |
 | Dialog list ordering | `ConversationPage::loadDialogList()` uses a raw correlated subquery to order by `MAX(messages.created_at) DESC` because `BotUser::messages()` has swapped FK args. Do not switch to `withMax()` without fixing the model relation |
 | Quick replies | Static list from `config('chat.quick_replies')` — clicking a chip calls `insertQuickReply($text)` which sets `$replyText`. No DB table |
@@ -34,9 +34,10 @@ The Admin Panel domain provides an alternative manager interface for the support
 | `SendReplyAction` | Static action that dispatches the correct queue job (Telegram, VK, or Webhook) based on `botUser->platform` |
 | Livewire Polling | `ConversationPage` refreshes every 5 seconds via `getPollingInterval(): '5s'` |
 | `MANAGER_INTERFACE` | Config key. Values: `telegram_group` (default) or `admin_panel`. Readable from `.env` OR from the `settings` DB table via `SettingsService` (DB row overrides env) |
-| `GeneralSettingsPage` | Custom Livewire full-page component at `/admin/settings/general` — edits bot name, description, the Telegram topic-name template (`telegram.template_topic_name`), and `MANAGER_INTERFACE`. Requires authenticated user (Filament `Authenticate` middleware redirects guests to `/admin/login`). Saves via `SettingsService`. Shows restart notice when `MANAGER_INTERFACE` changes |
+| `GeneralSettingsPage` | Custom Livewire full-page component at `/admin/settings/general` — edits only the Telegram topic-name template (`telegram.template_topic_name`). Bot name, description, and `MANAGER_INTERFACE` were removed from this screen. Requires authenticated user (Filament `Authenticate` middleware redirects guests to `/admin/login`). Saves via `SettingsService` |
 | Admin Design System | Tailwind v4 tokens in `resources/css/app.css @theme` (accent, sidebar, input, text colours; Inter font). Shared Blade components: `<x-admin.sidebar>`, `<x-admin.nav-item>`, `<x-admin.card>`, `<x-admin.form-field>`, `<x-admin.button-primary>`, `<x-admin.button-secondary>`, `<x-admin.toggle>` |
 | `admin-settings` layout | Full-page layout at `resources/views/layouts/admin-settings.blade.php` — dark sidebar (280px) + main content area. Used by all custom Livewire settings screens |
+| Logout control | «Выйти» posts to `route('filament.admin.auth.logout')` (`POST /admin/logout`, Filament). Rendered in two spots: a row at the bottom of `<x-admin.sidebar>` (settings screens) and an icon button next to the settings gear in the `ConversationPage` left panel header (chat workspace). Both are `<form method="POST">` with `@csrf` |
 | `IntegrationsListPage` | Custom Livewire full-page component at `/admin/settings/integrations`. Shows Telegram/VK/MAX channel cards with connection status badges. Reads statuses via `ChannelStatusService`. «Виджет для сайта» shown as disabled «Скоро» placeholder |
 | `IntegrationChannelPage` | Custom Livewire full-page component at `/admin/settings/integrations/{channel}` (channel ∈ telegram\|telegram_ai\|vk\|max). Per-channel config form (read/write via `SettingsService`). Primary action button is **«Сохранить»** — runs a **verify-before-save** flow: (1) field validation, (2) token verification via `WebhookRegistrationService::verifyX($token)` (entered value or stored fallback), (3) persist settings only on verification success, (4) register webhook (telegram\|vk\|max) or show success notice (telegram_ai — no webhook registration via UI; uses `php artisan ai-bot:set-webhook`) |
 | `ChannelStatusService` | `app/Modules/Admin/Services/ChannelStatusService.php`. Computes `connected/label` per channel based on whether required `SettingsService` keys are non-empty. Shared by list and per-channel pages |
@@ -49,17 +50,32 @@ The Admin Panel domain provides an alternative manager interface for the support
 **BR-001** — The `/admin` panel is accessible only to authenticated users from the `users` table (Laravel Filament auth). Unauthenticated requests are redirected to `/admin/login`.
 _Enforced in:_ `app/Modules/Admin/AdminPanelProvider.php`
 
-**BR-002** — In `telegram_group` mode, the reply form in `ConversationPage` must be hidden. Read-only view of messages is available in both modes.
-_Enforced in:_ `App\Livewire\Chat\ConversationPage::shouldShowReplyForm()` — returns `config('app.manager_interface') === 'admin_panel'`
+**BR-002** — The reply form in `ConversationPage` is shown in **both** modes (`telegram_group` and `admin_panel`). `SendReplyAction` routes the reply by `BotUser.platform` and does not depend on `MANAGER_INTERFACE`, so a manager can reply directly from the `/admin/chats` workspace regardless of the active interface mode.
+_Enforced in:_ `App\Livewire\Chat\ConversationPage::shouldShowReplyForm()` — returns `true`
 
-**BR-003** — `SendReplyAction::execute()` must determine the user's platform from `botUser->platform` and dispatch the correct job via queue. Never send synchronously.
-- `telegram` → `SendTelegramSimpleQueryJob`
-- `vk` → `SendVkSimpleMessageJob`
-- other (external) → `SendWebhookMessage` (only if `webhook_url` is set)
+**BR-003** — `SendReplyAction::execute(BotUser, string $text, ?UploadedFile $file = null)` must determine the user's platform from `botUser->platform` and dispatch the correct job via queue. Never send synchronously.
+- `telegram` → `SendTelegramSimpleQueryJob` (text) / `SendAdminDocumentJob` (with file)
+- `vk` → `SendVkSimpleMessageJob` (file uploaded via `docs.getMessagesUploadServer` → `docs.save`, attached as `doc{owner}_{id}`)
+- other (external/max) → `SendWebhookMessage` (text only, only if `webhook_url` is set — **files are not delivered**)
 
 _Enforced in:_ `app/Modules/Admin/Actions/SendReplyAction.php`
 
-**BR-004** — Livewire polling interval is 5 seconds (`getPollingInterval(): '5s'`). Do not change without load analysis — each open browser tab generates a DB query every 5 seconds.
+**BR-003a** — The reply form supports an optional file attachment via `ConversationPage::$attachment` (Livewire `WithFileUploads`, `max:20480` KB). Text is required only when no file is attached (file-only messages are allowed). The attach control is shown — and the file passed to `SendReplyAction` — only when `supportsAttachments()` is true (platform ∈ `telegram|vk`); for external/max the attachment is ignored so files are never silently dropped into a text-only webhook.
+_Enforced in:_ `App\Livewire\Chat\ConversationPage::sendReply()` / `supportsAttachments()` / `removeAttachment()`
+
+**BR-003b** — The right-panel «Закрыть» button runs the canonical close flow `App\Modules\Telegram\Actions\CloseTopic::execute()` (notify user, close the Telegram forum topic when present, set `is_closed`/`closed_at`, trigger the feedback form). It is a no-op when there is no active dialog or it is already closed, and is disabled in the UI once the dialog is closed.
+_Enforced in:_ `App\Livewire\Chat\ConversationPage::closeDialog()`
+
+**BR-003c** — The right-panel ban control is a **toggle**: when the user is not banned it shows «Блок» and runs `App\Modules\Admin\Actions\BanBotUser::execute()` (marks `is_banned`/`banned_at` and terminal `is_closed`/`closed_at`, closes the Telegram forum topic when present; **no feedback form** unlike close). When the user is banned it shows «Разблокировать» and runs `App\Modules\Admin\Actions\UnbanBotUser::execute()` (clears `is_banned`/`banned_at`; **does not** change `is_closed` — the conversation stays closed until a reply re-opens it per BR-003d). Both are no-ops in the wrong state. Banned users' incoming messages are rejected by the platform webhook controllers via `BotUser::isBanned()`. In the dialog list a banned conversation shows a «Заблокирован» badge (takes priority over the «Закрыт» badge).
+_Enforced in:_ `App\Livewire\Chat\ConversationPage::banUser()` / `unbanUser()`, `App\Modules\Admin\Actions\BanBotUser` / `UnbanBotUser`, `resources/views/components/chat-item.blade.php`
+
+**BR-003d** — Sending a reply via `SendReplyAction::execute()` **re-opens** a closed conversation: if `is_closed` is true it is reset to false and `closed_at` to null before the message is persisted. This applies to replies sent from the chat workspace (any platform). The feedback-rating message (written directly by `HandleFeedbackRating`, not via `SendReplyAction`) does **not** re-open the conversation.
+_Enforced in:_ `App\Modules\Admin\Actions\SendReplyAction::execute()`
+
+**BR-003e** — The dialog-list "new message" indicator (`hasUnread`) is shown only when the **last** message is incoming (`lastMessage->message_type === 'incoming'`) AND the conversation is open (not `is_closed`, not `is_banned`) AND it is not the currently active dialog (`activeBotUserId`) AND the last message arrived **after** `bot_users.manager_last_read_at`. Opening a dialog (`selectChat()`) stamps `manager_last_read_at = now()`, so the cleared indicator **persists across page reloads** (it is not just in-memory session state). A later incoming message (newer than the read stamp) re-flags the dialog. This is conversation-level read tracking — there is still no per-message read state.
+_Enforced in:_ `App\Livewire\Chat\ConversationPage::hasUnread()` / `selectChat()`, column `bot_users.manager_last_read_at`
+
+**BR-004** — Livewire polling interval is 5 seconds. The poll target is `pollUpdates()` (`wire:poll.5s`), which refreshes the dialog list and — when a dialog is open — reloads the active message thread, so incoming messages appear in the centre pane without a manual refresh. It scrolls to the bottom (and bumps `manager_last_read_at`) only when the message count grew, so a manager scrolled up reading history is not yanked down each tick. `loadMessages()` is a pure loader; callers (`selectChat`, `sendReply`, `pollUpdates`) emit the `messages-updated` browser event when a scroll is wanted. Do not change the interval without load analysis — each open browser tab generates DB queries every 5 seconds.
 _Enforced in:_ `App\Livewire\Chat\ConversationPage::getPollingInterval()`
 
 **BR-005** — Every reply sent via `SendReplyAction` must be persisted to the `messages` table as `message_type = 'outgoing'` before dispatching the queue job.
@@ -74,11 +90,10 @@ _Enforced in:_ `AdminPanelInterface::createConversation()` — empty body
 **BR-008** — The General Settings screen (`/admin/settings/general`, `app/Livewire/Settings/GeneralSettingsPage.php`) requires an authenticated user. Unauthenticated visitors are redirected to `/admin/login` by Filament's `Authenticate` middleware applied in `AdminServiceProvider::boot()`. The route does not add a separate admin-role guard at the middleware layer — access is open to any authenticated user; role enforcement can be added to `mount()` if needed in future.
 _Enforced in:_ `AdminServiceProvider::boot()` — `Route::middleware(['web', Authenticate::class])->prefix('admin/settings')...`
 
-**BR-009** — Settings editable from the General Settings screen (`app.bot_name`, `app.bot_description`, `telegram.template_topic_name`, `app.manager_interface`) are persisted via `SettingsService::set()` to the `settings` DB table. On read, DB rows take priority over `.env`/`config()` defaults. (`telegram.template_topic_name` lives in General settings, not the Telegram integration screen.)
-_Enforced in:_ `GeneralSettingsPage::save()` — calls `SettingsService::set()` for each field; `GeneralSettingsPage::mount()` — loads via `SettingsService::get()`
+**BR-009** — The only setting editable from the General Settings screen is `telegram.template_topic_name`, persisted via `SettingsService::set()` to the `settings` DB table. On read, DB rows take priority over `.env`/`config()` defaults. (Bot name, description, and `app.manager_interface` were removed from this screen.)
+_Enforced in:_ `GeneralSettingsPage::save()` — calls `SettingsService::set('telegram.template_topic_name', …)`; `GeneralSettingsPage::mount()` — loads via `SettingsService::get()`
 
-**BR-010** — Changing `MANAGER_INTERFACE` from the General Settings screen saves the new value to the DB, but the `ManagerInterfaceContract` DI binding in `AppServiceProvider::register()` is resolved from `config('app.manager_interface')` at container boot time. The change takes full effect only after `docker compose restart app`. Upon save, the screen must display a persistent yellow notice: "Изменение применится после перезапуска контейнера: `docker compose restart app`".
-_Enforced in:_ `GeneralSettingsPage::save()` — detects interface change (old vs new) and sets `$showRestartNotice = true`
+**BR-010** — `MANAGER_INTERFACE` is **no longer editable from the admin panel**. It is switched only via the `.env` file (`MANAGER_INTERFACE=…`) followed by `docker compose restart app`, because the `ManagerInterfaceContract` DI binding in `AppServiceProvider::register()` is resolved from `config('app.manager_interface')` at container boot time. (The previous General-Settings radio + restart notice were removed.)
 
 **BR-011** — Admin Design System tokens are declared in `resources/css/app.css @theme` (Tailwind v4). All custom admin screens MUST use the token variables (`bg-sidebar`, `text-accent`, `bg-bg-input`, etc.) — never hardcode hex values in Blade. Blade components under `resources/views/components/admin/` are the single source for reusable UI primitives.
 _Enforced by:_ design review; tokens defined at `resources/css/app.css:@theme`
@@ -124,7 +139,7 @@ _Enforced in:_ `AdminPanelProvider::panel()` → `->navigationItems([...])`
 
 **BR-023** — The "API и вебхуки" section consists of two pages, both restricted to admin-role users only. Non-admin authenticated users are redirected to `admin.settings.general` in `mount()` via `Auth::user()->isAdmin()`.
 - **List page** (`/admin/settings/api-webhooks`, `ApiWebhooksPage`): shows External Source cards with token/webhook status; "Добавить источник" creates a source and redirects to the edit page.
-- **Edit page** (`/admin/settings/api-webhooks/{source}`, `ApiWebhookSourcePage`): per-source configuration — bearer token regeneration (one-time reveal, 64 chars, never logged), webhook URL editing, design-placeholder fields (secret key + events).
+- **Edit page** (`/admin/settings/api-webhooks/{source}`, `ApiWebhookSourcePage`): per-source configuration — bearer token regeneration (one-time reveal, 64 chars, never logged), webhook URL editing, and an **allowed-IPs allowlist** (`external_sources.allowed_ips`). The previous secret-key and events design placeholders were removed.
 Token values are never logged or displayed in full — only a one-time reveal banner shown immediately after regeneration, stored in `$newToken` and cleared on dismiss.
 _Enforced in:_ `ApiWebhooksPage::mount()` and `ApiWebhookSourcePage::mount()` — `isAdmin()` check; `ApiWebhookSourcePage::regenerateToken()` — stores raw token in `$newToken` only, never logged
 
@@ -194,8 +209,7 @@ The binding is resolved at container boot time from `config()`. The binding does
 - Switching mode does **not** modify any DB records
 - `BotUser.topic_id` is preserved after switching to `admin_panel` — it is simply ignored in this mode
 - History in `/admin` is available in both modes (all messages in `messages` table)
-- **Via `.env`**: change `MANAGER_INTERFACE` in `.env`, then `docker compose restart app`
-- **Via admin panel** (General Settings page): save the new mode via the form; the value is stored in the `settings` DB table (overrides `.env` on next read via `SettingsService`); a restart notification is shown — execute `docker compose restart app` to apply
+- **Via `.env` only**: change `MANAGER_INTERFACE` in `.env`, then `docker compose restart app`. (The admin-panel switch was removed — `MANAGER_INTERFACE` is no longer editable from the General Settings screen.)
 
 ---
 
@@ -207,20 +221,19 @@ The binding is resolved at container boot time from `config()`. The binding does
 
 **Sidebar navigation**: 7 items. «Основные», «Интеграции», «ИИ-ассистент», «API и вебхуки», and «Команда» are active/linked; «Уведомления» and «Автоответы» remain disabled placeholders (`disabled` prop on `<x-admin.nav-item>`). They become real links as their respective tasks are implemented.
 
-**Form fields** (all persisted via `SettingsService`):
+**Form fields** (persisted via `SettingsService`):
 | Field | Setting key | Validation |
 |---|---|---|
-| Название бота | `app.bot_name` | nullable, string, max:255 |
-| Описание | `app.bot_description` | nullable, string, max:1000 |
 | Шаблон названия топика | `telegram.template_topic_name` | nullable, string, max:255 |
-| Интерфейс менеджера | `app.manager_interface` | required, in:telegram_group,admin_panel |
+
+(Bot name `app.bot_name`, description `app.bot_description`, and the manager-interface radio `app.manager_interface` were removed from this screen.)
 
 **Component property naming**: uses `$formErrors` (not `$errors`) to avoid shadowing Blade's global `$errors` bag.
 
 **Route**: `GET /admin/settings/general` → name `admin.settings.general`; registered in `AdminServiceProvider::boot()` under `['web', Filament\Http\Middleware\Authenticate::class]`.
 
 **Tests**:
-- `tests/Feature/Settings/GeneralSettingsPageTest.php` — Livewire-level integration: access control, mount, save, cancel, restart notice, route registration
+- `tests/Feature/Settings/GeneralSettingsPageTest.php` — Livewire-level integration: access control, mount, save, cancel, route registration
 - `tests/Unit/Livewire/Settings/GeneralSettingsPageTest.php` — unit tests using mocked SettingsService
 
 ---
@@ -328,16 +341,16 @@ The API и вебхуки section follows the same two-page pattern as Integrati
 **Access**: admin-role only. Missing source redirects to the list.
 
 **Layout**: `#[Layout('layouts.admin-settings')]`. Two-column body (`lg:grid-cols-[1fr_320px]`):
-- **Left form card**: source name header + Bearer token block (masked display, one-time reveal on regenerate, Скопировать + Сгенерировать новый) + URL вебхука field + Секретный ключ (disabled placeholder "скоро") + События (4 disabled toggle rows, "скоро") + Отмена / Сохранить actions.
+- **Left form card**: source name header + Bearer token block (masked display, one-time reveal on regenerate, Скопировать + Сгенерировать новый) + URL вебхука field + «Разрешённые IP-адреса» textarea (one IP per line) + Отмена / Сохранить actions.
 - **Right panel**: "REST API" header + base URL + endpoint list for this source ID + auth note + Swagger UI link.
 
 **Top breadcrumb bar**: back arrow + "API и вебхуки" link + chevron + source name.
 
 **Token**: `regenerateToken(ExternalSourceTokensService)` calls `setAccessToken()`, stores raw result in `$newToken` (one-time reveal only, never logged). `dismissNewToken()` clears it.
 
-**Webhook URL**: `saveWebhookUrl()` — empty clears, non-empty must pass `FILTER_VALIDATE_URL`. `cancel()` reloads from DB.
+**Webhook URL + allowed IPs**: `saveWebhookUrl()` saves both — empty URL clears, non-empty must pass `FILTER_VALIDATE_URL`; the «Разрешённые IP-адреса» textarea (one entry per line, comma also accepted) is parsed and deduplicated, every entry must pass `FILTER_VALIDATE_IP` or `$allowedIpsError` is set and nothing is saved. An empty allowlist persists as `NULL` (no restriction). `cancel()` reloads both from DB.
 
-**Design placeholders** (no DB backing): Секретный ключ disabled input, Events (4 disabled toggles).
+**IP allowlist enforcement**: `ExternalSource::isIpAllowed($ip)` returns true when the list is empty, else requires an exact match. `ApiQuery` middleware rejects (403) requests whose `$request->ip()` is not allowed.
 
 **Route**: `GET /admin/settings/api-webhooks/{source}` → name `admin.settings.api-webhooks.source`; constraint `source` ∈ `[0-9]+`; registered in `AdminServiceProvider::boot()`.
 
@@ -345,7 +358,7 @@ The API и вебхуки section follows the same two-page pattern as Integrati
 - Token length: 64 characters (`Str::random(64)`).
 - `external_source_access_tokens.active` gates `ApiQuery` and can be flipped via `ExternalSourceTokensService::setTokenActive()`, but the toggle is not surfaced in the UI.
 
-**Tests**: `tests/Unit/Livewire/Settings/ApiWebhookSourcePageTest.php` — access (admin/non-admin/guest), missing source redirect, render (source name, breadcrumb, all field labels, REST API panel, Swagger), token regeneration (one-time reveal, length 64, replace), dismissNewToken, saveWebhookUrl (valid, empty, invalid, saved flag).
+**Tests**: `tests/Unit/Livewire/Settings/ApiWebhookSourcePageTest.php` — access (admin/non-admin/guest), missing source redirect, render (source name, breadcrumb, field labels incl. allowed IPs, removed secret-key/events, REST API panel, Swagger), token regeneration, dismissNewToken, saveWebhookUrl (valid/empty/invalid URL, saved flag, allowed-IPs persist/dedupe/invalid/clear); `tests/Unit/Models/ExternalSourceTest.php` (isIpAllowed); `tests/Feature/Middleware/ApiQueryAllowedIpsTest.php` (middleware enforcement).
 
 ---
 
@@ -388,7 +401,6 @@ The API и вебхуки section follows the same two-page pattern as Integrati
 
 - ❌ Calling `SendReplyAction::execute()` synchronously from a Livewire component without `Queue::fake()` in tests
 - ❌ Sending messages directly from Livewire components — must go through `SendReplyAction`
-- ❌ Displaying the reply form when `config('app.manager_interface') !== 'admin_panel'`
 - ❌ Changing the Livewire polling interval without load analysis
 - ❌ Saving manager replies without recording them to the `messages` table first
 - ❌ Making `AdminPanelInterface` dispatch `TopicCreateJob` — this is `telegram_group` mode only
@@ -403,7 +415,7 @@ The API и вебхуки section follows the same two-page pattern as Integrati
 ## Checklist
 
 - [ ] `BR-001` through `BR-028` read and understood
-- [ ] `shouldShowReplyForm()` returns `false` in `telegram_group` mode
+- [ ] `shouldShowReplyForm()` returns `true` in both modes (reply form always available)
 - [ ] `SendReplyAction` uses queue jobs, not synchronous API calls
 - [ ] New Filament resources have feature tests in `tests/Feature/Admin/`
 - [ ] Polling interval not changed without load analysis

--- a/rules/domain/bot-users.md
+++ b/rules/domain/bot-users.md
@@ -61,6 +61,9 @@ _Enforced in:_ `app/Modules/Telegram/Actions/CloseTopic.php`, `app/Modules/Feedb
 **BR-021** — When a user submits a feedback rating (`callback_data` prefix `feedback_rate_{botUserId}_{feedbackId}_{score}`), the `Feedback` record must be updated with `rating = score` (1..5) and `status = 'completed_no_comment'`. The original form message must be edited to a thank-you text. No comment capture is triggered — `comment` remains nullable.
 _Enforced in:_ `app/Modules/Feedback/Actions/HandleFeedbackRating.php`, `TelegramBotController::checkBotQuery()`, `VkBotController::bot_query()`, `MaxBotController::bot_query()`
 
+**BR-021a** — On rating submission, the rating must also be surfaced in the conversation: `HandleFeedbackRating` writes an incoming `messages` row (`text = "Оценка обращения: ⭐… (N/5)"`) so the rating appears in the admin chat workspace history, and — in telegram_group mode (`telegram` platform with a `topic_id` and configured `telegram.group_id`) — posts the same text into the user's forum topic so managers in the supergroup see it too.
+_Enforced in:_ `App\Modules\Feedback\Actions\HandleFeedbackRating::postRatingToChat()`
+
 ---
 
 ## 4. User State Machine

--- a/rules/domain/external-sources.md
+++ b/rules/domain/external-sources.md
@@ -34,6 +34,9 @@ This domain does not own: message routing to Telegram (see `domain/messaging.md`
 **BR-001** — Every request from an External Source must be authenticated with a valid, active bearer token from `external_source_access_tokens`.
 _Enforced in:_ `app/Http/Middleware/ApiQuery.php`
 
+**BR-001a** — An External Source may restrict which IP addresses are allowed to call the API via `external_sources.allowed_ips` (a JSON list of IPs, managed from `/admin/settings/api-webhooks/{source}`). When the list is non-empty, `ApiQuery` rejects (403) any request whose IP is not an exact match; an empty/NULL list means no restriction.
+_Enforced in:_ `App\Modules\External\Middleware\ApiQuery` (calls `ExternalSource::isIpAllowed($request->ip())`)
+
 **BR-002** — An External Source must be registered in `external_sources` before it can send or receive messages.
 _Enforced in:_ `app/Models/ExternalSource.php`, `app/Services/External/ExternalTrafficService.php`
 

--- a/rules/domain/messaging.md
+++ b/rules/domain/messaging.md
@@ -62,6 +62,9 @@ _Enforced in:_ `app/Models/BotUser.php @ getOrCreateByTelegramUpdate()`, `getOrC
 **BR-002** — Every sent message must be recorded in the `messages` table with `bot_user_id`, `platform`, `message_type`, `from_id`, `to_id`.
 _Enforced in:_ `app/Jobs/SendMessage/AbstractSendMessageJob.php @ saveMessage()`
 
+**BR-002a** — When persisting a Telegram message, `messages.text` must capture the **caption** for media messages (photo/document), since Telegram puts that text in `caption`, not `text`. `SendTelegramMessageJob::saveMessage()` resolves text as `text ?? caption` for both directions, so a photo-with-caption stores both the caption text and the attachment (otherwise the admin chat workspace would show only the image).
+_Enforced in:_ `app/Modules/Telegram/Jobs/SendTelegramMessageJob.php @ saveMessage()`
+
 **BR-003** — A user with `is_banned = true` must not receive replies and must receive a banned notification instead.
 _Enforced in:_ `app/Actions/Telegram/SendBannedMessage.php`, `app/Actions/Vk/SendBannedMessageVk.php`
 

--- a/tests/Feature/Admin/ConversationWorkspaceTest.php
+++ b/tests/Feature/Admin/ConversationWorkspaceTest.php
@@ -8,7 +8,9 @@ use App\Models\Message;
 use App\Models\MessageAttachment;
 use App\Models\User;
 use App\Modules\Admin\Actions\SendReplyAction;
+use App\Modules\Admin\Jobs\SendAdminDocumentJob;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Queue;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -23,9 +25,11 @@ use Tests\TestCase;
  *  - Status-filter tabs (all / open / closed)
  *  - Selecting a dialog loads its messages and user panel
  *  - Sending a reply calls SendReplyAction and refreshes
+ *  - Sending a reply with a file attachment (telegram) and file-only messages
+ *  - Attachments gated to telegram/vk via supportsAttachments()
  *  - Quick-reply insertion
  *  - Media gallery returns image attachments
- *  - Reply form hidden in telegram_group mode
+ *  - Reply form shown in both manager-interface modes
  */
 class ConversationWorkspaceTest extends TestCase
 {
@@ -99,6 +103,27 @@ class ConversationWorkspaceTest extends TestCase
         $component->assertSet('dialogList', function ($list) use ($newer) {
             return $list->first()?->id === $newer->id;
         });
+    }
+
+    public function test_dialog_list_marks_closed_conversations(): void
+    {
+        BotUser::create([
+            'chat_id' => '300',
+            'platform' => 'telegram',
+            'is_closed' => true,
+            'closed_at' => now(),
+        ]);
+
+        Livewire::test(ConversationPage::class)
+            ->assertSee('Обращение закрыто');
+    }
+
+    public function test_dialog_list_does_not_mark_open_conversations(): void
+    {
+        BotUser::create(['chat_id' => '301', 'platform' => 'telegram', 'is_closed' => false]);
+
+        Livewire::test(ConversationPage::class)
+            ->assertDontSee('Обращение закрыто');
     }
 
     // ── Search ─────────────────────────────────────────────────────────────────
@@ -232,6 +257,66 @@ class ConversationWorkspaceTest extends TestCase
             });
     }
 
+    // ── Polling ────────────────────────────────────────────────────────────────
+
+    public function test_poll_updates_loads_new_messages_for_active_dialog(): void
+    {
+        Queue::fake();
+
+        $botUser = BotUser::create(['chat_id' => '1030', 'platform' => 'telegram']);
+
+        $component = Livewire::test(ConversationPage::class)
+            ->call('selectChat', $botUser->id);
+
+        $component->assertSet('chatMessages', fn ($m) => $m->isEmpty());
+
+        // A new incoming message arrives after the dialog was opened.
+        Message::create([
+            'bot_user_id' => $botUser->id,
+            'platform' => 'telegram',
+            'message_type' => 'incoming',
+            'from_id' => 0,
+            'to_id' => 0,
+            'text' => 'New incoming',
+        ]);
+
+        $component->call('pollUpdates')
+            ->assertSet('chatMessages', fn ($m) => $m->count() === 1 && $m->first()->text === 'New incoming')
+            ->assertDispatched('messages-updated');
+    }
+
+    public function test_poll_updates_does_not_scroll_without_new_messages(): void
+    {
+        Queue::fake();
+
+        $botUser = BotUser::create(['chat_id' => '1031', 'platform' => 'telegram']);
+        Message::create([
+            'bot_user_id' => $botUser->id,
+            'platform' => 'telegram',
+            'message_type' => 'incoming',
+            'from_id' => 0,
+            'to_id' => 0,
+            'text' => 'Existing',
+        ]);
+
+        Livewire::test(ConversationPage::class)
+            ->call('selectChat', $botUser->id)
+            ->call('pollUpdates')
+            ->assertNotDispatched('messages-updated');
+    }
+
+    public function test_poll_updates_refreshes_dialog_list(): void
+    {
+        BotUser::create(['chat_id' => '1032', 'platform' => 'telegram']);
+
+        $component = Livewire::test(ConversationPage::class);
+
+        BotUser::create(['chat_id' => '1033', 'platform' => 'telegram']);
+
+        $component->call('pollUpdates')
+            ->assertSet('dialogList', fn ($list) => $list->count() === 2);
+    }
+
     // ── Send reply ─────────────────────────────────────────────────────────────
 
     public function test_send_reply_calls_send_reply_action(): void
@@ -278,6 +363,83 @@ class ConversationWorkspaceTest extends TestCase
             ->assertHasErrors(['replyText' => 'required']);
     }
 
+    // ── Attachments ──────────────────────────────────────────────────────────────
+
+    public function test_send_reply_with_attachment_dispatches_document_job(): void
+    {
+        Queue::fake();
+
+        $botUser = BotUser::create(['chat_id' => '1004', 'platform' => 'telegram']);
+        $file = UploadedFile::fake()->create('report.pdf', 120, 'application/pdf');
+
+        Livewire::test(ConversationPage::class)
+            ->call('selectChat', $botUser->id)
+            ->set('attachment', $file)
+            ->set('replyText', 'See attached')
+            ->call('sendReply')
+            ->assertHasNoErrors()
+            ->assertSet('attachment', null);
+
+        $this->assertDatabaseHas('messages', [
+            'bot_user_id' => $botUser->id,
+            'message_type' => 'outgoing',
+            'text' => 'See attached',
+        ]);
+
+        Queue::assertPushed(SendAdminDocumentJob::class);
+    }
+
+    public function test_send_reply_allows_file_only_message(): void
+    {
+        Queue::fake();
+
+        $botUser = BotUser::create(['chat_id' => '1005', 'platform' => 'telegram']);
+        $file = UploadedFile::fake()->create('photo.png', 80, 'image/png');
+
+        Livewire::test(ConversationPage::class)
+            ->call('selectChat', $botUser->id)
+            ->set('attachment', $file)
+            ->set('replyText', '')
+            ->call('sendReply')
+            ->assertHasNoErrors();
+
+        $this->assertDatabaseHas('messages', [
+            'bot_user_id' => $botUser->id,
+            'message_type' => 'outgoing',
+            'text' => null,
+        ]);
+
+        Queue::assertPushed(SendAdminDocumentJob::class);
+    }
+
+    public function test_supports_attachments_only_for_telegram_and_vk(): void
+    {
+        $telegram = BotUser::create(['chat_id' => '1006', 'platform' => 'telegram']);
+        $component = Livewire::test(ConversationPage::class)->call('selectChat', $telegram->id);
+        $this->assertTrue($component->instance()->supportsAttachments());
+
+        $vk = BotUser::create(['chat_id' => '1007', 'platform' => 'vk']);
+        $component->call('selectChat', $vk->id);
+        $this->assertTrue($component->instance()->supportsAttachments());
+
+        $external = BotUser::create(['chat_id' => '1008', 'platform' => 'max']);
+        $component->call('selectChat', $external->id);
+        $this->assertFalse($component->instance()->supportsAttachments());
+    }
+
+    public function test_remove_attachment_clears_selected_file(): void
+    {
+        $botUser = BotUser::create(['chat_id' => '1009', 'platform' => 'telegram']);
+        $file = UploadedFile::fake()->create('doc.pdf', 50, 'application/pdf');
+
+        Livewire::test(ConversationPage::class)
+            ->call('selectChat', $botUser->id)
+            ->set('attachment', $file)
+            ->assertSet('attachment', fn ($a) => $a !== null)
+            ->call('removeAttachment')
+            ->assertSet('attachment', null);
+    }
+
     public function test_send_reply_skipped_when_no_active_dialog(): void
     {
         Queue::fake();
@@ -292,7 +454,175 @@ class ConversationWorkspaceTest extends TestCase
         ]);
     }
 
-    public function test_reply_form_hidden_in_telegram_group_mode(): void
+    // ── Close dialog ─────────────────────────────────────────────────────────────
+
+    public function test_close_dialog_marks_bot_user_closed(): void
+    {
+        Queue::fake();
+
+        $botUser = BotUser::create(['chat_id' => '1010', 'platform' => 'telegram', 'is_closed' => false]);
+
+        Livewire::test(ConversationPage::class)
+            ->call('selectChat', $botUser->id)
+            ->call('closeDialog')
+            ->assertNotified('Диалог закрыт');
+
+        $botUser->refresh();
+        $this->assertTrue($botUser->isClosed());
+        $this->assertNotNull($botUser->closed_at);
+    }
+
+    public function test_close_dialog_noop_when_already_closed(): void
+    {
+        Queue::fake();
+
+        $botUser = BotUser::create([
+            'chat_id' => '1011',
+            'platform' => 'telegram',
+            'is_closed' => true,
+            'closed_at' => now()->subDay(),
+        ]);
+
+        Livewire::test(ConversationPage::class)
+            ->call('selectChat', $botUser->id)
+            ->call('closeDialog');
+
+        // Already-closed short-circuit: no close-flow jobs dispatched.
+        Queue::assertNothingPushed();
+    }
+
+    public function test_close_dialog_skipped_when_no_active_dialog(): void
+    {
+        Queue::fake();
+
+        Livewire::test(ConversationPage::class)
+            ->call('closeDialog');
+
+        Queue::assertNothingPushed();
+    }
+
+    // ── Ban user ─────────────────────────────────────────────────────────────────
+
+    public function test_ban_user_marks_bot_user_banned_and_closed(): void
+    {
+        Queue::fake();
+
+        $botUser = BotUser::create(['chat_id' => '1020', 'platform' => 'telegram', 'is_banned' => false]);
+
+        Livewire::test(ConversationPage::class)
+            ->call('selectChat', $botUser->id)
+            ->call('banUser')
+            ->assertNotified('Пользователь заблокирован');
+
+        $botUser->refresh();
+        $this->assertTrue($botUser->isBanned());
+        $this->assertNotNull($botUser->banned_at);
+        $this->assertTrue($botUser->isClosed());
+    }
+
+    public function test_ban_user_noop_when_already_banned(): void
+    {
+        Queue::fake();
+
+        $botUser = BotUser::create([
+            'chat_id' => '1021',
+            'platform' => 'telegram',
+            'is_banned' => true,
+            'banned_at' => now()->subDay(),
+        ]);
+
+        Livewire::test(ConversationPage::class)
+            ->call('selectChat', $botUser->id)
+            ->call('banUser');
+
+        Queue::assertNothingPushed();
+    }
+
+    public function test_ban_user_skipped_when_no_active_dialog(): void
+    {
+        Queue::fake();
+
+        Livewire::test(ConversationPage::class)
+            ->call('banUser');
+
+        Queue::assertNothingPushed();
+    }
+
+    public function test_unban_user_clears_ban(): void
+    {
+        Queue::fake();
+
+        $botUser = BotUser::create([
+            'chat_id' => '1022',
+            'platform' => 'telegram',
+            'is_banned' => true,
+            'banned_at' => now()->subDay(),
+        ]);
+
+        Livewire::test(ConversationPage::class)
+            ->call('selectChat', $botUser->id)
+            ->call('unbanUser')
+            ->assertNotified('Пользователь разблокирован');
+
+        $botUser->refresh();
+        $this->assertFalse($botUser->isBanned());
+        $this->assertNull($botUser->banned_at);
+    }
+
+    public function test_unban_user_noop_when_not_banned(): void
+    {
+        $botUser = BotUser::create(['chat_id' => '1023', 'platform' => 'telegram', 'is_banned' => false]);
+
+        Livewire::test(ConversationPage::class)
+            ->call('selectChat', $botUser->id)
+            ->call('unbanUser');
+
+        $botUser->refresh();
+        $this->assertFalse($botUser->isBanned());
+    }
+
+    public function test_dialog_list_marks_banned_conversations(): void
+    {
+        BotUser::create([
+            'chat_id' => '1024',
+            'platform' => 'telegram',
+            'is_banned' => true,
+            'banned_at' => now(),
+            'is_closed' => true,
+            'closed_at' => now(),
+        ]);
+
+        Livewire::test(ConversationPage::class)
+            ->assertSee('Пользователь заблокирован')
+            // banned badge takes priority over the closed badge
+            ->assertDontSee('Обращение закрыто');
+    }
+
+    // ── Reopen on reply ────────────────────────────────────────────────────────
+
+    public function test_sending_reply_reopens_closed_conversation(): void
+    {
+        Queue::fake();
+
+        $botUser = BotUser::create([
+            'chat_id' => '1025',
+            'platform' => 'telegram',
+            'is_closed' => true,
+            'closed_at' => now()->subDay(),
+        ]);
+
+        Livewire::test(ConversationPage::class)
+            ->call('selectChat', $botUser->id)
+            ->set('replyText', 'Are you still there?')
+            ->call('sendReply')
+            ->assertHasNoErrors();
+
+        $botUser->refresh();
+        $this->assertFalse($botUser->isClosed());
+        $this->assertNull($botUser->closed_at);
+    }
+
+    public function test_reply_form_shown_in_telegram_group_mode(): void
     {
         config(['app.manager_interface' => 'telegram_group']);
 
@@ -303,7 +633,7 @@ class ConversationWorkspaceTest extends TestCase
 
         $component->assertSet('activeBotUserId', $botUser->id);
 
-        $this->assertFalse($component->instance()->shouldShowReplyForm());
+        $this->assertTrue($component->instance()->shouldShowReplyForm());
     }
 
     // ── Quick replies ──────────────────────────────────────────────────────────

--- a/tests/Feature/Admin/LoginPageTest.php
+++ b/tests/Feature/Admin/LoginPageTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Admin;
+
+use App\Enums\UserRole;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LoginPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_login_page_renders_custom_design(): void
+    {
+        $response = $this->get('/admin/login');
+
+        $response->assertOk()
+            ->assertSee('TG Support Bot')
+            ->assertSee('Вход в систему')
+            ->assertSee('Введите свои данные для доступа к панели управления')
+            ->assertSee('Войти');
+    }
+
+    public function test_valid_credentials_authenticate_via_custom_login(): void
+    {
+        $user = User::factory()->create([
+            'email' => 'admin@example.com',
+            'password' => bcrypt('secret123'),
+            'role' => UserRole::Admin,
+        ]);
+
+        \Livewire\Livewire::test(\App\Modules\Admin\Filament\Pages\Auth\Login::class)
+            ->set('data.email', 'admin@example.com')
+            ->set('data.password', 'secret123')
+            ->call('authenticate');
+
+        $this->assertAuthenticatedAs($user);
+    }
+}

--- a/tests/Feature/Admin/LogoutTest.php
+++ b/tests/Feature/Admin/LogoutTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Admin;
+
+use App\Enums\UserRole;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LogoutTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_logout_control_visible_on_chat_workspace(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+
+        $this->actingAs($admin)
+            ->get(route('admin.chats'))
+            ->assertOk()
+            ->assertSee('admin/logout');
+    }
+
+    public function test_logout_control_visible_on_settings(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+
+        $this->actingAs($admin)
+            ->get(route('admin.settings.general'))
+            ->assertOk()
+            ->assertSee('Выйти')
+            ->assertSee('admin/logout');
+    }
+
+    public function test_logout_logs_the_user_out(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+
+        // CSRF is enforced for the POST; the real form ships @csrf. Here we
+        // exercise the logout logic itself, so skip the CSRF middleware.
+        $this->actingAs($admin)
+            ->withoutMiddleware(\Illuminate\Foundation\Http\Middleware\VerifyCsrfToken::class)
+            ->post(route('filament.admin.auth.logout'))
+            ->assertRedirect();
+
+        $this->assertGuest();
+    }
+}

--- a/tests/Feature/Jobs/SendTelegramMessageJobIncomingMediaTest.php
+++ b/tests/Feature/Jobs/SendTelegramMessageJobIncomingMediaTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Tests\Feature\Jobs;
+
+use App\Models\BotUser;
+use App\Models\Message;
+use App\Modules\Telegram\Api\TelegramMethods;
+use App\Modules\Telegram\DTOs\TGTextMessageDto;
+use App\Modules\Telegram\Jobs\SendTelegramMessageJob;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Mocks\Tg\Answer\TelegramAnswerDtoMock;
+use Tests\Mocks\Tg\TelegramUpdateDtoMock;
+use Tests\TestCase;
+
+/**
+ * Hermetic tests for SendTelegramMessageJob::saveMessage() text/caption handling.
+ *
+ * Unlike SendTelegramMessageJobTest, this class does not run TopicCreateJob in
+ * setUp (no real HTTP) — the BotUser is created with a topic_id directly and
+ * TelegramMethods is mocked, so the incoming-message branch reaches saveMessage.
+ */
+class SendTelegramMessageJobIncomingMediaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeBotUser(): BotUser
+    {
+        return BotUser::create([
+            'chat_id' => 700700,
+            'platform' => 'telegram',
+            'topic_id' => 4242,
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $messageOverrides
+     */
+    private function incomingDtoWith(array $messageOverrides, BotUser $botUser): \App\Modules\Telegram\DTOs\TelegramUpdateDto
+    {
+        return TelegramUpdateDtoMock::getDto([
+            'update_id' => time(),
+            'message' => array_merge([
+                'message_id' => 555,
+                'from' => [
+                    'id' => 1,
+                    'is_bot' => false,
+                    'first_name' => 'Test',
+                    'username' => 'usertest',
+                    'language_code' => 'ru',
+                ],
+                'chat' => [
+                    'id' => $botUser->chat_id,
+                    'type' => 'private',
+                ],
+                'date' => time(),
+            ], $messageOverrides),
+        ]);
+    }
+
+    private function mockTelegram(): TelegramMethods
+    {
+        /** @var TelegramMethods&\Mockery\MockInterface $mock */
+        $mock = \Mockery::mock(TelegramMethods::class);
+        $mock->shouldReceive('sendQueryTelegram')->andReturn(TelegramAnswerDtoMock::getDto());
+
+        return $mock;
+    }
+
+    public function test_incoming_photo_saves_caption_as_text_with_attachment(): void
+    {
+        $botUser = $this->makeBotUser();
+
+        $dto = $this->incomingDtoWith([
+            'photo' => [['file_id' => 'PHOTO_FILE_ID']],
+            'caption' => 'Подпись к фото',
+        ], $botUser);
+
+        $params = TGTextMessageDto::from([
+            'methodQuery' => 'sendPhoto',
+            'chat_id' => '-100123456',
+            'photo' => 'PHOTO_FILE_ID',
+            'caption' => 'Подпись к фото',
+        ]);
+
+        (new SendTelegramMessageJob($botUser->id, $dto, $params, 'incoming', $this->mockTelegram()))->handle();
+
+        $this->assertDatabaseHas('messages', [
+            'bot_user_id' => $botUser->id,
+            'message_type' => 'incoming',
+            'text' => 'Подпись к фото',
+        ]);
+
+        $message = Message::where('bot_user_id', $botUser->id)->first();
+        $this->assertNotNull($message);
+        $this->assertDatabaseHas('message_attachments', [
+            'message_id' => $message->id,
+            'file_type' => 'photo',
+            'file_id' => 'PHOTO_FILE_ID',
+        ]);
+    }
+
+    public function test_incoming_photo_without_caption_saves_null_text(): void
+    {
+        $botUser = $this->makeBotUser();
+
+        $dto = $this->incomingDtoWith([
+            'photo' => [['file_id' => 'PHOTO_NO_CAPTION']],
+        ], $botUser);
+
+        $params = TGTextMessageDto::from([
+            'methodQuery' => 'sendPhoto',
+            'chat_id' => '-100123456',
+            'photo' => 'PHOTO_NO_CAPTION',
+        ]);
+
+        (new SendTelegramMessageJob($botUser->id, $dto, $params, 'incoming', $this->mockTelegram()))->handle();
+
+        $this->assertDatabaseHas('messages', [
+            'bot_user_id' => $botUser->id,
+            'message_type' => 'incoming',
+            'text' => null,
+        ]);
+    }
+
+    public function test_incoming_plain_text_still_saved(): void
+    {
+        $botUser = $this->makeBotUser();
+
+        $dto = $this->incomingDtoWith([
+            'text' => 'Просто текст',
+        ], $botUser);
+
+        $params = TGTextMessageDto::from([
+            'methodQuery' => 'sendMessage',
+            'chat_id' => '-100123456',
+            'text' => 'Просто текст',
+        ]);
+
+        (new SendTelegramMessageJob($botUser->id, $dto, $params, 'incoming', $this->mockTelegram()))->handle();
+
+        $this->assertDatabaseHas('messages', [
+            'bot_user_id' => $botUser->id,
+            'message_type' => 'incoming',
+            'text' => 'Просто текст',
+        ]);
+    }
+}

--- a/tests/Feature/Middleware/ApiQueryAllowedIpsTest.php
+++ b/tests/Feature/Middleware/ApiQueryAllowedIpsTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Feature\Middleware;
+
+use App\Models\ExternalSource;
+use App\Models\ExternalSourceAccessTokens;
+use App\Modules\External\Middleware\ApiQuery;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\TestCase;
+
+class ApiQueryAllowedIpsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeRequest(string $token, string $ip): Request
+    {
+        $request = Request::create('/api/external/messages', 'GET');
+        $request->headers->set('Authorization', 'Bearer ' . $token);
+        $request->server->set('REMOTE_ADDR', $ip);
+
+        return $request;
+    }
+
+    private function tokenFor(ExternalSource $source): string
+    {
+        $value = str_repeat('a', 64);
+
+        ExternalSourceAccessTokens::create([
+            'external_source_id' => $source->id,
+            'token' => $value,
+            'active' => true,
+        ]);
+
+        return $value;
+    }
+
+    public function test_allows_request_from_listed_ip(): void
+    {
+        $source = ExternalSource::factory()->create(['allowed_ips' => ['203.0.113.10']]);
+        $token = $this->tokenFor($source);
+
+        $response = (new ApiQuery())->handle(
+            $this->makeRequest($token, '203.0.113.10'),
+            fn () => response('ok')
+        );
+
+        $this->assertSame('ok', $response->getContent());
+    }
+
+    public function test_rejects_request_from_unlisted_ip(): void
+    {
+        $source = ExternalSource::factory()->create(['allowed_ips' => ['203.0.113.10']]);
+        $token = $this->tokenFor($source);
+
+        $response = (new ApiQuery())->handle(
+            $this->makeRequest($token, '5.6.7.8'),
+            fn () => response('ok')
+        );
+
+        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+    }
+
+    public function test_allows_any_ip_when_allowlist_empty(): void
+    {
+        $source = ExternalSource::factory()->create(['allowed_ips' => null]);
+        $token = $this->tokenFor($source);
+
+        $response = (new ApiQuery())->handle(
+            $this->makeRequest($token, '5.6.7.8'),
+            fn () => response('ok')
+        );
+
+        $this->assertSame('ok', $response->getContent());
+    }
+}

--- a/tests/Feature/Settings/GeneralSettingsPageTest.php
+++ b/tests/Feature/Settings/GeneralSettingsPageTest.php
@@ -7,7 +7,6 @@ use App\Livewire\Settings\GeneralSettingsPage;
 use App\Models\User;
 use App\Services\Settings\SettingsService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\Cache;
 use Livewire\Livewire;
 use Tests\TestCase;
 
@@ -33,14 +32,8 @@ class GeneralSettingsPageTest extends TestCase
             ->assertSuccessful();
     }
 
-    public function test_manager_role_is_redirected_when_not_authorized(): void
+    public function test_manager_role_can_load_the_page(): void
     {
-        // Filament's Authenticate middleware allows all authenticated users to
-        // view the panel (role-gating is at the page level in Filament, not the
-        // route level). For the custom settings route we use the same
-        // Authenticate middleware which lets any authenticated user through —
-        // the page itself does not enforce isAdmin() at the route, so managers
-        // can access the form. This test confirms a manager can load it.
         $manager = User::factory()->manager()->create();
         $this->actingAs($manager);
 
@@ -50,193 +43,85 @@ class GeneralSettingsPageTest extends TestCase
 
     // ── Mount / initial state ────────────────────────────────────────────────
 
-    public function test_loads_current_values_from_settings_service(): void
+    public function test_loads_template_value_from_settings_service(): void
     {
         $admin = User::factory()->create(['role' => UserRole::Admin]);
         $this->actingAs($admin);
 
         /** @var SettingsService $settings */
         $settings = app(SettingsService::class);
-        $settings->set('app.bot_name', 'My Bot');
-        $settings->set('app.bot_description', 'A great bot');
-        $settings->set('app.manager_interface', 'admin_panel');
+        $settings->set('telegram.template_topic_name', 'Обращение {first_name}');
 
         Livewire::test(GeneralSettingsPage::class)
-            ->assertSet('bot_name', 'My Bot')
-            ->assertSet('bot_description', 'A great bot')
-            ->assertSet('manager_interface', 'admin_panel');
+            ->assertSet('template_topic_name', 'Обращение {first_name}');
     }
 
-    public function test_loads_defaults_when_no_db_row_exists(): void
-    {
-        $admin = User::factory()->create(['role' => UserRole::Admin]);
-        $this->actingAs($admin);
+    // ── Save ─────────────────────────────────────────────────────────────────
 
-        config(['app.manager_interface' => 'telegram_group']);
-        Cache::flush();
-
-        Livewire::test(GeneralSettingsPage::class)
-            ->assertSet('bot_name', '')
-            ->assertSet('bot_description', '')
-            ->assertSet('manager_interface', 'telegram_group');
-    }
-
-    // ── Save — valid inputs ──────────────────────────────────────────────────
-
-    public function test_save_persists_bot_name_and_description(): void
+    public function test_save_persists_template_topic_name(): void
     {
         $admin = User::factory()->create(['role' => UserRole::Admin]);
         $this->actingAs($admin);
 
         Livewire::test(GeneralSettingsPage::class)
-            ->set('bot_name', 'Новый бот')
-            ->set('bot_description', 'Описание')
-            ->set('manager_interface', 'telegram_group')
+            ->set('template_topic_name', 'Новое обращение')
             ->call('save')
             ->assertSet('saved', true)
             ->assertSet('formErrors', []);
 
-        $this->assertDatabaseHas('settings', ['key' => 'app.bot_name', 'value' => 'Новый бот']);
-        $this->assertDatabaseHas('settings', ['key' => 'app.bot_description', 'value' => 'Описание']);
+        $this->assertDatabaseHas('settings', ['key' => 'telegram.template_topic_name', 'value' => 'Новое обращение']);
     }
 
-    public function test_save_accepts_nullable_bot_name(): void
+    public function test_save_rejects_template_exceeding_255_chars(): void
     {
         $admin = User::factory()->create(['role' => UserRole::Admin]);
         $this->actingAs($admin);
 
         Livewire::test(GeneralSettingsPage::class)
-            ->set('bot_name', '')
-            ->set('bot_description', '')
-            ->set('manager_interface', 'telegram_group')
-            ->call('save')
-            ->assertSet('saved', true)
-            ->assertSet('formErrors', []);
-    }
-
-    // ── Save — invalid inputs ────────────────────────────────────────────────
-
-    public function test_save_rejects_bot_name_exceeding_255_chars(): void
-    {
-        $admin = User::factory()->create(['role' => UserRole::Admin]);
-        $this->actingAs($admin);
-
-        Livewire::test(GeneralSettingsPage::class)
-            ->set('bot_name', str_repeat('a', 256))
-            ->set('manager_interface', 'telegram_group')
+            ->set('template_topic_name', str_repeat('a', 256))
             ->call('save')
             ->assertSet('saved', false)
-            ->assertSet('formErrors', ['bot_name' => 'Максимальная длина — 255 символов.']);
-
-        $this->assertDatabaseMissing('settings', ['key' => 'app.bot_name']);
-    }
-
-    public function test_save_rejects_description_exceeding_1000_chars(): void
-    {
-        $admin = User::factory()->create(['role' => UserRole::Admin]);
-        $this->actingAs($admin);
-
-        Livewire::test(GeneralSettingsPage::class)
-            ->set('bot_description', str_repeat('x', 1001))
-            ->set('manager_interface', 'telegram_group')
-            ->call('save')
-            ->assertSet('saved', false)
-            ->assertSet('formErrors', ['bot_description' => 'Максимальная длина — 1000 символов.']);
-    }
-
-    public function test_save_rejects_invalid_manager_interface_value(): void
-    {
-        $admin = User::factory()->create(['role' => UserRole::Admin]);
-        $this->actingAs($admin);
-
-        Livewire::test(GeneralSettingsPage::class)
-            ->set('manager_interface', 'invalid_value')
-            ->call('save')
-            ->assertSet('saved', false);
-
-        $component = Livewire::test(GeneralSettingsPage::class)
-            ->set('manager_interface', 'invalid_value')
-            ->call('save');
-
-        $this->assertNotEmpty($component->get('formErrors'));
-    }
-
-    // ── MANAGER_INTERFACE switch → restart notice ────────────────────────────
-
-    public function test_switching_manager_interface_shows_restart_notice(): void
-    {
-        $admin = User::factory()->create(['role' => UserRole::Admin]);
-        $this->actingAs($admin);
-
-        /** @var SettingsService $settings */
-        $settings = app(SettingsService::class);
-        $settings->set('app.manager_interface', 'telegram_group');
-
-        Livewire::test(GeneralSettingsPage::class)
-            ->set('manager_interface', 'admin_panel')
-            ->call('save')
-            ->assertSet('showRestartNotice', true)
-            ->assertSet('saved', true)
-            ->assertSee('docker compose restart app');
-    }
-
-    public function test_no_restart_notice_when_manager_interface_unchanged(): void
-    {
-        $admin = User::factory()->create(['role' => UserRole::Admin]);
-        $this->actingAs($admin);
-
-        /** @var SettingsService $settings */
-        $settings = app(SettingsService::class);
-        $settings->set('app.manager_interface', 'telegram_group');
-
-        Livewire::test(GeneralSettingsPage::class)
-            ->set('manager_interface', 'telegram_group')
-            ->call('save')
-            ->assertSet('showRestartNotice', false);
+            ->assertSet('formErrors', ['template_topic_name' => 'Максимальная длина — 255 символов.']);
     }
 
     // ── Cancel ───────────────────────────────────────────────────────────────
 
-    public function test_cancel_resets_to_stored_values(): void
+    public function test_cancel_resets_to_stored_value(): void
     {
         $admin = User::factory()->create(['role' => UserRole::Admin]);
         $this->actingAs($admin);
 
         /** @var SettingsService $settings */
         $settings = app(SettingsService::class);
-        $settings->set('app.bot_name', 'Original');
-        $settings->set('app.manager_interface', 'telegram_group');
+        $settings->set('telegram.template_topic_name', 'Original');
 
         Livewire::test(GeneralSettingsPage::class)
-            ->set('bot_name', 'Changed')
-            ->set('manager_interface', 'admin_panel')
+            ->set('template_topic_name', 'Changed')
             ->call('cancel')
-            ->assertSet('bot_name', 'Original')
-            ->assertSet('manager_interface', 'telegram_group')
-            ->assertSet('saved', false)
-            ->assertSet('showRestartNotice', false);
+            ->assertSet('template_topic_name', 'Original')
+            ->assertSet('saved', false);
     }
 
     // ── UI rendering ──────────────────────────────────────────────────────────
 
-    public function test_renders_page_title_and_subtitle(): void
+    public function test_renders_page_title_and_template_field(): void
     {
         $admin = User::factory()->create(['role' => UserRole::Admin]);
         $this->actingAs($admin);
 
         Livewire::test(GeneralSettingsPage::class)
             ->assertSee('Основные')
-            ->assertSee('Общие настройки бота');
+            ->assertSee('Шаблон названия топика');
     }
 
-    public function test_renders_manager_interface_options(): void
+    public function test_does_not_render_removed_fields(): void
     {
         $admin = User::factory()->create(['role' => UserRole::Admin]);
         $this->actingAs($admin);
 
         Livewire::test(GeneralSettingsPage::class)
-            ->assertSee('telegram_group')
-            ->assertSee('admin_panel');
+            ->assertDontSee('Название бот')
+            ->assertDontSee('Интерфейс менеджера');
     }
 
     // ── Route resolution ──────────────────────────────────────────────────────
@@ -248,9 +133,6 @@ class GeneralSettingsPageTest extends TestCase
 
     public function test_component_is_routable_and_mounts_successfully(): void
     {
-        // Verifies the route resolves to GeneralSettingsPage and the component
-        // mounts without errors. Uses Livewire::test() to avoid @vite() failures
-        // in the test environment (no compiled assets).
         $admin = User::factory()->create(['role' => UserRole::Admin]);
         $this->actingAs($admin);
 

--- a/tests/Unit/Livewire/Chat/ConversationPageTest.php
+++ b/tests/Unit/Livewire/Chat/ConversationPageTest.php
@@ -127,7 +127,7 @@ class ConversationPageTest extends TestCase
         Queue::assertPushed(SendTelegramSimpleQueryJob::class);
     }
 
-    public function test_send_reply_does_nothing_outside_admin_panel_mode(): void
+    public function test_send_reply_works_in_telegram_group_mode(): void
     {
         Queue::fake();
         config(['app.manager_interface' => 'telegram_group']);
@@ -137,14 +137,16 @@ class ConversationPageTest extends TestCase
         Livewire::test(ConversationPage::class)
             ->call('selectChat', $botUser->id)
             ->set('replyText', 'Hello!')
-            ->call('sendReply');
+            ->call('sendReply')
+            ->assertHasNoErrors();
 
-        $this->assertDatabaseMissing('messages', [
+        $this->assertDatabaseHas('messages', [
             'bot_user_id' => $botUser->id,
             'message_type' => 'outgoing',
+            'text' => 'Hello!',
         ]);
 
-        Queue::assertNothingPushed();
+        Queue::assertPushed(SendTelegramSimpleQueryJob::class);
     }
 
     // ── Polling interval ───────────────────────────────────────────────────────
@@ -167,13 +169,13 @@ class ConversationPageTest extends TestCase
         $this->assertTrue($instance->shouldShowReplyForm());
     }
 
-    public function test_should_show_reply_form_returns_false_in_telegram_group_mode(): void
+    public function test_should_show_reply_form_returns_true_in_telegram_group_mode(): void
     {
         config(['app.manager_interface' => 'telegram_group']);
 
         $instance = Livewire::test(ConversationPage::class)->instance();
 
-        $this->assertFalse($instance->shouldShowReplyForm());
+        $this->assertTrue($instance->shouldShowReplyForm());
     }
 
     // ── insertQuickReply ──────────────────────────────────────────────────────
@@ -183,6 +185,101 @@ class ConversationPageTest extends TestCase
         Livewire::test(ConversationPage::class)
             ->call('insertQuickReply', 'Ожидайте, пожалуйста')
             ->assertSet('replyText', 'Ожидайте, пожалуйста');
+    }
+
+    // ── hasUnread ──────────────────────────────────────────────────────────────
+
+    private function botUserWithLastMessage(string $type, array $attrs = []): BotUser
+    {
+        $botUser = BotUser::create(array_merge(['chat_id' => 5000, 'platform' => 'telegram'], $attrs));
+
+        Message::create([
+            'bot_user_id' => $botUser->id,
+            'platform' => 'telegram',
+            'message_type' => $type,
+            'from_id' => 0,
+            'to_id' => 0,
+            'text' => 'msg',
+        ]);
+
+        return $botUser->fresh(['lastMessage']);
+    }
+
+    public function test_has_unread_true_for_open_dialog_with_incoming_last_message(): void
+    {
+        $user = $this->botUserWithLastMessage('incoming');
+
+        $instance = Livewire::test(ConversationPage::class)->instance();
+
+        $this->assertTrue($instance->hasUnread($user));
+    }
+
+    public function test_has_unread_false_when_last_message_outgoing(): void
+    {
+        $user = $this->botUserWithLastMessage('outgoing');
+
+        $instance = Livewire::test(ConversationPage::class)->instance();
+
+        $this->assertFalse($instance->hasUnread($user));
+    }
+
+    public function test_has_unread_false_for_closed_dialog(): void
+    {
+        $user = $this->botUserWithLastMessage('incoming', ['is_closed' => true, 'closed_at' => now()]);
+
+        $instance = Livewire::test(ConversationPage::class)->instance();
+
+        $this->assertFalse($instance->hasUnread($user));
+    }
+
+    public function test_has_unread_false_for_banned_dialog(): void
+    {
+        $user = $this->botUserWithLastMessage('incoming', ['is_banned' => true, 'banned_at' => now()]);
+
+        $instance = Livewire::test(ConversationPage::class)->instance();
+
+        $this->assertFalse($instance->hasUnread($user));
+    }
+
+    public function test_has_unread_false_for_active_dialog(): void
+    {
+        $user = $this->botUserWithLastMessage('incoming');
+
+        $component = Livewire::test(ConversationPage::class)->call('selectChat', $user->id);
+
+        $this->assertFalse($component->instance()->hasUnread($user));
+    }
+
+    public function test_has_unread_false_when_read_after_last_message(): void
+    {
+        $user = $this->botUserWithLastMessage('incoming', ['manager_last_read_at' => now()->addHour()]);
+
+        $instance = Livewire::test(ConversationPage::class)->instance();
+
+        $this->assertFalse($instance->hasUnread($user));
+    }
+
+    public function test_has_unread_true_when_message_arrived_after_read(): void
+    {
+        $user = $this->botUserWithLastMessage('incoming', ['manager_last_read_at' => now()->subHour()]);
+
+        $instance = Livewire::test(ConversationPage::class)->instance();
+
+        $this->assertTrue($instance->hasUnread($user));
+    }
+
+    public function test_selecting_dialog_persists_read_timestamp(): void
+    {
+        $user = $this->botUserWithLastMessage('incoming');
+
+        Livewire::test(ConversationPage::class)->call('selectChat', $user->id);
+
+        // Persisted: a fresh, non-active load is no longer flagged unread.
+        $reloaded = $user->fresh(['lastMessage']);
+        $this->assertNotNull($reloaded->manager_last_read_at);
+
+        $freshComponent = Livewire::test(ConversationPage::class)->instance();
+        $this->assertFalse($freshComponent->hasUnread($reloaded));
     }
 
     // ── getImageAttachments ──────────────────────────────────────────────────

--- a/tests/Unit/Livewire/Settings/ApiWebhookSourcePageTest.php
+++ b/tests/Unit/Livewire/Settings/ApiWebhookSourcePageTest.php
@@ -73,10 +73,12 @@ class ApiWebhookSourcePageTest extends TestCase
             ->assertSee('API и вебхуки')   // breadcrumb
             ->assertSee('Ключ API')
             ->assertSee('URL вебхука')
-            ->assertSee('Секретный ключ')
-            ->assertSee('События')
+            ->assertSee('Разрешённые IP-адреса')
             ->assertSee('REST API')
-            ->assertSee('Swagger');
+            ->assertSee('Swagger')
+            // Removed sections must no longer render.
+            ->assertDontSee('Секретный ключ')
+            ->assertDontSee('События');
     }
 
     public function test_renders_masked_token_when_token_exists(): void
@@ -244,5 +246,76 @@ class ApiWebhookSourcePageTest extends TestCase
             ->call('saveWebhookUrl');
 
         $this->assertTrue($component->get('saved'));
+    }
+
+    // ── Allowed IPs ─────────────────────────────────────────────────────────────
+
+    public function test_mount_loads_allowed_ips_as_lines(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        $source = ExternalSource::factory()->create([
+            'name' => 'Source',
+            'allowed_ips' => ['203.0.113.10', '198.51.100.5'],
+        ]);
+
+        Livewire::test(ApiWebhookSourcePage::class, ['source' => $source->id])
+            ->assertSet('allowedIps', "203.0.113.10\n198.51.100.5");
+    }
+
+    public function test_save_persists_allowed_ips_list(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        $source = ExternalSource::factory()->create(['name' => 'Source']);
+
+        Livewire::test(ApiWebhookSourcePage::class, ['source' => $source->id])
+            ->set('webhookUrl', '')
+            ->set('allowedIps', "203.0.113.10\n198.51.100.5\n203.0.113.10")
+            ->call('saveWebhookUrl')
+            ->assertSuccessful()
+            ->assertSet('saved', true);
+
+        // Deduplicated, two unique IPs persisted.
+        $this->assertSame(
+            ['203.0.113.10', '198.51.100.5'],
+            ExternalSource::find($source->id)->allowed_ips
+        );
+    }
+
+    public function test_save_rejects_invalid_ip(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        $source = ExternalSource::factory()->create(['name' => 'Source']);
+
+        $component = Livewire::test(ApiWebhookSourcePage::class, ['source' => $source->id])
+            ->set('allowedIps', "203.0.113.10\nnot-an-ip")
+            ->call('saveWebhookUrl');
+
+        $this->assertNotNull($component->get('allowedIpsError'));
+        $this->assertFalse($component->get('saved'));
+        $this->assertNull(ExternalSource::find($source->id)->allowed_ips);
+    }
+
+    public function test_empty_allowed_ips_saved_as_null(): void
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        $source = ExternalSource::factory()->create([
+            'name' => 'Source',
+            'allowed_ips' => ['203.0.113.10'],
+        ]);
+
+        Livewire::test(ApiWebhookSourcePage::class, ['source' => $source->id])
+            ->set('allowedIps', '')
+            ->call('saveWebhookUrl')
+            ->assertSet('saved', true);
+
+        $this->assertNull(ExternalSource::find($source->id)->allowed_ips);
     }
 }

--- a/tests/Unit/Livewire/Settings/GeneralSettingsPageTest.php
+++ b/tests/Unit/Livewire/Settings/GeneralSettingsPageTest.php
@@ -5,16 +5,15 @@ namespace Tests\Unit\Livewire\Settings;
 use App\Livewire\Settings\GeneralSettingsPage;
 use App\Services\Settings\SettingsService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\Cache;
 use Mockery;
 use Tests\TestCase;
 
 /**
  * Unit-level tests for GeneralSettingsPage Livewire component.
  *
- * Focuses on business logic in isolation: mount(), save(), cancel()
- * methods using a mocked SettingsService so no DB or Livewire rendering
- * is required for the core logic assertions.
+ * The screen now manages a single setting — the Telegram topic-name template
+ * (`telegram.template_topic_name`). Bot name, description, and manager
+ * interface were removed from this screen.
  */
 class GeneralSettingsPageTest extends TestCase
 {
@@ -26,88 +25,47 @@ class GeneralSettingsPageTest extends TestCase
         Mockery::close();
     }
 
-    public function test_mount_populates_properties_from_settings_service(): void
+    public function test_mount_populates_template_from_settings_service(): void
     {
         /** @var \Mockery\MockInterface&SettingsService $mock */
         $mock = Mockery::mock(SettingsService::class);
-        $mock->shouldReceive('get')->with('app.bot_name')->andReturn('Test Bot');
-        $mock->shouldReceive('get')->with('app.bot_description')->andReturn('A description');
-        $mock->shouldReceive('get')->with('app.manager_interface')->andReturn('admin_panel');
-        $mock->shouldReceive('get')->with('telegram.template_topic_name')->andReturn('');
+        $mock->shouldReceive('get')->with('telegram.template_topic_name')->andReturn('Обращение');
 
         $component = new GeneralSettingsPage();
         $component->mount($mock);
 
-        $this->assertSame('Test Bot', $component->bot_name);
-        $this->assertSame('A description', $component->bot_description);
-        $this->assertSame('admin_panel', $component->manager_interface);
+        $this->assertSame('Обращение', $component->template_topic_name);
     }
 
-    public function test_mount_uses_empty_string_when_settings_return_null(): void
+    public function test_mount_uses_empty_string_when_setting_returns_null(): void
     {
         /** @var \Mockery\MockInterface&SettingsService $mock */
         $mock = Mockery::mock(SettingsService::class);
-        $mock->shouldReceive('get')->with('app.bot_name')->andReturn(null);
-        $mock->shouldReceive('get')->with('app.bot_description')->andReturn(null);
-        $mock->shouldReceive('get')->with('app.manager_interface')->andReturn(null);
-        $mock->shouldReceive('get')->with('telegram.template_topic_name')->andReturn('');
+        $mock->shouldReceive('get')->with('telegram.template_topic_name')->andReturn(null);
 
         $component = new GeneralSettingsPage();
         $component->mount($mock);
 
-        $this->assertSame('', $component->bot_name);
-        $this->assertSame('', $component->bot_description);
-        $this->assertSame('telegram_group', $component->manager_interface);
+        $this->assertSame('', $component->template_topic_name);
     }
 
-    public function test_save_calls_settings_service_set_for_all_three_keys(): void
+    public function test_save_persists_template_topic_name(): void
     {
         /** @var \Mockery\MockInterface&SettingsService $mock */
         $mock = Mockery::mock(SettingsService::class);
-        // mount call
-        $mock->shouldReceive('get')->with('app.bot_name')->andReturn('');
-        $mock->shouldReceive('get')->with('app.bot_description')->andReturn('');
-        $mock->shouldReceive('get')->with('app.manager_interface')->andReturn('telegram_group');
         $mock->shouldReceive('get')->with('telegram.template_topic_name')->andReturn('');
-        // save: reads current interface to detect change
-        $mock->shouldReceive('get')->with('app.manager_interface')->andReturn('telegram_group');
-        $mock->shouldReceive('get')->with('telegram.template_topic_name')->andReturn('');
-        // save: writes
-        $mock->shouldReceive('set')->with('app.bot_name', 'My Bot')->once();
-        $mock->shouldReceive('set')->with('app.bot_description', 'Desc')->once();
-        $mock->shouldReceive('set')->with('app.manager_interface', 'telegram_group')->once();
-        $mock->shouldReceive('set')->with('telegram.template_topic_name', Mockery::type('string'))->once();
+        $mock->shouldReceive('set')->with('telegram.template_topic_name', 'Новое обращение')->once();
 
         $component = new GeneralSettingsPage();
         $component->mount($mock);
-        $component->bot_name = 'My Bot';
-        $component->bot_description = 'Desc';
-        $component->manager_interface = 'telegram_group';
+        $component->template_topic_name = 'Новое обращение';
         $component->save($mock);
 
         $this->assertTrue($component->saved);
         $this->assertEmpty($component->formErrors);
     }
 
-    public function test_save_sets_restart_notice_when_interface_changes(): void
-    {
-        /** @var \Mockery\MockInterface&SettingsService $mock */
-        $mock = Mockery::mock(SettingsService::class);
-        $mock->shouldReceive('get')->with('app.bot_name')->andReturn('');
-        $mock->shouldReceive('get')->with('app.bot_description')->andReturn('');
-        $mock->shouldReceive('get')->with('app.manager_interface')->andReturn('telegram_group');
-        $mock->shouldReceive('get')->with('telegram.template_topic_name')->andReturn('');
-        $mock->shouldReceive('set')->with(Mockery::any(), Mockery::any());
-
-        $component = new GeneralSettingsPage();
-        $component->mount($mock);
-        $component->manager_interface = 'admin_panel';
-        $component->save($mock);
-
-        $this->assertTrue($component->showRestartNotice);
-    }
-
-    public function test_save_does_not_persist_when_bot_name_exceeds_255(): void
+    public function test_save_does_not_persist_when_template_exceeds_255(): void
     {
         /** @var \Mockery\MockInterface&SettingsService $mock */
         $mock = Mockery::mock(SettingsService::class);
@@ -116,86 +74,28 @@ class GeneralSettingsPageTest extends TestCase
 
         $component = new GeneralSettingsPage();
         $component->mount($mock);
-        $component->bot_name = str_repeat('a', 256);
-        $component->manager_interface = 'telegram_group';
+        $component->template_topic_name = str_repeat('a', 256);
         $component->save($mock);
 
         $this->assertFalse($component->saved);
-        $this->assertArrayHasKey('bot_name', $component->formErrors);
+        $this->assertArrayHasKey('template_topic_name', $component->formErrors);
     }
 
-    public function test_save_does_not_persist_when_description_exceeds_1000(): void
+    public function test_cancel_resets_template_to_stored_value(): void
     {
         /** @var \Mockery\MockInterface&SettingsService $mock */
         $mock = Mockery::mock(SettingsService::class);
-        $mock->shouldReceive('get')->andReturn('');
-        $mock->shouldNotReceive('set');
+        $mock->shouldReceive('get')->with('telegram.template_topic_name')->andReturn('Stored');
 
         $component = new GeneralSettingsPage();
         $component->mount($mock);
-        $component->bot_description = str_repeat('x', 1001);
-        $component->manager_interface = 'telegram_group';
-        $component->save($mock);
-
-        $this->assertFalse($component->saved);
-        $this->assertArrayHasKey('bot_description', $component->formErrors);
-    }
-
-    public function test_save_does_not_persist_when_manager_interface_invalid(): void
-    {
-        /** @var \Mockery\MockInterface&SettingsService $mock */
-        $mock = Mockery::mock(SettingsService::class);
-        $mock->shouldReceive('get')->andReturn('');
-        $mock->shouldNotReceive('set');
-
-        $component = new GeneralSettingsPage();
-        $component->mount($mock);
-        $component->manager_interface = 'not_valid';
-        $component->save($mock);
-
-        $this->assertFalse($component->saved);
-        $this->assertArrayHasKey('manager_interface', $component->formErrors);
-    }
-
-    public function test_cancel_resets_properties_to_stored_values(): void
-    {
-        /** @var \Mockery\MockInterface&SettingsService $mock */
-        $mock = Mockery::mock(SettingsService::class);
-        $mock->shouldReceive('get')->with('app.bot_name')->andReturn('Stored');
-        $mock->shouldReceive('get')->with('app.bot_description')->andReturn('Stored desc');
-        $mock->shouldReceive('get')->with('app.manager_interface')->andReturn('admin_panel');
-        $mock->shouldReceive('get')->with('telegram.template_topic_name')->andReturn('');
-
-        $component = new GeneralSettingsPage();
-        $component->mount($mock);
-        // Simulate in-flight edits
-        $component->bot_name = 'Changed';
+        $component->template_topic_name = 'Changed';
         $component->saved = true;
-        $component->showRestartNotice = true;
 
         $component->cancel($mock);
 
-        $this->assertSame('Stored', $component->bot_name);
+        $this->assertSame('Stored', $component->template_topic_name);
         $this->assertFalse($component->saved);
-        $this->assertFalse($component->showRestartNotice);
         $this->assertEmpty($component->formErrors);
-    }
-
-    public function test_cache_flush_does_not_break_mount(): void
-    {
-        Cache::flush();
-        config(['app.manager_interface' => 'telegram_group']);
-
-        /** @var \Mockery\MockInterface&SettingsService $mock */
-        $mock = Mockery::mock(SettingsService::class);
-        $mock->shouldReceive('get')->with('app.bot_name')->andReturn(null);
-        $mock->shouldReceive('get')->with('app.bot_description')->andReturn(null);
-        $mock->shouldReceive('get')->with('app.manager_interface')->andReturn(null);
-        $mock->shouldReceive('get')->with('telegram.template_topic_name')->andReturn('');
-
-        $component = new GeneralSettingsPage();
-        $component->mount($mock);
-
-        $this->assertSame('telegram_group', $component->manager_interface);
     }
 }

--- a/tests/Unit/Models/ExternalSourceTest.php
+++ b/tests/Unit/Models/ExternalSourceTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\ExternalSource;
+use PHPUnit\Framework\TestCase;
+
+class ExternalSourceTest extends TestCase
+{
+    public function test_ip_allowed_when_allowlist_empty(): void
+    {
+        $source = new ExternalSource();
+        $source->allowed_ips = null;
+
+        $this->assertTrue($source->isIpAllowed('203.0.113.10'));
+        $this->assertTrue($source->isIpAllowed(null));
+    }
+
+    public function test_ip_allowed_when_in_list(): void
+    {
+        $source = new ExternalSource();
+        $source->allowed_ips = ['203.0.113.10', '198.51.100.5'];
+
+        $this->assertTrue($source->isIpAllowed('198.51.100.5'));
+    }
+
+    public function test_ip_rejected_when_not_in_list(): void
+    {
+        $source = new ExternalSource();
+        $source->allowed_ips = ['203.0.113.10'];
+
+        $this->assertFalse($source->isIpAllowed('5.6.7.8'));
+        $this->assertFalse($source->isIpAllowed(null));
+    }
+}

--- a/tests/Unit/Modules/Admin/Actions/BanBotUserTest.php
+++ b/tests/Unit/Modules/Admin/Actions/BanBotUserTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Unit\Modules\Admin\Actions;
+
+use App\Models\BotUser;
+use App\Modules\Admin\Actions\BanBotUser;
+use App\Modules\Telegram\Jobs\SendTelegramSimpleQueryJob;
+use App\Services\Settings\SettingsService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class BanBotUserTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
+    public function test_marks_user_banned_and_closed(): void
+    {
+        $botUser = BotUser::create(['chat_id' => 3001, 'platform' => 'telegram']);
+
+        (new BanBotUser())->execute($botUser);
+
+        $botUser->refresh();
+        $this->assertTrue($botUser->isBanned());
+        $this->assertNotNull($botUser->banned_at);
+        $this->assertTrue($botUser->isClosed());
+        $this->assertNotNull($botUser->closed_at);
+    }
+
+    public function test_closes_forum_topic_when_topic_id_present(): void
+    {
+        app(SettingsService::class)->set('telegram.group_id', '-1009876543210');
+
+        $botUser = BotUser::create(['chat_id' => 3002, 'platform' => 'telegram', 'topic_id' => 777]);
+
+        (new BanBotUser())->execute($botUser);
+
+        /** @phpstan-ignore-next-line */
+        $pushed = Queue::pushedJobs()[SendTelegramSimpleQueryJob::class] ?? [];
+        $methods = array_map(fn ($p) => $p['job']->queryParams->methodQuery, $pushed);
+
+        $this->assertContains('editForumTopic', $methods);
+        $this->assertContains('closeForumTopic', $methods);
+    }
+
+    public function test_does_not_close_topic_without_topic_id(): void
+    {
+        app(SettingsService::class)->set('telegram.group_id', '-1009876543210');
+
+        $botUser = BotUser::create(['chat_id' => 3003, 'platform' => 'telegram']);
+
+        (new BanBotUser())->execute($botUser);
+
+        Queue::assertNothingPushed();
+    }
+
+    public function test_noop_when_already_banned(): void
+    {
+        app(SettingsService::class)->set('telegram.group_id', '-1009876543210');
+
+        $botUser = BotUser::create([
+            'chat_id' => 3004,
+            'platform' => 'telegram',
+            'topic_id' => 888,
+            'is_banned' => true,
+            'banned_at' => now()->subDay(),
+        ]);
+
+        (new BanBotUser())->execute($botUser);
+
+        Queue::assertNothingPushed();
+    }
+}

--- a/tests/Unit/Modules/Admin/Actions/SendReplyActionTest.php
+++ b/tests/Unit/Modules/Admin/Actions/SendReplyActionTest.php
@@ -134,4 +134,34 @@ class SendReplyActionTest extends TestCase
                 && $job->payload['message']['text'] === 'Test message';
         });
     }
+
+    public function test_reopens_closed_conversation_on_reply(): void
+    {
+        Queue::fake();
+
+        $botUser = BotUser::create([
+            'chat_id' => 300,
+            'platform' => 'telegram',
+            'is_closed' => true,
+            'closed_at' => now()->subDay(),
+        ]);
+
+        SendReplyAction::execute($botUser, 'Reopening reply');
+
+        $botUser->refresh();
+        $this->assertFalse($botUser->isClosed());
+        $this->assertNull($botUser->closed_at);
+    }
+
+    public function test_does_not_touch_open_conversation_on_reply(): void
+    {
+        Queue::fake();
+
+        $botUser = BotUser::create(['chat_id' => 301, 'platform' => 'telegram', 'is_closed' => false]);
+
+        SendReplyAction::execute($botUser, 'Regular reply');
+
+        $botUser->refresh();
+        $this->assertFalse($botUser->isClosed());
+    }
 }

--- a/tests/Unit/Modules/Admin/Actions/UnbanBotUserTest.php
+++ b/tests/Unit/Modules/Admin/Actions/UnbanBotUserTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Unit\Modules\Admin\Actions;
+
+use App\Models\BotUser;
+use App\Modules\Admin\Actions\UnbanBotUser;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UnbanBotUserTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_clears_ban_fields(): void
+    {
+        $botUser = BotUser::create([
+            'chat_id' => 4001,
+            'platform' => 'telegram',
+            'is_banned' => true,
+            'banned_at' => now()->subDay(),
+        ]);
+
+        (new UnbanBotUser())->execute($botUser);
+
+        $botUser->refresh();
+        $this->assertFalse($botUser->isBanned());
+        $this->assertNull($botUser->banned_at);
+    }
+
+    public function test_does_not_reopen_closed_conversation(): void
+    {
+        $botUser = BotUser::create([
+            'chat_id' => 4002,
+            'platform' => 'telegram',
+            'is_banned' => true,
+            'banned_at' => now()->subDay(),
+            'is_closed' => true,
+            'closed_at' => now()->subDay(),
+        ]);
+
+        (new UnbanBotUser())->execute($botUser);
+
+        $botUser->refresh();
+        $this->assertFalse($botUser->isBanned());
+        $this->assertTrue($botUser->isClosed());
+    }
+
+    public function test_noop_when_not_banned(): void
+    {
+        $botUser = BotUser::create(['chat_id' => 4003, 'platform' => 'telegram', 'is_banned' => false]);
+
+        (new UnbanBotUser())->execute($botUser);
+
+        $botUser->refresh();
+        $this->assertFalse($botUser->isBanned());
+    }
+}

--- a/tests/Unit/Modules/Feedback/Actions/HandleFeedbackRatingTest.php
+++ b/tests/Unit/Modules/Feedback/Actions/HandleFeedbackRatingTest.php
@@ -6,6 +6,7 @@ use App\Models\BotUser;
 use App\Models\Feedback;
 use App\Modules\Feedback\Actions\HandleFeedbackRating;
 use App\Modules\Telegram\Jobs\SendTelegramSimpleQueryJob;
+use App\Services\Settings\SettingsService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Queue;
 use Tests\TestCase;
@@ -100,6 +101,73 @@ class HandleFeedbackRatingTest extends TestCase
         (new HandleFeedbackRating())->execute($callbackData);
 
         Queue::assertNothingPushed();
+    }
+
+    public function test_records_rating_as_incoming_chat_message(): void
+    {
+        $botUser = BotUser::create(['chat_id' => 2001, 'platform' => 'telegram']);
+        $feedback = Feedback::create([
+            'bot_user_id' => $botUser->id,
+            'status' => 'awaiting_rating',
+            'closed_at' => now(),
+        ]);
+
+        (new HandleFeedbackRating())->execute("feedback_rate_{$botUser->id}_{$feedback->id}_5");
+
+        $this->assertDatabaseHas('messages', [
+            'bot_user_id' => $botUser->id,
+            'message_type' => 'incoming',
+            'text' => 'Оценка обращения: ' . str_repeat('⭐', 5) . ' (5/5)',
+        ]);
+    }
+
+    public function test_posts_rating_to_group_topic_when_topic_id_present(): void
+    {
+        app(SettingsService::class)->set('telegram.group_id', '-1001234567890');
+
+        $botUser = BotUser::create(['chat_id' => 2002, 'platform' => 'telegram', 'topic_id' => 555]);
+        $feedback = Feedback::create([
+            'bot_user_id' => $botUser->id,
+            'status' => 'awaiting_rating',
+            'closed_at' => now(),
+        ]);
+
+        (new HandleFeedbackRating())->execute("feedback_rate_{$botUser->id}_{$feedback->id}_4");
+
+        /** @phpstan-ignore-next-line */
+        $pushed = Queue::pushedJobs()[SendTelegramSimpleQueryJob::class] ?? [];
+        $topicJobs = array_values(array_filter(
+            $pushed,
+            fn ($p) => $p['job']->queryParams->methodQuery === 'sendMessage'
+        ));
+
+        $this->assertNotEmpty($topicJobs);
+        $job = $topicJobs[0]['job'];
+        $this->assertEquals('-1001234567890', $job->queryParams->chat_id);
+        $this->assertEquals(555, $job->queryParams->message_thread_id);
+    }
+
+    public function test_does_not_post_to_group_topic_without_topic_id(): void
+    {
+        app(SettingsService::class)->set('telegram.group_id', '-1001234567890');
+
+        $botUser = BotUser::create(['chat_id' => 2003, 'platform' => 'telegram']);
+        $feedback = Feedback::create([
+            'bot_user_id' => $botUser->id,
+            'status' => 'awaiting_rating',
+            'closed_at' => now(),
+        ]);
+
+        (new HandleFeedbackRating())->execute("feedback_rate_{$botUser->id}_{$feedback->id}_4");
+
+        /** @phpstan-ignore-next-line */
+        $pushed = Queue::pushedJobs()[SendTelegramSimpleQueryJob::class] ?? [];
+        $sendMessageJobs = array_filter(
+            $pushed,
+            fn ($p) => $p['job']->queryParams->methodQuery === 'sendMessage'
+        );
+
+        $this->assertEmpty($sendMessageJobs);
     }
 
     public function test_parse_callback_data_returns_correct_values(): void


### PR DESCRIPTION
## Summary

Redesigns the manager admin panel: the Filament resources are replaced by a standalone, chrome-free Livewire chat workspace (`/admin/chats`) plus custom settings screens (General, Integrations, AI assistant, API & webhooks, Team), all backed by a new runtime settings layer (`SettingsService` + `SettingKeyRegistry` + `settings` table) that moves every channel/AI credential out of `.env` into the encrypted DB store. On top of that the chat workspace gains operator actions — send replies with file attachments, close / ban / unban a dialog, an unread indicator with persisted read tracking, 5 s polling of the open thread, the feedback rating echoed into the conversation, and a Telegram photo-caption fix — alongside a custom Filament login/logout, an external-source IP allowlist, AI provider verify-before-save, Telescope (replacing Pulse), and removal of the Loki/Grafana stack.

## Linked issues

Closes #163

## Checklist

- [ ] Tests pass locally
- [ ] Docs / CHANGELOG updated if behavior changed
- [ ] No leftover debug code, prints, or stale TODOs
- [ ] Breaking changes flagged in the summary

## Notes for reviewer

Large branch (75 commits). Key risk areas: (1) all channel/AI credentials now read from the DB via `SettingsService` with `config => null` (no `.env` fallback) — environments must re-enter values via the admin UI; (2) `MANAGER_INTERFACE` is switched only via `.env` + container restart (the admin-panel switch was removed); (3) the external-source IP allowlist enforces exact IP match in `ApiQuery` — behind a proxy, `TrustProxies` must be configured for `$request->ip()` to be correct. Full suite is green (722 tests) and PHPStan level 6 passes via the pre-push hook.

---

_The task was generated using the MCP server — [prog-time/mcp-github-issues](https://github.com/prog-time/mcp-github-issues)._
