### PR TITLE
Профили пользователей, аватарки команды и авторство сообщений (issues-171, #172)

### DIFF
--- a/app/Jobs/EnrichBotUserProfileJob.php
+++ b/app/Jobs/EnrichBotUserProfileJob.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\BotUser;
+use App\Modules\Api\Services\FileService;
+use App\Modules\Telegram\Actions\GetChat;
+use App\Modules\Vk\Api\VkMethods;
+use App\Services\Settings\SettingsService;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+
+class EnrichBotUserProfileJob implements ShouldQueue
+{
+    use Queueable;
+
+    public const SYNC_TTL_DAYS = 30;
+
+    /**
+     * @param BotUser $botUser
+     */
+    public function __construct(private readonly BotUser $botUser)
+    {
+    }
+
+    /**
+     * Execute the job.
+     *
+     * Fetches the profile avatar from Telegram or VK and stores it locally.
+     * For other platforms, just records the sync timestamp.
+     *
+     * @return void
+     */
+    public function handle(): void
+    {
+        // TTL guard — skip if profile was synced recently.
+        if (
+            $this->botUser->profile_synced_at !== null
+            && $this->botUser->profile_synced_at->diffInDays(now()) < self::SYNC_TTL_DAYS
+        ) {
+            return;
+        }
+
+        try {
+            match ($this->botUser->platform) {
+                'telegram' => $this->enrichFromTelegram(),
+                'vk' => $this->enrichFromVk(),
+                default => $this->botUser->update(['profile_synced_at' => now()]),
+            };
+        } catch (\Throwable $e) {
+            Log::channel('app')->error(
+                'EnrichBotUserProfileJob failed',
+                [
+                    'bot_user_id' => $this->botUser->id,
+                    'platform' => $this->botUser->platform,
+                    'error' => $e->getMessage(),
+                    'file' => $e->getFile(),
+                    'line' => $e->getLine(),
+                ]
+            );
+        }
+    }
+
+    /**
+     * Fetch avatar from Telegram getChat and store it locally.
+     *
+     * @return void
+     */
+    private function enrichFromTelegram(): void
+    {
+        $answer = app(GetChat::class)->execute((int) $this->botUser->chat_id);
+
+        $fileId = $answer->rawData['result']['photo']['small_file_id'] ?? null;
+
+        if ($fileId !== null) {
+            $fileData = app(FileService::class)->getTelegramFile((string) $fileId);
+            $filePath = $fileData['result']['file_path'] ?? null;
+
+            if ($filePath !== null) {
+                $token = (string) app(SettingsService::class)->get('telegram.token');
+                $response = Http::get("https://api.telegram.org/file/bot{$token}/{$filePath}");
+
+                if ($response->ok()) {
+                    $storagePath = "avatars/bot-user-{$this->botUser->id}.jpg";
+                    Storage::disk('local')->put($storagePath, $response->body());
+                    $this->botUser->update([
+                        'avatar_path' => $storagePath,
+                        'profile_synced_at' => now(),
+                    ]);
+
+                    return;
+                }
+            }
+        }
+
+        // No photo or download failed — still mark synced so we don't retry immediately.
+        $this->botUser->update(['profile_synced_at' => now()]);
+    }
+
+    /**
+     * Fetch profile data from VK users.get and store avatar locally.
+     *
+     * @return void
+     */
+    private function enrichFromVk(): void
+    {
+        $vkAnswer = VkMethods::sendQueryVk('users.get', [
+            'user_ids' => $this->botUser->chat_id,
+            'fields' => 'photo_200',
+        ]);
+
+        $user = null;
+        if (is_array($vkAnswer->response) && !empty($vkAnswer->response[0])) {
+            $user = $vkAnswer->response[0];
+        }
+
+        $update = ['profile_synced_at' => now()];
+
+        if ($user !== null) {
+            $firstName = $user['first_name'] ?? null;
+            $lastName = $user['last_name'] ?? null;
+            $name = trim(($firstName ?? '') . ' ' . ($lastName ?? ''));
+
+            if ($name !== '' && $this->botUser->display_name === null) {
+                $update['display_name'] = $name;
+            }
+
+            $photoUrl = $user['photo_200'] ?? null;
+            if ($photoUrl !== null) {
+                $response = Http::get($photoUrl);
+                if ($response->ok()) {
+                    $storagePath = "avatars/bot-user-{$this->botUser->id}.jpg";
+                    Storage::disk('local')->put($storagePath, $response->body());
+                    $update['avatar_path'] = $storagePath;
+                }
+            }
+        }
+
+        $this->botUser->update($update);
+    }
+}

--- a/app/Livewire/Chat/ConversationPage.php
+++ b/app/Livewire/Chat/ConversationPage.php
@@ -17,6 +17,7 @@ use App\Modules\Telegram\Actions\CloseTopic;
 use Filament\Notifications\Notification;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
 use Livewire\Attributes\Layout;
 use Livewire\Attributes\Locked;
 use Livewire\Component;
@@ -407,7 +408,10 @@ class ConversationPage extends Component
         $latest = $fresh->last();
         $count = $fresh->count();
 
-        $chatId = (string) (BotUser::where('id', $latest->bot_user_id)->value('chat_id') ?? '');
+        $notifyUser = BotUser::where('id', $latest->bot_user_id)->first(['chat_id', 'display_name']);
+        $chatId = $notifyUser !== null
+            ? (string) ($notifyUser->display_name ?? $notifyUser->chat_id)
+            : '';
         $preview = filled($latest->text)
             ? mb_substr((string) $latest->text, 0, 80)
             : 'Вложение';
@@ -442,7 +446,7 @@ class ConversationPage extends Component
         // Most recent page only — older messages are pulled in on scroll-up.
         // Fetch one extra row to detect whether more history exists.
         $batch = Message::where('bot_user_id', $this->activeBotUserId)
-            ->with(['externalMessage', 'attachments'])
+            ->with(['externalMessage', 'attachments', 'sender'])
             ->orderByDesc('created_at')
             ->orderByDesc('id')
             ->limit(self::MESSAGES_PER_PAGE + 1)
@@ -473,7 +477,7 @@ class ConversationPage extends Component
         $oldest = $this->chatMessages->first();
 
         $batch = Message::where('bot_user_id', $this->activeBotUserId)
-            ->with(['externalMessage', 'attachments'])
+            ->with(['externalMessage', 'attachments', 'sender'])
             ->where(function ($q) use ($oldest): void {
                 $q->where('created_at', '<', $oldest->created_at)
                     ->orWhere(function ($q2) use ($oldest): void {
@@ -511,7 +515,7 @@ class ConversationPage extends Component
         $newest = $this->chatMessages->last();
 
         $query = Message::where('bot_user_id', $this->activeBotUserId)
-            ->with(['externalMessage', 'attachments'])
+            ->with(['externalMessage', 'attachments', 'sender'])
             ->orderBy('created_at')
             ->orderBy('id');
 
@@ -563,7 +567,9 @@ class ConversationPage extends Component
             'attachment' => ['nullable', 'file', 'max:20480'],
         ]);
 
-        SendReplyAction::execute($this->activeBotUser, $this->replyText, $file);
+        /** @var \App\Models\User $operator */
+        $operator = Auth::user();
+        SendReplyAction::execute($this->activeBotUser, $this->replyText, $file, $operator);
 
         $this->replyText = '';
         $this->attachment = null;

--- a/app/Livewire/Settings/TeamMemberCreatePage.php
+++ b/app/Livewire/Settings/TeamMemberCreatePage.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\Rule;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
+use Livewire\WithFileUploads;
 
 /**
  * «Новый участник» — add a team member (operator) with an explicit password.
@@ -25,6 +26,8 @@ use Livewire\Component;
 #[Layout('layouts.admin-settings')]
 class TeamMemberCreatePage extends Component
 {
+    use WithFileUploads;
+
     /** @var string Member name */
     public string $name = '';
 
@@ -39,6 +42,9 @@ class TeamMemberCreatePage extends Component
 
     /** @var string Role slug: admin|manager */
     public string $role = '';
+
+    /** @var \Livewire\Features\SupportFileUploads\TemporaryUploadedFile|null Avatar image to upload (optional) */
+    public $avatar = null;
 
     /**
      * Boot: redirect non-admins to general settings.
@@ -55,6 +61,9 @@ class TeamMemberCreatePage extends Component
 
     /**
      * Validate and create the team member, then return to the team list.
+     *
+     * If an avatar was uploaded, it is stored on the `local` disk under
+     * `avatars/user-{id}.jpg` after the user record is created.
      */
     public function save(): void
     {
@@ -63,6 +72,7 @@ class TeamMemberCreatePage extends Component
             'email' => ['required', 'email', 'max:255', Rule::unique('users', 'email')],
             'password' => ['required', 'string', 'min:8', 'confirmed'],
             'role' => ['required', Rule::in(array_keys(UserRole::options()))],
+            'avatar' => ['nullable', 'image', 'max:2048'],
         ], [
             'name.required' => 'Введите имя.',
             'email.required' => 'Введите email.',
@@ -73,14 +83,21 @@ class TeamMemberCreatePage extends Component
             'password.confirmed' => 'Пароли не совпадают.',
             'role.required' => 'Выберите роль.',
             'role.in' => 'Недопустимая роль.',
+            'avatar.image' => 'Файл должен быть изображением.',
+            'avatar.max' => 'Размер изображения не должен превышать 2 МБ.',
         ]);
 
-        User::create([
+        $user = User::create([
             'name' => $validated['name'],
             'email' => $validated['email'],
             'password' => $validated['password'],
             'role' => UserRole::from($validated['role']),
         ]);
+
+        if ($this->avatar !== null) {
+            $path = $this->avatar->storeAs('avatars', "user-{$user->id}.jpg", 'local');
+            $user->update(['avatar_path' => $path]);
+        }
 
         $this->redirectRoute('admin.settings.team');
     }

--- a/app/Livewire/Settings/TeamMemberEditPage.php
+++ b/app/Livewire/Settings/TeamMemberEditPage.php
@@ -7,9 +7,11 @@ namespace App\Livewire\Settings;
 use App\Enums\UserRole;
 use App\Models\User;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Validation\Rule;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
+use Livewire\WithFileUploads;
 
 /**
  * «Редактирование участника» — edit a team member (name, email, role) and
@@ -26,6 +28,8 @@ use Livewire\Component;
 #[Layout('layouts.admin-settings')]
 class TeamMemberEditPage extends Component
 {
+    use WithFileUploads;
+
     /** @var int The edited user id */
     public int $userId = 0;
 
@@ -43,6 +47,12 @@ class TeamMemberEditPage extends Component
 
     /** @var string New password confirmation */
     public string $password_confirmation = '';
+
+    /** @var string|null Current avatar path stored in the DB */
+    public ?string $currentAvatarPath = null;
+
+    /** @var \Livewire\Features\SupportFileUploads\TemporaryUploadedFile|null New avatar image to upload (optional) */
+    public $avatar = null;
 
     /**
      * Boot: guard admin access, then prefill from the user.
@@ -72,12 +82,14 @@ class TeamMemberEditPage extends Component
         $this->name = $member->name;
         $this->email = $member->email;
         $this->role = $member->role->value;
+        $this->currentAvatarPath = $member->avatar_path;
     }
 
     /**
      * Validate and persist the changes, then return to the team list.
      *
      * Password is optional: a blank value keeps the current password.
+     * If a new avatar was uploaded, it overwrites the existing one.
      */
     public function save(): void
     {
@@ -86,6 +98,7 @@ class TeamMemberEditPage extends Component
             'email' => ['required', 'email', 'max:255', Rule::unique('users', 'email')->ignore($this->userId)],
             'role' => ['required', Rule::in(array_keys(UserRole::options()))],
             'password' => ['nullable', 'string', 'min:8', 'confirmed'],
+            'avatar' => ['nullable', 'image', 'max:2048'],
         ], [
             'name.required' => 'Введите имя.',
             'email.required' => 'Введите email.',
@@ -95,6 +108,8 @@ class TeamMemberEditPage extends Component
             'role.in' => 'Недопустимая роль.',
             'password.min' => 'Пароль должен быть не короче 8 символов.',
             'password.confirmed' => 'Пароли не совпадают.',
+            'avatar.image' => 'Файл должен быть изображением.',
+            'avatar.max' => 'Размер изображения не должен превышать 2 МБ.',
         ]);
 
         $member = User::find($this->userId);
@@ -115,9 +130,34 @@ class TeamMemberEditPage extends Component
             $data['password'] = $validated['password'];
         }
 
+        if ($this->avatar !== null) {
+            $path = $this->avatar->storeAs('avatars', "user-{$member->id}.jpg", 'local');
+            $data['avatar_path'] = $path;
+        }
+
         $member->update($data);
 
         $this->redirectRoute('admin.settings.team');
+    }
+
+    /**
+     * Remove the current avatar: delete the file from local disk and null avatar_path.
+     */
+    public function removeAvatar(): void
+    {
+        $member = User::find($this->userId);
+
+        if (! $member) {
+            return;
+        }
+
+        if ($member->avatar_path !== null) {
+            Storage::disk('local')->delete($member->avatar_path);
+            $member->update(['avatar_path' => null]);
+            $this->currentAvatarPath = null;
+        }
+
+        $this->avatar = null;
     }
 
     /**

--- a/app/Livewire/Settings/TeamPage.php
+++ b/app/Livewire/Settings/TeamPage.php
@@ -6,6 +6,7 @@ namespace App\Livewire\Settings;
 
 use App\Models\User;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
 
@@ -129,7 +130,17 @@ class TeamPage extends Component
             return;
         }
 
-        User::whereKey($userId)->delete();
+        $member = User::find($userId);
+
+        if (! $member) {
+            return;
+        }
+
+        if ($member->avatar_path !== null) {
+            Storage::disk('local')->delete($member->avatar_path);
+        }
+
+        $member->delete();
     }
 
     /**

--- a/app/Models/BotUser.php
+++ b/app/Models/BotUser.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Jobs\EnrichBotUserProfileJob;
 use App\Modules\External\DTOs\ExternalMessageDto;
 use App\Modules\Telegram\DTOs\TelegramUpdateDto;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -16,6 +17,10 @@ use phpDocumentor\Reflection\Exception;
  * @property int                             $topic_id
  * @property int                             $chat_id
  * @property string                          $platform
+ * @property string|null                     $display_name
+ * @property string|null                     $username
+ * @property string|null                     $avatar_path
+ * @property \Illuminate\Support\Carbon|null $profile_synced_at
  * @property mixed                           $aiCondition
  * @property mixed                           $lastMessageManager
  * @property ExternalUser|null               $externalUser
@@ -34,6 +39,10 @@ class BotUser extends Model
         'chat_id',
         'topic_id',
         'platform',
+        'display_name',
+        'username',
+        'avatar_path',
+        'profile_synced_at',
         'is_banned',
         'banned_at',
         'is_closed',
@@ -43,6 +52,7 @@ class BotUser extends Model
 
     protected $casts = [
         'manager_last_read_at' => 'datetime',
+        'profile_synced_at' => 'datetime',
     ];
 
     /**
@@ -159,6 +169,34 @@ class BotUser extends Model
                         'platform' => 'telegram',
                     ]
                 );
+
+                if ($botUser->wasRecentlyCreated) {
+                    // New user — fill profile from DTO synchronously.
+                    $fill = [];
+                    if ($update->displayName !== null) {
+                        $fill['display_name'] = $update->displayName;
+                    }
+                    if ($update->username !== null) {
+                        $fill['username'] = $update->username;
+                    }
+                    if (!empty($fill)) {
+                        $botUser->update($fill);
+                    }
+                } else {
+                    // Existing user — opportunistically update only if changed.
+                    $fill = [];
+                    if ($update->displayName !== null && $botUser->display_name !== $update->displayName) {
+                        $fill['display_name'] = $update->displayName;
+                    }
+                    if ($update->username !== null && $botUser->username !== $update->username) {
+                        $fill['username'] = $update->username;
+                    }
+                    if (!empty($fill)) {
+                        $botUser->update($fill);
+                    }
+                }
+
+                self::maybeEnrichProfile($botUser);
             }
 
             return $botUser ?? null;
@@ -197,13 +235,37 @@ class BotUser extends Model
     public static function getUserByChatId(string|int $chatId, string $platform): ?BotUser
     {
         try {
-            return self::firstOrCreate([
+            $botUser = self::firstOrCreate([
                 'chat_id' => $chatId,
             ], [
                 'platform' => $platform,
             ]);
+
+            self::maybeEnrichProfile($botUser);
+
+            return $botUser;
         } catch (\Throwable $e) {
             return null;
+        }
+    }
+
+    /**
+     * Dispatch the async profile-enrichment job only when a (re)sync is due —
+     * i.e. the profile has never been synced or its data is older than the TTL.
+     *
+     * Guarding the dispatch (not just the job body) avoids enqueuing a no-op job
+     * on every incoming message; the job's own TTL check is the final safety net.
+     *
+     * @param BotUser $botUser
+     *
+     * @return void
+     */
+    private static function maybeEnrichProfile(BotUser $botUser): void
+    {
+        $syncedAt = $botUser->profile_synced_at;
+
+        if ($syncedAt === null || $syncedAt->diffInDays(now()) >= EnrichBotUserProfileJob::SYNC_TTL_DAYS) {
+            dispatch(new EnrichBotUserProfileJob($botUser));
         }
     }
 

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -15,8 +15,11 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  * @property int                  $from_id
  * @property int                  $to_id
  * @property string|null          $text
+ * @property int|null             $sender_user_id
+ * @property string|null          $sender_name
  * @property ExternalMessage|null $externalMessage
  * @property BotUser|null         $botUser
+ * @property User|null            $sender
  * @property-read \Illuminate\Database\Eloquent\Collection<int, MessageAttachment> $attachments
  */
 class Message extends Model
@@ -30,6 +33,8 @@ class Message extends Model
         'from_id',
         'to_id',
         'text',
+        'sender_user_id',
+        'sender_name',
     ];
 
     /**
@@ -54,6 +59,17 @@ class Message extends Model
     public function botUser(): BelongsTo
     {
         return $this->belongsTo(BotUser::class);
+    }
+
+    /**
+     * The admin-panel operator who sent this outgoing message.
+     * Null for incoming messages, AI auto-replies, or Telegram-group replies.
+     *
+     * @return BelongsTo
+     */
+    public function sender(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'sender_user_id');
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -10,7 +10,8 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
 /**
- * @property UserRole $role
+ * @property UserRole    $role
+ * @property string|null $avatar_path
  */
 class User extends Authenticatable implements FilamentUser
 {
@@ -45,6 +46,7 @@ class User extends Authenticatable implements FilamentUser
         'email',
         'password',
         'role',
+        'avatar_path',
     ];
 
     /**

--- a/app/Modules/Admin/Actions/DeleteBotUser.php
+++ b/app/Modules/Admin/Actions/DeleteBotUser.php
@@ -10,6 +10,7 @@ use App\Models\Feedback;
 use App\Models\Message;
 use App\Models\MessageAttachment;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
 
 class DeleteBotUser
 {
@@ -43,6 +44,17 @@ class DeleteBotUser
             AiMessage::where('bot_user_id', $botUser->id)->delete();
             Feedback::where('bot_user_id', $botUser->id)->delete();
             AiCondition::where('bot_user_id', $botUser->id)->delete();
+
+            // Remove the locally-stored avatar file and clear PII profile fields.
+            if ($botUser->avatar_path) {
+                Storage::disk('local')->delete($botUser->avatar_path);
+            }
+            $botUser->update([
+                'display_name' => null,
+                'username' => null,
+                'avatar_path' => null,
+                'profile_synced_at' => null,
+            ]);
 
             $botUser->delete();
         });

--- a/app/Modules/Admin/Actions/SendReplyAction.php
+++ b/app/Modules/Admin/Actions/SendReplyAction.php
@@ -4,6 +4,7 @@ namespace App\Modules\Admin\Actions;
 
 use App\Models\BotUser;
 use App\Models\Message;
+use App\Models\User;
 use App\Modules\Admin\Jobs\SendAdminDocumentJob;
 use App\Modules\External\Jobs\SendWebhookMessage;
 use App\Modules\Max\Actions\UploadFileMax;
@@ -28,10 +29,11 @@ class SendReplyAction
      * @param BotUser           $botUser Target user
      * @param string            $text    Message text (may be empty when file is provided)
      * @param UploadedFile|null $file    Optional file attachment
+     * @param User|null         $author  Operator sending the reply (null for AI/telegram-group paths)
      *
      * @return void
      */
-    public static function execute(BotUser $botUser, string $text, ?UploadedFile $file = null): void
+    public static function execute(BotUser $botUser, string $text, ?UploadedFile $file = null, ?User $author = null): void
     {
         // A new reply re-opens a previously closed conversation.
         if ($botUser->isClosed()) {
@@ -45,6 +47,8 @@ class SendReplyAction
             'from_id' => 0,
             'to_id' => 0,
             'text' => $text ?: null,
+            'sender_user_id' => $author?->id,
+            'sender_name' => $author?->name,
         ]);
 
         match (true) {

--- a/app/Modules/Admin/AdminServiceProvider.php
+++ b/app/Modules/Admin/AdminServiceProvider.php
@@ -15,8 +15,10 @@ use App\Livewire\Settings\IntegrationsListPage;
 use App\Livewire\Settings\TeamMemberCreatePage;
 use App\Livewire\Settings\TeamMemberEditPage;
 use App\Livewire\Settings\TeamPage;
+use App\Modules\Admin\Controllers\BotUserAvatarController;
 use App\Modules\Admin\Controllers\ChatAttachmentController;
 use App\Modules\Admin\Controllers\PwaController;
+use App\Modules\Admin\Controllers\UserAvatarController;
 use Filament\Http\Middleware\Authenticate;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
@@ -55,6 +57,18 @@ class AdminServiceProvider extends ServiceProvider
             ->get('/admin/chat-attachments/{attachment}', [ChatAttachmentController::class, 'show'])
             ->name('admin.chat-attachment')
             ->where('attachment', '[0-9]+');
+
+        // Streams locally-stored bot user avatars — fetched async by EnrichBotUserProfileJob.
+        Route::middleware(['web', Authenticate::class])
+            ->get('/admin/bot-user-avatars/{botUser}', [BotUserAvatarController::class, 'show'])
+            ->name('admin.bot-user-avatar')
+            ->where('botUser', '[0-9]+');
+
+        // Streams locally-stored team member (operator) avatars — uploaded via TeamMemberCreatePage / TeamMemberEditPage.
+        Route::middleware(['web', Authenticate::class])
+            ->get('/admin/team-member-avatars/{user}', [UserAvatarController::class, 'show'])
+            ->name('admin.team-member-avatar')
+            ->where('user', '[0-9]+');
 
         // Custom Livewire Settings routes.
         // Prefix: /admin/settings — verified not claimed by Filament's panel.

--- a/app/Modules/Admin/Controllers/BotUserAvatarController.php
+++ b/app/Modules/Admin/Controllers/BotUserAvatarController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Modules\Admin\Controllers;
+
+use App\Models\BotUser;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+/**
+ * Serves locally-stored bot user avatars to the admin chat workspace.
+ *
+ * Avatars are fetched asynchronously by EnrichBotUserProfileJob and stored
+ * under avatars/ on the private `local` disk. This auth-gated route streams
+ * them back — no dependency on the `public` disk symlink.
+ */
+class BotUserAvatarController
+{
+    /**
+     * Stream the avatar inline.
+     *
+     * Validates that the stored path is a safe avatars/ path before serving.
+     *
+     * @param BotUser $botUser
+     *
+     * @return StreamedResponse
+     */
+    public function show(BotUser $botUser): StreamedResponse
+    {
+        $path = (string) $botUser->avatar_path;
+
+        abort_unless(
+            $path !== '' && str_starts_with($path, 'avatars/') && ! str_contains($path, '..'),
+            404
+        );
+
+        abort_unless(Storage::disk('local')->exists($path), 404);
+
+        return Storage::disk('local')->response($path, null, [
+            'Cache-Control' => 'private, max-age=86400',
+        ]);
+    }
+}

--- a/app/Modules/Admin/Controllers/UserAvatarController.php
+++ b/app/Modules/Admin/Controllers/UserAvatarController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Modules\Admin\Controllers;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+/**
+ * Serves locally-stored team member (operator) avatars to the admin UI.
+ *
+ * Avatars are uploaded by the admin via TeamMemberCreatePage / TeamMemberEditPage
+ * and stored under avatars/ on the private `local` disk. This auth-gated route
+ * streams them back — no dependency on the `public` disk symlink.
+ */
+class UserAvatarController
+{
+    /**
+     * Stream the user avatar inline.
+     *
+     * Validates that the stored path is a safe avatars/ path before serving.
+     *
+     * @param User $user
+     *
+     * @return StreamedResponse
+     */
+    public function show(User $user): StreamedResponse
+    {
+        $path = (string) $user->avatar_path;
+
+        abort_unless(
+            $path !== '' && str_starts_with($path, 'avatars/') && ! str_contains($path, '..'),
+            404
+        );
+
+        abort_unless(Storage::disk('local')->exists($path), 404);
+
+        return Storage::disk('local')->response($path, null, [
+            'Cache-Control' => 'private, max-age=86400',
+        ]);
+    }
+}

--- a/app/Modules/Telegram/DTOs/TelegramUpdateDto.php
+++ b/app/Modules/Telegram/DTOs/TelegramUpdateDto.php
@@ -27,6 +27,7 @@ use Spatie\LaravelData\Data;
  * @property string|null $fileId
  * @property string|null $fileType
  * @property string|null $username
+ * @property string|null $displayName
  * @property string|null $callbackData
  * @property array|null  $location
  * @property array|null  $contact
@@ -53,6 +54,7 @@ class TelegramUpdateDto extends Data
         public ?string $fileId = null,
         public ?string $fileType = null,
         public ?string $username = null,
+        public ?string $displayName = null,
         public ?string $callbackData = null,
         public ?array  $location = null,
         public ?array  $contact = null,
@@ -102,6 +104,7 @@ class TelegramUpdateDto extends Data
                 fileId: TelegramHelper::extractFileId($data),
                 fileType: TelegramHelper::extractFileType($data),
                 username: self::extractUsername($data, $type),
+                displayName: self::extractDisplayName($data, $type),
                 callbackData: $data['callback_query']['data'] ?? null,
                 location: $data['message']['location'] ?? null,
                 contact: $data['message']['contact'] ?? null,
@@ -198,7 +201,29 @@ class TelegramUpdateDto extends Data
      */
     private static function extractUsername(array $data, string $type): ?string
     {
-        return $data[$type]['username'] ?? $data['callback_query']['message']['from']['username'] ?? null;
+        return $data[$type]['from']['username'] ?? $data['callback_query']['from']['username'] ?? null;
+    }
+
+    /**
+     * Compose a display name from first_name + last_name, fallback to username.
+     *
+     * @param array  $data
+     * @param string $type
+     *
+     * @return string|null
+     */
+    private static function extractDisplayName(array $data, string $type): ?string
+    {
+        $firstName = $data[$type]['from']['first_name'] ?? $data['callback_query']['from']['first_name'] ?? null;
+        $lastName = $data[$type]['from']['last_name'] ?? $data['callback_query']['from']['last_name'] ?? null;
+
+        $name = trim(($firstName ?? '') . ' ' . ($lastName ?? ''));
+
+        if ($name !== '') {
+            return $name;
+        }
+
+        return $data[$type]['from']['username'] ?? $data['callback_query']['from']['username'] ?? null;
     }
 
     /**

--- a/database/migrations/2026_06_15_000001_add_profile_fields_to_bot_users_table.php
+++ b/database/migrations/2026_06_15_000001_add_profile_fields_to_bot_users_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('bot_users', function (Blueprint $table): void {
+            $table->string('display_name')->nullable()->after('platform');
+            $table->string('username')->nullable()->after('display_name');
+            $table->string('avatar_path')->nullable()->after('username');
+            $table->timestamp('profile_synced_at')->nullable()->after('avatar_path');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('bot_users', function (Blueprint $table): void {
+            $table->dropColumn(['display_name', 'username', 'avatar_path', 'profile_synced_at']);
+        });
+    }
+};

--- a/database/migrations/2026_06_15_000002_add_avatar_path_to_users_table.php
+++ b/database/migrations/2026_06_15_000002_add_avatar_path_to_users_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Add avatar_path to users table.
+     *
+     * Stores the relative path on the `local` disk (e.g. `avatars/user-42.jpg`).
+     * Nullable — users without an uploaded photo fall back to deterministic initials.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->string('avatar_path')->nullable()->after('role');
+        });
+    }
+
+    /**
+     * Remove avatar_path from users table.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->dropColumn('avatar_path');
+        });
+    }
+};

--- a/database/migrations/2026_06_15_000003_add_sender_to_messages_table.php
+++ b/database/migrations/2026_06_15_000003_add_sender_to_messages_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('messages', function (Blueprint $table): void {
+            $table->foreignId('sender_user_id')
+                ->nullable()
+                ->after('to_id')
+                ->constrained('users')
+                ->nullOnDelete();
+
+            $table->string('sender_name')->nullable()->after('sender_user_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('messages', function (Blueprint $table): void {
+            $table->dropForeign(['sender_user_id']);
+            $table->dropColumn(['sender_user_id', 'sender_name']);
+        });
+    }
+};

--- a/resources/views/components/chat-item.blade.php
+++ b/resources/views/components/chat-item.blade.php
@@ -16,7 +16,8 @@
     ];
     $avatarIndex  = abs(crc32((string) $botUser->chat_id)) % 8;
     $avatarColor  = $avatarHex[$avatarIndex];
-    $initials     = strtoupper(substr((string) $botUser->chat_id, 0, 2));
+    $displayLabel = $botUser->display_name ?? (string) $botUser->chat_id;
+    $initials     = strtoupper(substr($displayLabel, 0, 2));
 
     /*
      * Platform badge — small coloured pill (TG / VK / Web / Max).
@@ -77,13 +78,23 @@
     onmouseenter="if(!{{ $isActive ? 'true' : 'false' }}) this.style.background='#252A3A'"
     onmouseleave="if(!{{ $isActive ? 'true' : 'false' }}) this.style.background='transparent'"
 >
-    {{-- Avatar: 44×44 circle, deterministic color, white initials 15/600 --}}
+    {{-- Avatar: 44×44 circle — photo if available, else deterministic color + initials --}}
     {{-- Design: node STtU2 — cornerRadius 22, fill = avatar color; Lqpcy — initials text --}}
-    <div
-        class="relative flex shrink-0 items-center justify-center rounded-full text-white select-none"
-        style="width:44px; height:44px; background:{{ $avatarColor }}; font-size:15px; font-weight:600; border-radius:22px; {{ ($isClosed || $isBanned) ? 'opacity:0.5;' : '' }}"
-        aria-hidden="true"
-    >{{ $initials }}</div>
+    @if($botUser->avatar_path)
+        <img
+            src="{{ route('admin.bot-user-avatar', $botUser->id) }}"
+            alt="{{ $displayLabel }}"
+            class="relative shrink-0 rounded-full object-cover select-none"
+            style="width:44px; height:44px; border-radius:22px; {{ ($isClosed || $isBanned) ? 'opacity:0.5;' : '' }}"
+            aria-hidden="true"
+        >
+    @else
+        <div
+            class="relative flex shrink-0 items-center justify-center rounded-full text-white select-none"
+            style="width:44px; height:44px; background:{{ $avatarColor }}; font-size:15px; font-weight:600; border-radius:22px; {{ ($isClosed || $isBanned) ? 'opacity:0.5;' : '' }}"
+            aria-hidden="true"
+        >{{ $initials }}</div>
+    @endif
 
     {{-- Info column --}}
     {{-- Design: node s9GO9k — vertical, gap 4, fill_container --}}
@@ -97,7 +108,7 @@
             {{-- Design: node qwERT — gap 6, align center --}}
             <div class="flex items-center min-w-0" style="gap:6px;">
                 <span class="truncate text-text-sidebar font-semibold" style="font-size:14px;">
-                    {{ $botUser->chat_id }}
+                    {{ $displayLabel }}
                 </span>
                 {{-- Platform badge --}}
                 {{-- Design: node QeXDw — cornerRadius 3, padding [2,5], platform fill --}}

--- a/resources/views/livewire/chat/conversation-page.blade.php
+++ b/resources/views/livewire/chat/conversation-page.blade.php
@@ -331,7 +331,9 @@
                         $hdrColors = ['#6366F1','#E85D75','#34C759','#F5A623','#06B6D4','#10B981','#8B5CF6','#EF4444'];
                         $hdrIdx = abs(crc32((string) $activeBotUser->chat_id)) % 8;
                         $hdrColor = $hdrColors[$hdrIdx];
-                        $hdrInitials = strtoupper(substr((string) $activeBotUser->chat_id, 0, 2));
+                        $hdrDisplayName = $activeBotUser->display_name ?? (string) $activeBotUser->chat_id;
+                        $hdrInitials = strtoupper(substr($hdrDisplayName, 0, 2));
+                        $hdrHandle = $activeBotUser->username;
                         $platformLabel = match ($activeBotUser->platform) {
                             'telegram' => 'Telegram',
                             'vk'       => 'VK',
@@ -351,21 +353,31 @@
                         aria-label="Открыть сведения о клиенте"
                         title="Сведения о клиенте"
                     >
-                        {{-- User avatar (42×42 ellipse) with initials --}}
-                        <div
-                            class="relative shrink-0 flex items-center justify-center rounded-full text-white font-semibold select-none"
-                            style="width:42px; height:42px; background:{{ $hdrColor }}; font-size:16px;"
-                            aria-hidden="true"
-                        >{{ $hdrInitials }}</div>
+                        {{-- User avatar (42×42 ellipse) — photo or initials --}}
+                        @if($activeBotUser->avatar_path)
+                            <img
+                                src="{{ route('admin.bot-user-avatar', $activeBotUser->id) }}"
+                                alt="{{ $hdrDisplayName }}"
+                                class="relative shrink-0 rounded-full object-cover select-none"
+                                style="width:42px; height:42px;"
+                                aria-hidden="true"
+                            >
+                        @else
+                            <div
+                                class="relative shrink-0 flex items-center justify-center rounded-full text-white font-semibold select-none"
+                                style="width:42px; height:42px; background:{{ $hdrColor }}; font-size:16px;"
+                                aria-hidden="true"
+                            >{{ $hdrInitials }}</div>
+                        @endif
 
                         {{-- Name + platform sub-line --}}
                         {{-- Design: node O6aEj — vertical layout gap 2 --}}
                         <div class="flex flex-col min-w-0" style="gap:2px;">
                             <span class="text-sm font-semibold text-text-primary leading-tight truncate max-w-[280px]">
-                                {{ $activeBotUser->chat_id }}
+                                {{ $hdrDisplayName }}
                             </span>
                             <span class="text-xs text-text-secondary leading-tight truncate">
-                                {{ '@' . $activeBotUser->chat_id }} · {{ $platformLabel }}
+                                @if($hdrHandle){{ '@' . $hdrHandle }} · @endif{{ $platformLabel }}
                             </span>
                         </div>
                     </div>
@@ -535,9 +547,10 @@
                     @endphp
 
                     @if($isOutgoing)
-                        {{-- Outgoing: right-aligned, bg-accent (#4F6EF7), white text, cornerRadius [16,16,4,16] --}}
-                        {{-- Design: node uduZU / Bubble Out --}}
-                        <div class="flex w-full" style="justify-content:flex-end;">
+                        {{-- Outgoing: right-aligned with small manager avatar, bg-accent (#4F6EF7), white text, cornerRadius [16,16,4,16] --}}
+                        {{-- Design: node uduZU / Bubble Out — mirrors the incoming layout (bubble + 32×32 avatar) --}}
+                        <div class="flex items-end w-full" style="gap:10px; justify-content:flex-end;">
+                            {{-- Bubble --}}
                             <div class="flex flex-col" style="border-radius:16px 16px 4px 16px; background:#4F6EF7; padding:10px 14px; gap:4px; max-width:70%;">
                                 @if($message->attachments->isNotEmpty())
                                     <x-message-attachments
@@ -555,6 +568,56 @@
                                     {{ $message->created_at?->format('H:i') }}
                                 </p>
                             </div>
+                            {{-- Operator avatar: photo > initials > generic headset glyph --}}
+                            @php
+                                $sender = $message->sender;
+                                $senderName = $sender?->name ?? $message->sender_name;
+                                // Derive 2-letter initials from the name.
+                                $senderInitials = null;
+                                if ($senderName) {
+                                    $parts = explode(' ', trim($senderName));
+                                    $senderInitials = count($parts) >= 2
+                                        ? mb_strtoupper(mb_substr($parts[0], 0, 1) . mb_substr($parts[1], 0, 1))
+                                        : mb_strtoupper(mb_substr($parts[0], 0, 2));
+                                }
+                                // 8-color palette (same hue set used for team-member initials).
+                                $avatarPalette = ['#6366F1','#8B5CF6','#EC4899','#F59E0B','#10B981','#3B82F6','#EF4444','#14B8A6'];
+                                $senderColor = $senderName
+                                    ? $avatarPalette[abs(crc32($senderName)) % 8]
+                                    : '#4F6EF7';
+                            @endphp
+                            @if($sender && $sender->avatar_path)
+                                {{-- Known operator with uploaded photo --}}
+                                <img
+                                    src="{{ route('admin.team-member-avatar', $sender) }}"
+                                    alt="{{ $senderName }}"
+                                    title="{{ $senderName }}"
+                                    class="shrink-0 rounded-full object-cover select-none"
+                                    style="width:32px; height:32px;"
+                                >
+                            @elseif($senderInitials)
+                                {{-- Known operator — show initials circle --}}
+                                <div
+                                    class="flex shrink-0 items-center justify-center rounded-full text-white font-semibold select-none"
+                                    style="width:32px; height:32px; background:{{ $senderColor }}; font-size:11px;"
+                                    title="{{ $senderName }}"
+                                    aria-hidden="true"
+                                >{{ $senderInitials }}</div>
+                            @else
+                                {{-- No author recorded — generic headset glyph (historical / AI / telegram-group) --}}
+                                <div
+                                    class="flex shrink-0 items-center justify-center rounded-full select-none"
+                                    style="width:32px; height:32px; background:#EEF2FF;"
+                                    aria-hidden="true"
+                                    title="Менеджер"
+                                >
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#4F6EF7" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                        <path d="M3 14v-3a9 9 0 0 1 18 0v3" />
+                                        <path d="M21 16a2 2 0 0 1-2 2h-1a1 1 0 0 1-1-1v-3a1 1 0 0 1 1-1h3z" />
+                                        <path d="M3 16a2 2 0 0 0 2 2h1a1 1 0 0 0 1-1v-3a1 1 0 0 0-1-1H3z" />
+                                    </svg>
+                                </div>
+                            @endif
                         </div>
                     @else
                         {{-- Incoming: left-aligned with small avatar, bg-primary / bg-input bubble, cornerRadius [16,16,16,4] --}}
@@ -773,19 +836,31 @@
                     $rpColors = ['#6366F1','#E85D75','#34C759','#F5A623','#06B6D4','#10B981','#8B5CF6','#EF4444'];
                     $rpIdx = abs(crc32((string) $activeBotUser->chat_id)) % 8;
                     $rpColor = $rpColors[$rpIdx];
-                    $rpInitials = strtoupper(substr((string) $activeBotUser->chat_id, 0, 2));
+                    $rpDisplayName = $activeBotUser->display_name ?? (string) $activeBotUser->chat_id;
+                    $rpInitials = strtoupper(substr($rpDisplayName, 0, 2));
+                    $rpHandle = $activeBotUser->username;
                 @endphp
-                <div
-                    class="flex items-center justify-center rounded-full text-white font-semibold select-none shrink-0"
-                    style="width:64px; height:64px; background:{{ $rpColor }}; font-size:22px; border-radius:32px;"
-                    aria-hidden="true"
-                >{{ $rpInitials }}</div>
+                @if($activeBotUser->avatar_path)
+                    <img
+                        src="{{ route('admin.bot-user-avatar', $activeBotUser->id) }}"
+                        alt="{{ $rpDisplayName }}"
+                        class="flex items-center justify-center rounded-full object-cover select-none shrink-0"
+                        style="width:64px; height:64px; border-radius:32px;"
+                        aria-hidden="true"
+                    >
+                @else
+                    <div
+                        class="flex items-center justify-center rounded-full text-white font-semibold select-none shrink-0"
+                        style="width:64px; height:64px; background:{{ $rpColor }}; font-size:22px; border-radius:32px;"
+                        aria-hidden="true"
+                    >{{ $rpInitials }}</div>
+                @endif
 
                 {{-- Name + handle --}}
                 {{-- Design: node wAn8z — vertical, gap 4, center --}}
                 <div class="flex flex-col items-center w-full" style="gap:4px;">
                     <span class="text-text-primary font-semibold text-center" style="font-size:16px;">
-                        {{ $activeBotUser->chat_id }}
+                        {{ $rpDisplayName }}
                     </span>
                     @php
                         $rpPlatformLabel = match ($activeBotUser->platform) {
@@ -796,7 +871,7 @@
                         };
                     @endphp
                     <span class="text-text-secondary text-center" style="font-size:13px;">
-                        {{ '@' . $activeBotUser->chat_id }} · {{ $rpPlatformLabel }}
+                        @if($rpHandle){{ '@' . $rpHandle }} · @endif{{ $rpPlatformLabel }}
                     </span>
                 </div>
 

--- a/resources/views/livewire/settings/team-member-create-page.blade.php
+++ b/resources/views/livewire/settings/team-member-create-page.blade.php
@@ -11,6 +11,29 @@
 
         <div class="space-y-5">
 
+            {{-- Avatar upload --}}
+            <x-admin.form-field label="Фото" for="avatar" :error="$errors->first('avatar')">
+                <div class="flex items-center gap-4">
+                    {{-- Preview — only for previewable image types --}}
+                    @if ($avatar && in_array($avatar->extension(), ['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp', 'svg']))
+                        <img src="{{ $avatar->temporaryUrl() }}" alt="Предпросмотр" class="h-14 w-14 rounded-full object-cover">
+                    @else
+                        <div class="flex h-14 w-14 shrink-0 items-center justify-center rounded-full bg-bg-secondary text-text-secondary">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z" />
+                            </svg>
+                        </div>
+                    @endif
+                    <input
+                        id="avatar"
+                        type="file"
+                        wire:model="avatar"
+                        accept="image/*"
+                        class="block text-sm text-text-secondary file:mr-3 file:rounded-lg file:border file:border-border-light file:bg-bg-primary file:px-3 file:py-1.5 file:text-sm file:text-text-primary file:transition file:hover:bg-bg-secondary"
+                    >
+                </div>
+            </x-admin.form-field>
+
             {{-- Name --}}
             <x-admin.form-field label="Имя" for="name" :error="$errors->first('name')">
                 <input

--- a/resources/views/livewire/settings/team-member-edit-page.blade.php
+++ b/resources/views/livewire/settings/team-member-edit-page.blade.php
@@ -11,6 +11,43 @@
 
         <div class="space-y-5">
 
+            {{-- Avatar upload --}}
+            <x-admin.form-field label="Фото" for="avatar" :error="$errors->first('avatar')">
+                <div class="flex items-center gap-4">
+                    {{-- Current avatar or preview of new upload — only for previewable image types --}}
+                    @if ($avatar && in_array($avatar->extension(), ['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp', 'svg']))
+                        <img src="{{ $avatar->temporaryUrl() }}" alt="Предпросмотр" class="h-14 w-14 rounded-full object-cover">
+                    @elseif ($currentAvatarPath)
+                        <img src="{{ route('admin.team-member-avatar', $userId) }}" alt="Текущее фото" class="h-14 w-14 rounded-full object-cover">
+                    @else
+                        <div class="flex h-14 w-14 shrink-0 items-center justify-center rounded-full bg-bg-secondary text-text-secondary">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z" />
+                            </svg>
+                        </div>
+                    @endif
+                    <div class="flex flex-col gap-2">
+                        <input
+                            id="avatar"
+                            type="file"
+                            wire:model="avatar"
+                            accept="image/*"
+                            class="block text-sm text-text-secondary file:mr-3 file:rounded-lg file:border file:border-border-light file:bg-bg-primary file:px-3 file:py-1.5 file:text-sm file:text-text-primary file:transition file:hover:bg-bg-secondary"
+                        >
+                        @if ($currentAvatarPath && !$avatar)
+                            <button
+                                type="button"
+                                wire:click="removeAvatar"
+                                wire:confirm="Удалить фото участника? Действие необратимо."
+                                class="self-start text-[12px] text-red-500 hover:underline"
+                            >
+                                Удалить фото
+                            </button>
+                        @endif
+                    </div>
+                </div>
+            </x-admin.form-field>
+
             {{-- Name --}}
             <x-admin.form-field label="Имя" for="name" :error="$errors->first('name')">
                 <input

--- a/resources/views/livewire/settings/team-page.blade.php
+++ b/resources/views/livewire/settings/team-page.blade.php
@@ -66,11 +66,20 @@
 
                 {{-- Participant column --}}
                 <div class="flex items-center gap-3">
-                    <div
-                        class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-[12px] font-semibold text-white"
-                        style="background: {{ $avatarColor }}"
-                        aria-hidden="true"
-                    >{{ $initials }}</div>
+                    @if ($member->avatar_path)
+                        <img
+                            src="{{ route('admin.team-member-avatar', $member->id) }}"
+                            alt="{{ $memberLabel }}"
+                            class="h-9 w-9 shrink-0 rounded-full object-cover"
+                            aria-hidden="true"
+                        >
+                    @else
+                        <div
+                            class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-[12px] font-semibold text-white"
+                            style="background: {{ $avatarColor }}"
+                            aria-hidden="true"
+                        >{{ $initials }}</div>
+                    @endif
 
                     <div class="min-w-0">
                         <p class="truncate text-[13px] font-medium text-text-primary">
@@ -124,11 +133,20 @@
             <div class="relative flex items-center justify-between gap-2 px-4 py-3.5 transition hover:bg-bg-secondary/40 lg:hidden">
                 <a href="{{ $editUrl }}" class="absolute inset-0" aria-label="Редактировать «{{ $memberLabel }}»"></a>
                 <div class="flex min-w-0 items-center gap-3">
-                    <div
-                        class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-[12px] font-semibold text-white"
-                        style="background: {{ $avatarColor }}"
-                        aria-hidden="true"
-                    >{{ $initials }}</div>
+                    @if ($member->avatar_path)
+                        <img
+                            src="{{ route('admin.team-member-avatar', $member->id) }}"
+                            alt="{{ $memberLabel }}"
+                            class="h-9 w-9 shrink-0 rounded-full object-cover"
+                            aria-hidden="true"
+                        >
+                    @else
+                        <div
+                            class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-[12px] font-semibold text-white"
+                            style="background: {{ $avatarColor }}"
+                            aria-hidden="true"
+                        >{{ $initials }}</div>
+                    @endif
                     <div class="min-w-0">
                         <p class="truncate text-[13px] font-medium text-text-primary">
                             {{ $member->name !== '' ? $member->name : '—' }}

--- a/rules/api/endpoints.md
+++ b/rules/api/endpoints.md
@@ -101,6 +101,8 @@ The generated JSON is the authoritative OpenAPI file. Do not write a separate `o
 | `GET` | `/admin/settings/api-webhooks` | session (admin only) | API and webhooks list (`ApiWebhooksPage`, custom Livewire) — name `admin.settings.api-webhooks` |
 | `GET` | `/admin/settings/api-webhooks/{source}` | session (admin only) | Per-source config (`ApiWebhookSourcePage`; source ∈ `[0-9]+`) — name `admin.settings.api-webhooks.source` |
 | `GET` | `/admin/settings/team` | session (admin only) | Team management screen (`TeamPage`, custom Livewire) — name `admin.settings.team` |
+| `GET` | `/admin/bot-user-avatars/{botUser}` | session | Stream locally-stored bot user avatar (fetched by `EnrichBotUserProfileJob`); `avatar_path` must start with `avatars/` — name `admin.bot-user-avatar` |
+| `GET` | `/admin/team-member-avatars/{user}` | session | Stream locally-stored team member (operator) avatar (uploaded via Team admin UI); `avatar_path` must start with `avatars/` and contain no `..` — name `admin.team-member-avatar` |
 
 > The legacy Filament resource routes (`/admin/conversations`, `/admin/bot-users`, `/admin/feedbacks`, `/admin/external-sources`) were removed when the admin was rebuilt as custom Livewire screens. The underlying models, services, and artisan commands are unchanged.
 

--- a/rules/database/schema.md
+++ b/rules/database/schema.md
@@ -27,6 +27,7 @@ erDiagram
         string name
         string email UK
         string role
+        string avatar_path
         string password
         timestamp email_verified_at
         string remember_token
@@ -38,6 +39,10 @@ erDiagram
         bigint chat_id
         bigint topic_id
         string platform
+        string display_name
+        string username
+        string avatar_path
+        timestamp profile_synced_at
         string external_source_id
         boolean is_banned
         timestamp banned_at
@@ -51,6 +56,8 @@ erDiagram
         enum message_type
         bigint from_id
         bigint to_id
+        bigint sender_user_id FK "nullable"
+        string sender_name "nullable"
         timestamps
     }
 
@@ -123,6 +130,7 @@ erDiagram
     }
 
     BOT_USERS ||--o{ MESSAGES : "has many"
+    USERS ||--o{ MESSAGES : "sender (nullable)"
     MESSAGES ||--o| EXTERNAL_MESSAGES : "has one"
     BOT_USERS ||--o| EXTERNAL_USERS : "has one"
     BOT_USERS ||--o| AI_CONDITIONS : "has one"
@@ -145,6 +153,7 @@ Laravel authentication table for admin users.
 | `name` | `string` | No | — | Display name |
 | `email` | `string` | No | — | Unique login identifier |
 | `role` | `string` | No | `manager` | Access role: `admin` or `manager` |
+| `avatar_path` | `string` | Yes | NULL | Local storage path on the `local` disk (e.g. `avatars/user-42.jpg`) — uploaded via the Team admin UI; NULL = use deterministic initials |
 | `email_verified_at` | `timestamp` | Yes | NULL | Email verification timestamp |
 | `password` | `string` | No | — | Hashed password (bcrypt) |
 | `remember_token` | `string(100)` | Yes | NULL | Session remember token |
@@ -154,6 +163,8 @@ Laravel authentication table for admin users.
 **Indexes:**
 - PRIMARY on `id`
 - UNIQUE on `email` — prevents duplicate accounts
+
+**Migration:** `database/migrations/2026_06_15_000002_add_avatar_path_to_users_table.php`
 
 ---
 
@@ -167,6 +178,10 @@ Core table. Stores every user that has interacted with the bot across all platfo
 | `chat_id` | `bigint` | No | — | User's ID in Telegram, VK, or External system |
 | `topic_id` | `bigint` | Yes | NULL | Telegram forum topic ID for this user's conversation |
 | `platform` | `string` | No | — | Platform: `telegram`, `vk`, `external_source` |
+| `display_name` | `string` | Yes | NULL | Human-readable display name (first + last name or username fallback) — populated by `EnrichBotUserProfileJob` and sync'd from webhook on Telegram |
+| `username` | `string` | Yes | NULL | Platform handle/username (e.g. Telegram @username) — populated from DTO or async job |
+| `avatar_path` | `string` | Yes | NULL | Local storage path on the `local` disk under `avatars/` (e.g. `avatars/bot-user-42.jpg`) — populated by `EnrichBotUserProfileJob` |
+| `profile_synced_at` | `timestamp` | Yes | NULL | Last time profile data was fetched from the platform API; used as a 30-day TTL guard in `EnrichBotUserProfileJob` |
 | `external_source_id` | `string` | Yes | NULL | External source identifier (for `external_source` platform) |
 | `is_banned` | `boolean` | No | `false` | Whether user is banned from sending messages |
 | `banned_at` | `timestamp` | Yes | NULL | When the user was banned |
@@ -202,6 +217,8 @@ Tracks all individual messages exchanged between users and the support team.
 | `message_type` | `enum` | No | — | Direction: `incoming` or `outgoing` |
 | `from_id` | `bigint` | No | — | Sender's ID |
 | `to_id` | `bigint` | No | — | Recipient's ID |
+| `sender_user_id` | `bigint` | Yes | NULL | FK → `users.id` (nullOnDelete) — admin-panel operator who sent this outgoing message; null for incoming, AI auto-replies, and telegram-group replies |
+| `sender_name` | `string` | Yes | NULL | Name snapshot of the operator at send time — survives operator deletion; null when no author is recorded |
 | `created_at` | `timestamp` | Yes | NULL | Message time |
 | `updated_at` | `timestamp` | Yes | NULL | Last update time |
 
@@ -209,6 +226,9 @@ Tracks all individual messages exchanged between users and the support team.
 - PRIMARY on `id`
 - INDEX on `message_type` — used in filtering queries
 - FOREIGN KEY `bot_user_id` → `bot_users.id` ON DELETE CASCADE
+- FOREIGN KEY `sender_user_id` → `users.id` ON DELETE SET NULL
+
+**Migration:** `database/migrations/2026_06_15_000003_add_sender_to_messages_table.php`
 
 **Enums:**
 

--- a/rules/domain/admin-panel.md
+++ b/rules/domain/admin-panel.md
@@ -396,6 +396,8 @@ The API и вебхуки section follows the same two-page pattern as Integrati
    - **Статус**: v1 stub — renders a muted «—» placeholder badge. No `last_seen_at` column, no real online tracking yet. The placeholder is consistent with `ApiWebhookSourcePage`'s design-stub pattern.
    - **Действия**: delete button (hidden for the current user's own row). Two-step: `confirmDelete(userId)` shows inline confirm/cancel; `deleteMember()` executes deletion (BR-028 self-lockout guard).
 
+**Avatar upload**: each member may optionally have an uploaded avatar stored on the `local` disk at `avatars/user-{id}.jpg`. The avatar is uploaded from `TeamMemberCreatePage` or `TeamMemberEditPage` (both use `WithFileUploads`; validation: nullable, image, max 2 MB). Stored path is written to `users.avatar_path`. The team list renders an `<img>` via `admin.team-member-avatar` (`UserAvatarController::show()`) when `avatar_path` is set, otherwise falls back to the deterministic initials circle. `removeAvatar()` on `TeamMemberEditPage` deletes the file from disk and nulls `avatar_path`. `deleteMember()` on `TeamPage` also deletes the file from disk before removing the user record.
+
 **Avatar initials logic** (`avatarInitials(User)`):
 - Two-word name → first letter of each word uppercased.
 - Single-word name → first two letters uppercased.
@@ -410,6 +412,8 @@ The API и вебхуки section follows the same two-page pattern as Integrati
 **Tests**:
 - `tests/Unit/Livewire/Settings/TeamPageTest.php` — access (admin/manager/guest), heading, members display, invite happy path + password reveal/dismiss + validation, delete happy path, self-lockout, avatar helpers.
 - `tests/Unit/Modules/Admin/Actions/InviteOperatorTest.php` — user creation, role assignment, password hashing, returned plain password (length + matches stored hash), persisted user.
+- `tests/Feature/Admin/TeamAvatarTest.php` — create with avatar (file stored, avatar_path set), create without avatar (null), edit replaces file, removeAvatar (file deleted + null), deleteMember removes file, team list renders img vs initials.
+- `tests/Feature/Admin/UserAvatarControllerTest.php` — serves file to authed user, guest redirect, 404 for invalid/traversal/empty path, 404 for missing file.
 
 ---
 

--- a/rules/domain/bot-users.md
+++ b/rules/domain/bot-users.md
@@ -55,6 +55,21 @@ _Enforced in:_ `app/Models/BotUser.php @ getOrCreateByTelegramUpdate()`
 **BR-008** — For `external_source` platform users, an `ExternalUser` sub-record must be created or found by `external_id` + `source`.
 _Enforced in:_ `app/Models/BotUser.php @ getOrCreateExternalBotUser()`
 
+**BR-009** — When a `BotUser` for a Telegram private-chat message is first created via `getOrCreateByTelegramUpdate()`, the `display_name` and `username` fields must be filled synchronously from `TelegramUpdateDto::displayName` and `TelegramUpdateDto::username`.
+_Enforced in:_ `app/Models/BotUser.php @ getOrCreateByTelegramUpdate()`
+
+**BR-010** — For an existing `BotUser`, `display_name` and `username` are updated opportunistically when the incoming DTO carries a different value. No write is issued if the values are unchanged.
+_Enforced in:_ `app/Models/BotUser.php @ getOrCreateByTelegramUpdate()`
+
+**BR-011** — After a `BotUser` is found or created via `getOrCreateByTelegramUpdate()` (private chat) or `getUserByChatId()`, an `EnrichBotUserProfileJob` must be dispatched to the queue. The job fetches the avatar from the platform API and updates `avatar_path` and `profile_synced_at`. The job is guarded by a 30-day TTL (`profile_synced_at`): it skips work if `profile_synced_at` is set and less than 30 days old.
+_Enforced in:_ `app/Jobs/EnrichBotUserProfileJob.php`, `app/Models/BotUser.php`
+
+**BR-012** — When `DeleteBotUser::execute()` removes a user, the locally stored avatar file (`avatar_path` on the `local` disk) must be deleted before the DB row is removed. PII profile fields (`display_name`, `username`, `avatar_path`, `profile_synced_at`) must be nulled before the delete.
+_Enforced in:_ `app/Modules/Admin/Actions/DeleteBotUser.php`
+
+**BR-013** — In the admin chat workspace, `display_name` is shown wherever the user's name appears (dialog list, chat header, right panel). If `display_name` is NULL, `chat_id` is used as the fallback. If `avatar_path` is set, the avatar image is shown instead of the initials circle.
+_Enforced in:_ `resources/views/components/chat-item.blade.php`, `resources/views/livewire/chat/conversation-page.blade.php`
+
 **BR-020** — When `CloseTopic::execute()` successfully closes a conversation (`is_closed = true`), a `Feedback` record with `status = 'awaiting_rating'` must be created and a rating form must be sent to the user on their platform. Every close event creates a new feedback record — history accumulates.
 _Enforced in:_ `app/Modules/Telegram/Actions/CloseTopic.php`, `app/Modules/Feedback/Actions/SendFeedbackForm.php`
 

--- a/rules/domain/messaging.md
+++ b/rules/domain/messaging.md
@@ -89,6 +89,11 @@ _Enforced in:_ `app/Services/Button/KeyboardBuilder.php`, `app/Services/Button/B
 **BR-010** — External source messages delivered via REST API must trigger a webhook notification to the source's `webhook_url` when the team replies.
 _Enforced in:_ `app/Jobs/SendMessage/SendWebhookMessage.php`, `app/Services/Webhook/WebhookService.php`
 
+**BR-011** — Outgoing messages sent from the admin-panel chat workspace record the authenticated operator as a name snapshot (`messages.sender_name`) and a FK (`messages.sender_user_id`). If the operator is later deleted, `sender_user_id` is nulled by the DB constraint but `sender_name` is preserved. The chat workspace displays the operator avatar/initials when available; falls back to the generic headset glyph when `sender_name` is null (historical messages, AI auto-replies, telegram-group replies).
+_Enforced in:_ `app/Modules/Admin/Actions/SendReplyAction.php @ execute()`, `app/Livewire/Chat/ConversationPage.php @ sendReply()`
+
+**DEFERRED (issue #172)** — AI Accept-callback operator attribution (`DeliverAiAnswerToUser`, `TelegramBotController` Accept handler) — AI paths continue to pass `null` as the author until a dedicated task implements it.
+
 ---
 
 ## 5. Message Type State Machine

--- a/tests/Feature/Admin/BotUserAvatarControllerTest.php
+++ b/tests/Feature/Admin/BotUserAvatarControllerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\BotUser;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class BotUserAvatarControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeBotUserWithAvatar(string $avatarPath): BotUser
+    {
+        return BotUser::create([
+            'chat_id' => 5000,
+            'platform' => 'telegram',
+            'avatar_path' => $avatarPath,
+        ]);
+    }
+
+    public function test_serves_avatar_to_authed_admin(): void
+    {
+        Storage::fake('local');
+        Storage::disk('local')->put('avatars/bot-user-1.jpg', 'AVATAR-BYTES');
+
+        $botUser = $this->makeBotUserWithAvatar('avatars/bot-user-1.jpg');
+        // Update avatar_path to match the actual ID.
+        $storagePath = "avatars/bot-user-{$botUser->id}.jpg";
+        Storage::disk('local')->put($storagePath, 'AVATAR-BYTES');
+        $botUser->update(['avatar_path' => $storagePath]);
+
+        $this->actingAs(User::factory()->create())
+            ->get(route('admin.bot-user-avatar', $botUser->id))
+            ->assertOk();
+    }
+
+    public function test_guests_are_redirected(): void
+    {
+        Storage::fake('local');
+        $botUser = BotUser::create(['chat_id' => 5001, 'platform' => 'telegram', 'avatar_path' => 'avatars/x.jpg']);
+
+        $this->get(route('admin.bot-user-avatar', $botUser->id))
+            ->assertRedirect();
+    }
+
+    public function test_404_when_path_invalid(): void
+    {
+        $botUser = BotUser::create([
+            'chat_id' => 5002,
+            'platform' => 'telegram',
+            'avatar_path' => 'etc/passwd',
+        ]);
+
+        $this->actingAs(User::factory()->create())
+            ->get(route('admin.bot-user-avatar', $botUser->id))
+            ->assertNotFound();
+    }
+
+    public function test_404_when_file_missing(): void
+    {
+        Storage::fake('local');
+
+        $botUser = BotUser::create([
+            'chat_id' => 5003,
+            'platform' => 'telegram',
+            'avatar_path' => 'avatars/missing.jpg',
+        ]);
+
+        $this->actingAs(User::factory()->create())
+            ->get(route('admin.bot-user-avatar', $botUser->id))
+            ->assertNotFound();
+    }
+}

--- a/tests/Feature/Admin/ConversationWorkspaceTest.php
+++ b/tests/Feature/Admin/ConversationWorkspaceTest.php
@@ -8,11 +8,13 @@ use App\Models\BotUser;
 use App\Models\Message;
 use App\Models\MessageAttachment;
 use App\Models\User;
+use App\Modules\Admin\Actions\DeleteBotUser;
 use App\Modules\Admin\Actions\SendReplyAction;
 use App\Modules\Admin\Jobs\SendAdminDocumentJob;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Storage;
 use Livewire\Livewire;
 use Tests\TestCase;
 
@@ -726,5 +728,92 @@ class ConversationWorkspaceTest extends TestCase
         Livewire::test(ConversationPage::class)
             ->call('selectChat', $botUser->id)
             ->assertSee('Привет');
+    }
+
+    // ── Avatar cleanup on delete ───────────────────────────────────────────────
+
+    public function test_delete_bot_user_removes_avatar_file(): void
+    {
+        Storage::fake('local');
+
+        $avatarPath = 'avatars/bot-user-99.jpg';
+        Storage::disk('local')->put($avatarPath, 'AVATAR-BYTES');
+
+        $botUser = BotUser::create([
+            'chat_id' => 9999,
+            'platform' => 'telegram',
+            'avatar_path' => $avatarPath,
+        ]);
+
+        (new DeleteBotUser())->execute($botUser);
+
+        Storage::disk('local')->assertMissing($avatarPath);
+    }
+
+    // ── Operator authorship ────────────────────────────────────────────────────
+
+    public function test_send_reply_attributes_authenticated_operator(): void
+    {
+        Queue::fake();
+
+        $operator = User::factory()->create(['name' => 'Operator Masha']);
+        $botUser = BotUser::create(['chat_id' => '6000', 'platform' => 'telegram']);
+
+        Livewire::actingAs($operator)
+            ->test(ConversationPage::class)
+            ->call('selectChat', $botUser->id)
+            ->set('replyText', 'Attributed reply')
+            ->call('sendReply')
+            ->assertHasNoErrors();
+
+        $this->assertDatabaseHas('messages', [
+            'bot_user_id' => $botUser->id,
+            'message_type' => 'outgoing',
+            'sender_user_id' => $operator->id,
+            'sender_name' => 'Operator Masha',
+        ]);
+    }
+
+    public function test_outgoing_bubble_shows_operator_initials_when_author_known(): void
+    {
+        Queue::fake();
+
+        $operator = User::factory()->create(['name' => 'Anna Ivanova']);
+        $botUser = BotUser::create(['chat_id' => '6001', 'platform' => 'telegram']);
+
+        Message::create([
+            'bot_user_id' => $botUser->id,
+            'platform' => 'telegram',
+            'message_type' => 'outgoing',
+            'from_id' => 0,
+            'to_id' => 0,
+            'text' => 'Hello from operator',
+            'sender_user_id' => $operator->id,
+            'sender_name' => $operator->name,
+        ]);
+
+        Livewire::test(ConversationPage::class)
+            ->call('selectChat', $botUser->id)
+            ->assertSee('AI');  // initials A+I of "Anna Ivanova"
+    }
+
+    public function test_outgoing_bubble_shows_generic_fallback_when_no_author(): void
+    {
+        Queue::fake();
+
+        $botUser = BotUser::create(['chat_id' => '6002', 'platform' => 'telegram']);
+
+        Message::create([
+            'bot_user_id' => $botUser->id,
+            'platform' => 'telegram',
+            'message_type' => 'outgoing',
+            'from_id' => 0,
+            'to_id' => 0,
+            'text' => 'Historic reply without author',
+        ]);
+
+        Livewire::test(ConversationPage::class)
+            ->call('selectChat', $botUser->id)
+            ->assertSee('Менеджер');
     }
 }

--- a/tests/Feature/Admin/TeamAvatarTest.php
+++ b/tests/Feature/Admin/TeamAvatarTest.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Enums\UserRole;
+use App\Livewire\Settings\TeamMemberCreatePage;
+use App\Livewire\Settings\TeamMemberEditPage;
+use App\Livewire\Settings\TeamPage;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+/**
+ * Feature tests for team member avatar upload, replace, and removal.
+ *
+ * Covers:
+ *  - Creating a member with an avatar stores the file and sets avatar_path
+ *  - Creating a member without an avatar leaves avatar_path null
+ *  - Editing a member with a new avatar replaces the stored file
+ *  - Removing an avatar via removeAvatar() deletes the file and nulls avatar_path
+ *  - Deleting a member removes the avatar file from disk
+ *  - TeamPage list shows an <img> when avatar_path is set, initials otherwise
+ */
+class TeamAvatarTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actingAdmin(): User
+    {
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        $this->actingAs($admin);
+
+        return $admin;
+    }
+
+    // ── Create page — avatar upload ────────────────────────────────────────────
+
+    public function test_create_member_with_avatar_stores_file_and_sets_avatar_path(): void
+    {
+        Storage::fake('local');
+        $this->actingAdmin();
+
+        $file = UploadedFile::fake()->image('photo.jpg');
+
+        Livewire::test(TeamMemberCreatePage::class)
+            ->set('name', 'Пётр Иванов')
+            ->set('email', 'petr@example.com')
+            ->set('password', 'secret123')
+            ->set('password_confirmation', 'secret123')
+            ->set('role', 'manager')
+            ->set('avatar', $file)
+            ->call('save')
+            ->assertRedirect(route('admin.settings.team'));
+
+        $user = User::where('email', 'petr@example.com')->firstOrFail();
+
+        $this->assertNotNull($user->avatar_path);
+        $this->assertStringStartsWith('avatars/user-', $user->avatar_path);
+        Storage::disk('local')->assertExists($user->avatar_path);
+    }
+
+    public function test_create_member_without_avatar_leaves_avatar_path_null(): void
+    {
+        Storage::fake('local');
+        $this->actingAdmin();
+
+        Livewire::test(TeamMemberCreatePage::class)
+            ->set('name', 'Мария Смирнова')
+            ->set('email', 'maria@example.com')
+            ->set('password', 'secret123')
+            ->set('password_confirmation', 'secret123')
+            ->set('role', 'manager')
+            ->call('save');
+
+        $user = User::where('email', 'maria@example.com')->firstOrFail();
+        $this->assertNull($user->avatar_path);
+    }
+
+    public function test_create_rejects_non_image_file(): void
+    {
+        Storage::fake('local');
+        $this->actingAdmin();
+
+        $file = UploadedFile::fake()->create('document.pdf', 100, 'application/pdf');
+
+        Livewire::test(TeamMemberCreatePage::class)
+            ->set('avatar', $file)
+            ->call('save')
+            ->assertHasErrors(['avatar']);
+    }
+
+    public function test_create_rejects_image_exceeding_2mb(): void
+    {
+        Storage::fake('local');
+        $this->actingAdmin();
+
+        // 2049 KB — just over the 2 MB limit
+        $file = UploadedFile::fake()->image('big.jpg')->size(2049);
+
+        Livewire::test(TeamMemberCreatePage::class)
+            ->set('avatar', $file)
+            ->call('save')
+            ->assertHasErrors(['avatar']);
+    }
+
+    // ── Edit page — avatar replace ─────────────────────────────────────────────
+
+    public function test_edit_member_with_new_avatar_replaces_file(): void
+    {
+        Storage::fake('local');
+        $this->actingAdmin();
+
+        $member = User::factory()->manager()->create();
+        $oldPath = "avatars/user-{$member->id}.jpg";
+        Storage::disk('local')->put($oldPath, 'OLD-AVATAR');
+        $member->update(['avatar_path' => $oldPath]);
+
+        $newFile = UploadedFile::fake()->image('new.jpg');
+
+        Livewire::test(TeamMemberEditPage::class, ['user' => $member->id])
+            ->set('avatar', $newFile)
+            ->call('save')
+            ->assertHasNoErrors();
+
+        $member->refresh();
+        $this->assertNotNull($member->avatar_path);
+        Storage::disk('local')->assertExists($member->avatar_path);
+    }
+
+    // ── Edit page — remove avatar ──────────────────────────────────────────────
+
+    public function test_remove_avatar_deletes_file_and_nulls_avatar_path(): void
+    {
+        Storage::fake('local');
+        $this->actingAdmin();
+
+        $member = User::factory()->manager()->create();
+        $path = "avatars/user-{$member->id}.jpg";
+        Storage::disk('local')->put($path, 'AVATAR-BYTES');
+        $member->update(['avatar_path' => $path]);
+
+        Livewire::test(TeamMemberEditPage::class, ['user' => $member->id])
+            ->call('removeAvatar')
+            ->assertSet('currentAvatarPath', null);
+
+        $member->refresh();
+        $this->assertNull($member->avatar_path);
+        Storage::disk('local')->assertMissing($path);
+    }
+
+    // ── Team list page — avatar display ───────────────────────────────────────
+
+    public function test_team_list_shows_img_when_member_has_avatar(): void
+    {
+        Storage::fake('local');
+        $admin = $this->actingAdmin();
+
+        $member = User::factory()->manager()->create();
+        $path = "avatars/user-{$member->id}.jpg";
+        Storage::disk('local')->put($path, 'AVATAR');
+        $member->update(['avatar_path' => $path]);
+
+        Livewire::test(TeamPage::class)
+            ->assertSeeHtml(route('admin.team-member-avatar', $member->id));
+    }
+
+    public function test_team_list_shows_initials_when_member_has_no_avatar(): void
+    {
+        $this->actingAdmin();
+
+        $member = User::factory()->manager()->create([
+            'name' => 'Анна Козлова',
+            'avatar_path' => null,
+        ]);
+
+        Livewire::test(TeamPage::class)
+            ->assertSee('АК');
+    }
+
+    // ── Delete member — avatar cleanup ─────────────────────────────────────────
+
+    public function test_delete_member_removes_avatar_file_from_disk(): void
+    {
+        Storage::fake('local');
+        $admin = $this->actingAdmin();
+
+        $member = User::factory()->manager()->create();
+        $path = "avatars/user-{$member->id}.jpg";
+        Storage::disk('local')->put($path, 'AVATAR-BYTES');
+        $member->update(['avatar_path' => $path]);
+
+        Livewire::test(TeamPage::class)
+            ->call('deleteMember', $member->id);
+
+        $this->assertDatabaseMissing('users', ['id' => $member->id]);
+        Storage::disk('local')->assertMissing($path);
+    }
+
+    public function test_delete_member_without_avatar_does_not_error(): void
+    {
+        Storage::fake('local');
+        $this->actingAdmin();
+
+        $member = User::factory()->manager()->create(['avatar_path' => null]);
+
+        Livewire::test(TeamPage::class)
+            ->call('deleteMember', $member->id)
+            ->assertHasNoErrors();
+
+        $this->assertDatabaseMissing('users', ['id' => $member->id]);
+    }
+}

--- a/tests/Feature/Admin/UserAvatarControllerTest.php
+++ b/tests/Feature/Admin/UserAvatarControllerTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Enums\UserRole;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+/**
+ * Feature tests for UserAvatarController — the auth-gated route that streams
+ * locally-stored team member avatar images.
+ */
+class UserAvatarControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeUserWithAvatar(string $avatarPath): User
+    {
+        return User::factory()->create([
+            'role' => UserRole::Manager,
+            'avatar_path' => $avatarPath,
+        ]);
+    }
+
+    public function test_serves_avatar_to_authed_user(): void
+    {
+        Storage::fake('local');
+
+        $user = User::factory()->create(['role' => UserRole::Manager]);
+        $storagePath = "avatars/user-{$user->id}.jpg";
+        Storage::disk('local')->put($storagePath, 'AVATAR-BYTES');
+        $user->update(['avatar_path' => $storagePath]);
+
+        $this->actingAs(User::factory()->create())
+            ->get(route('admin.team-member-avatar', $user->id))
+            ->assertOk()
+            ->assertStreamedContent('AVATAR-BYTES');
+    }
+
+    public function test_guests_are_redirected(): void
+    {
+        Storage::fake('local');
+
+        $user = $this->makeUserWithAvatar('avatars/user-9.jpg');
+        Storage::disk('local')->put('avatars/user-9.jpg', 'X');
+
+        $this->get(route('admin.team-member-avatar', $user->id))
+            ->assertRedirect();
+    }
+
+    public function test_404_when_path_does_not_start_with_avatars(): void
+    {
+        $user = $this->makeUserWithAvatar('etc/passwd');
+
+        $this->actingAs(User::factory()->create())
+            ->get(route('admin.team-member-avatar', $user->id))
+            ->assertNotFound();
+    }
+
+    public function test_404_when_path_contains_directory_traversal(): void
+    {
+        $user = $this->makeUserWithAvatar('avatars/../etc/passwd');
+
+        $this->actingAs(User::factory()->create())
+            ->get(route('admin.team-member-avatar', $user->id))
+            ->assertNotFound();
+    }
+
+    public function test_404_when_avatar_path_is_empty(): void
+    {
+        $user = User::factory()->create(['role' => UserRole::Manager, 'avatar_path' => null]);
+
+        $this->actingAs(User::factory()->create())
+            ->get(route('admin.team-member-avatar', $user->id))
+            ->assertNotFound();
+    }
+
+    public function test_404_when_file_missing_on_disk(): void
+    {
+        Storage::fake('local');
+
+        $user = $this->makeUserWithAvatar('avatars/user-missing.jpg');
+
+        $this->actingAs(User::factory()->create())
+            ->get(route('admin.team-member-avatar', $user->id))
+            ->assertNotFound();
+    }
+}

--- a/tests/Unit/Jobs/EnrichBotUserProfileJobTest.php
+++ b/tests/Unit/Jobs/EnrichBotUserProfileJobTest.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace Tests\Unit\Jobs;
+
+use App\Jobs\EnrichBotUserProfileJob;
+use App\Models\BotUser;
+use App\Modules\Api\Services\FileService;
+use App\Modules\Telegram\Actions\GetChat;
+use App\Modules\Telegram\DTOs\TelegramAnswerDto;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class EnrichBotUserProfileJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeBotUser(string $platform = 'telegram', ?Carbon $profileSyncedAt = null): BotUser
+    {
+        return BotUser::create([
+            'chat_id' => 1001,
+            'platform' => $platform,
+            'profile_synced_at' => $profileSyncedAt,
+        ]);
+    }
+
+    // ── TTL guard ──────────────────────────────────────────────────────────────
+
+    public function test_ttl_guard_skips_fresh_profile(): void
+    {
+        Http::fake();
+        Storage::fake('local');
+
+        $botUser = $this->makeBotUser('telegram', now()->subDays(5));
+
+        (new EnrichBotUserProfileJob($botUser))->handle();
+
+        // No HTTP calls should have been made.
+        Http::assertNothingSent();
+        $this->assertNull($botUser->avatar_path);
+    }
+
+    // ── Telegram avatar fetched and stored ─────────────────────────────────────
+
+    public function test_telegram_avatar_fetched_and_stored(): void
+    {
+        Storage::fake('local');
+
+        $botUser = $this->makeBotUser('telegram');
+
+        // Mock GetChat to return a response with a photo.
+        $getChatAnswer = new TelegramAnswerDto(
+            ok: true,
+            rawData: [
+                'ok' => true,
+                'result' => [
+                    'photo' => [
+                        'small_file_id' => 'test_file_id_123',
+                    ],
+                ],
+            ]
+        );
+        $this->instance(GetChat::class, new class ($getChatAnswer) extends GetChat {
+            public function __construct(private TelegramAnswerDto $answer)
+            {
+            }
+
+            public function execute(int $chatId): TelegramAnswerDto
+            {
+                return $this->answer;
+            }
+        });
+
+        // Mock FileService::getTelegramFile to return a file_path.
+        $this->instance(FileService::class, new class () extends FileService {
+            public function __construct()
+            {
+            }
+
+            public function getTelegramFile(string $fileId): array
+            {
+                return ['result' => ['file_path' => 'photos/avatar.jpg']];
+            }
+        });
+
+        Http::fake([
+            'https://api.telegram.org/file/bot*/photos/avatar.jpg' => Http::response('AVATAR_BYTES', 200),
+        ]);
+
+        (new EnrichBotUserProfileJob($botUser))->handle();
+
+        $botUser->refresh();
+        $this->assertSame("avatars/bot-user-{$botUser->id}.jpg", $botUser->avatar_path);
+        $this->assertNotNull($botUser->profile_synced_at);
+        Storage::disk('local')->assertExists("avatars/bot-user-{$botUser->id}.jpg");
+    }
+
+    // ── No photo field — still marks synced ────────────────────────────────────
+
+    public function test_no_photo_fallback(): void
+    {
+        Storage::fake('local');
+
+        $botUser = $this->makeBotUser('telegram');
+
+        $getChatAnswer = new TelegramAnswerDto(
+            ok: true,
+            rawData: [
+                'ok' => true,
+                'result' => [],   // no 'photo' key
+            ]
+        );
+        $this->instance(GetChat::class, new class ($getChatAnswer) extends GetChat {
+            public function __construct(private TelegramAnswerDto $answer)
+            {
+            }
+
+            public function execute(int $chatId): TelegramAnswerDto
+            {
+                return $this->answer;
+            }
+        });
+
+        $this->instance(FileService::class, new class () extends FileService {
+            public function __construct()
+            {
+            }
+        });
+
+        Http::fake();
+
+        (new EnrichBotUserProfileJob($botUser))->handle();
+
+        $botUser->refresh();
+        $this->assertNull($botUser->avatar_path);
+        $this->assertNotNull($botUser->profile_synced_at);
+    }
+
+    // ── VK enrichment ─────────────────────────────────────────────────────────
+
+    public function test_vk_enrichment(): void
+    {
+        Storage::fake('local');
+
+        $botUser = $this->makeBotUser('vk');
+
+        // Fake VK users.get call + photo download.
+        Http::fake([
+            'https://api.vk.com/method/users.get' => Http::response([
+                'response' => [
+                    [
+                        'id' => 1001,
+                        'first_name' => 'Анна',
+                        'last_name' => 'Смирнова',
+                        'photo_200' => 'https://vk.com/photo.jpg',
+                    ],
+                ],
+            ], 200),
+            'https://vk.com/photo.jpg' => Http::response('VK_AVATAR_BYTES', 200),
+        ]);
+
+        (new EnrichBotUserProfileJob($botUser))->handle();
+
+        $botUser->refresh();
+        $this->assertSame('Анна Смирнова', $botUser->display_name);
+        $this->assertSame("avatars/bot-user-{$botUser->id}.jpg", $botUser->avatar_path);
+        $this->assertNotNull($botUser->profile_synced_at);
+        Storage::disk('local')->assertExists("avatars/bot-user-{$botUser->id}.jpg");
+    }
+}

--- a/tests/Unit/Models/BotUserTest.php
+++ b/tests/Unit/Models/BotUserTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Jobs\EnrichBotUserProfileJob;
+use App\Models\BotUser;
+use App\Modules\Telegram\DTOs\TelegramUpdateDto;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class BotUserTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // ── Helper: build a minimal TelegramUpdateDto ──────────────────────────────
+
+    /**
+     * @param array<string, mixed> $overrides
+     */
+    private function makeDto(array $overrides = []): TelegramUpdateDto
+    {
+        return new TelegramUpdateDto(
+            updateId: 1,
+            typeQuery: 'message',
+            aiTechMessage: false,
+            typeSource: $overrides['typeSource'] ?? 'private',
+            isBot: false,
+            chatId: $overrides['chatId'] ?? 100,
+            username: $overrides['username'] ?? null,
+            displayName: $overrides['displayName'] ?? null,
+        );
+    }
+
+    // ── Profile sync on creation ───────────────────────────────────────────────
+
+    public function test_sync_display_name_on_new_user_creation(): void
+    {
+        Queue::fake();
+
+        $dto = $this->makeDto(['chatId' => 200, 'displayName' => 'Ivan Petrov', 'username' => 'ivan_p']);
+
+        $botUser = BotUser::getOrCreateByTelegramUpdate($dto);
+
+        $this->assertNotNull($botUser);
+        $this->assertSame('Ivan Petrov', $botUser->display_name);
+        $this->assertSame('ivan_p', $botUser->username);
+        $this->assertTrue($botUser->wasRecentlyCreated);
+
+        Queue::assertPushed(EnrichBotUserProfileJob::class);
+    }
+
+    // ── Opportunistic update when name changes ─────────────────────────────────
+
+    public function test_opportunistic_update_when_name_changes(): void
+    {
+        Queue::fake();
+
+        // Pre-existing user with old name.
+        BotUser::create([
+            'chat_id' => 300,
+            'platform' => 'telegram',
+            'display_name' => 'Old Name',
+            'username' => 'old_handle',
+        ]);
+
+        $dto = $this->makeDto(['chatId' => 300, 'displayName' => 'New Name', 'username' => 'new_handle']);
+
+        $botUser = BotUser::getOrCreateByTelegramUpdate($dto);
+
+        $this->assertNotNull($botUser);
+        $botUser->refresh();
+        $this->assertSame('New Name', $botUser->display_name);
+        $this->assertSame('new_handle', $botUser->username);
+    }
+
+    // ── No write when name is unchanged ───────────────────────────────────────
+
+    public function test_no_write_when_name_unchanged(): void
+    {
+        Queue::fake();
+
+        BotUser::create([
+            'chat_id' => 400,
+            'platform' => 'telegram',
+            'display_name' => 'Same Name',
+            'username' => 'same_handle',
+        ]);
+
+        $dto = $this->makeDto(['chatId' => 400, 'displayName' => 'Same Name', 'username' => 'same_handle']);
+
+        DB::enableQueryLog();
+        BotUser::getOrCreateByTelegramUpdate($dto);
+        $log = DB::getQueryLog();
+        DB::disableQueryLog();
+
+        $updateQueries = array_filter($log, static fn ($q) => str_contains(strtolower($q['query']), 'update'));
+
+        // Should only be the firstOrCreate SELECT + no UPDATE for profile fields.
+        $profileUpdates = array_filter($updateQueries, static fn ($q) => str_contains($q['query'], 'display_name'));
+        $this->assertCount(0, $profileUpdates);
+    }
+}

--- a/tests/Unit/Models/MessageTest.php
+++ b/tests/Unit/Models/MessageTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\BotUser;
+use App\Models\Message;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MessageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // ── sender() relation ──────────────────────────────────────────────────────
+
+    public function test_sender_relation_resolves_to_user(): void
+    {
+        $user = User::factory()->create(['name' => 'Operator One']);
+        $botUser = BotUser::create(['chat_id' => 100, 'platform' => 'telegram']);
+
+        $message = Message::create([
+            'bot_user_id' => $botUser->id,
+            'platform' => 'telegram',
+            'message_type' => 'outgoing',
+            'from_id' => 0,
+            'to_id' => 0,
+            'sender_user_id' => $user->id,
+            'sender_name' => $user->name,
+        ]);
+
+        $this->assertInstanceOf(User::class, $message->sender);
+        $this->assertSame($user->id, $message->sender->id);
+        $this->assertSame('Operator One', $message->sender->name);
+    }
+
+    public function test_sender_relation_is_null_when_no_sender_user_id(): void
+    {
+        $botUser = BotUser::create(['chat_id' => 101, 'platform' => 'telegram']);
+
+        $message = Message::create([
+            'bot_user_id' => $botUser->id,
+            'platform' => 'telegram',
+            'message_type' => 'outgoing',
+            'from_id' => 0,
+            'to_id' => 0,
+        ]);
+
+        $this->assertNull($message->sender);
+        $this->assertNull($message->sender_user_id);
+        $this->assertNull($message->sender_name);
+    }
+
+    // ── nullOnDelete behaviour ─────────────────────────────────────────────────
+
+    public function test_deleting_user_nulls_sender_user_id_but_preserves_sender_name(): void
+    {
+        $user = User::factory()->create(['name' => 'Deletable Operator']);
+        $botUser = BotUser::create(['chat_id' => 102, 'platform' => 'telegram']);
+
+        $message = Message::create([
+            'bot_user_id' => $botUser->id,
+            'platform' => 'telegram',
+            'message_type' => 'outgoing',
+            'from_id' => 0,
+            'to_id' => 0,
+            'sender_user_id' => $user->id,
+            'sender_name' => 'Deletable Operator',
+        ]);
+
+        $user->delete();
+
+        $message->refresh();
+
+        $this->assertNull($message->sender_user_id);
+        $this->assertSame('Deletable Operator', $message->sender_name);
+    }
+
+    // ── $fillable ──────────────────────────────────────────────────────────────
+
+    public function test_sender_user_id_and_sender_name_are_fillable(): void
+    {
+        $user = User::factory()->create(['name' => 'Fill Test']);
+        $botUser = BotUser::create(['chat_id' => 103, 'platform' => 'telegram']);
+
+        $message = Message::create([
+            'bot_user_id' => $botUser->id,
+            'platform' => 'telegram',
+            'message_type' => 'outgoing',
+            'from_id' => 0,
+            'to_id' => 0,
+            'sender_user_id' => $user->id,
+            'sender_name' => 'Fill Test',
+        ]);
+
+        $this->assertSame($user->id, $message->sender_user_id);
+        $this->assertSame('Fill Test', $message->sender_name);
+    }
+}

--- a/tests/Unit/Modules/Admin/Actions/SendReplyActionTest.php
+++ b/tests/Unit/Modules/Admin/Actions/SendReplyActionTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Modules\Admin\Actions;
 use App\Models\BotUser;
 use App\Models\ExternalSource;
 use App\Models\ExternalUser;
+use App\Models\User;
 use App\Modules\Admin\Actions\SendReplyAction;
 use App\Modules\External\Jobs\SendWebhookMessage;
 use App\Modules\Max\Actions\UploadFileMax;
@@ -255,5 +256,56 @@ class SendReplyActionTest extends TestCase
 
         $botUser->refresh();
         $this->assertFalse($botUser->isClosed());
+    }
+
+    // ── Authorship ─────────────────────────────────────────────────────────────
+
+    public function test_passing_author_writes_sender_user_id_and_sender_name(): void
+    {
+        Queue::fake();
+
+        $user = User::factory()->create(['name' => 'Operator Vasya']);
+        $botUser = BotUser::create(['chat_id' => 500, 'platform' => 'telegram']);
+
+        SendReplyAction::execute($botUser, 'Authored reply', null, $user);
+
+        $this->assertDatabaseHas('messages', [
+            'bot_user_id' => $botUser->id,
+            'message_type' => 'outgoing',
+            'sender_user_id' => $user->id,
+            'sender_name' => 'Operator Vasya',
+        ]);
+    }
+
+    public function test_omitting_author_leaves_sender_fields_null(): void
+    {
+        Queue::fake();
+
+        $botUser = BotUser::create(['chat_id' => 501, 'platform' => 'telegram']);
+
+        SendReplyAction::execute($botUser, 'Anonymous reply');
+
+        $this->assertDatabaseHas('messages', [
+            'bot_user_id' => $botUser->id,
+            'message_type' => 'outgoing',
+            'sender_user_id' => null,
+            'sender_name' => null,
+        ]);
+    }
+
+    public function test_explicit_null_author_preserves_backward_compatibility(): void
+    {
+        Queue::fake();
+
+        $botUser = BotUser::create(['chat_id' => 502, 'platform' => 'vk']);
+
+        SendReplyAction::execute($botUser, 'Compat reply', null, null);
+
+        $this->assertDatabaseHas('messages', [
+            'bot_user_id' => $botUser->id,
+            'message_type' => 'outgoing',
+            'sender_user_id' => null,
+            'sender_name' => null,
+        ]);
     }
 }

--- a/tests/Unit/Modules/Ai/Actions/DeliverAiAnswerToUserTest.php
+++ b/tests/Unit/Modules/Ai/Actions/DeliverAiAnswerToUserTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Modules\Ai\Actions;
 
+use App\Jobs\EnrichBotUserProfileJob;
 use App\Models\BotUser;
 use App\Models\Message;
 use App\Modules\Ai\Actions\DeliverAiAnswerToUser;
@@ -105,6 +106,10 @@ class DeliverAiAnswerToUserTest extends TestCase
 
         $this->assertFalse($result);
 
-        Queue::assertNothingPushed();
+        // getUserByChatId() now always dispatches EnrichBotUserProfileJob (BR-011).
+        // Verify only that no platform send jobs were dispatched for unsupported platforms.
+        Queue::assertNotPushed(SendTelegramMessageJob::class);
+        Queue::assertNotPushed(SendVkMessageJob::class);
+        Queue::assertNotPushed(SendMaxMessageJob::class);
     }
 }

--- a/tests/Unit/Modules/Max/Services/MaxMessageServiceTest.php
+++ b/tests/Unit/Modules/Max/Services/MaxMessageServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Modules\Max\Services;
 
+use App\Jobs\EnrichBotUserProfileJob;
 use App\Models\BotUser;
 use App\Modules\Max\Services\MaxMessageService;
 use App\Modules\Telegram\Jobs\SendMaxTelegramMessageJob;
@@ -244,6 +245,8 @@ class MaxMessageServiceTest extends TestCase
         $dto = MaxUpdateDtoMock::getDto($payload);
         (new MaxMessageService($dto))->handleUpdate();
 
-        Queue::assertNothingPushed();
+        // getUserByChatId() now always dispatches EnrichBotUserProfileJob (BR-011).
+        // Assert the message-processing job was not dispatched (no text/attachment to forward).
+        Queue::assertNotPushed(SendMaxTelegramMessageJob::class);
     }
 }

--- a/tests/Unit/Modules/Telegram/Services/TgMax/TgMaxMessageServiceTest.php
+++ b/tests/Unit/Modules/Telegram/Services/TgMax/TgMaxMessageServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Modules\Telegram\Services\TgMax;
 
+use App\Jobs\EnrichBotUserProfileJob;
 use App\Models\BotUser;
 use App\Models\Message;
 use App\Modules\Max\Actions\UploadFileMax;
@@ -174,6 +175,8 @@ class TgMaxMessageServiceTest extends TestCase
 
         (new TgMaxMessageService($dto))->handleUpdate();
 
-        Queue::assertNothingPushed();
+        // getUserByChatId() now always dispatches EnrichBotUserProfileJob (BR-011).
+        // Assert no message-forwarding job was dispatched (no text/caption to forward).
+        Queue::assertNotPushed(SendMaxMessageJob::class);
     }
 }


### PR DESCRIPTION
## Summary

Adds enriched bot-user profiles (name/username captured from the Telegram webhook, avatar fetched asynchronously with a 30-day TTL), uploadable account avatars for team members (operators), and operator attribution for outgoing messages — all surfaced in the chat workspace: real names instead of `chat_id`, the user's avatar, a manager avatar on outgoing bubbles, and the sending operator's name/avatar. Everything degrades gracefully to initials / a generic icon when data is absent.

## Linked issues

Closes #171
Closes #172

## Checklist

- [ ] Tests pass locally
- [ ] Docs / CHANGELOG updated if behavior changed
- [ ] No leftover debug code, prints, or stale TODOs
- [ ] Breaking changes flagged in the summary

## Notes for reviewer

- **Three migrations** — `bot_users` (display_name/username/avatar_path/profile_synced_at), `users` (avatar_path), `messages` (sender_user_id FK nullOnDelete + sender_name snapshot). Run `php artisan migrate`; the profile-enrichment job needs `queue:work`.
- Avatars live on the `local` disk under `avatars/`, served via auth-gated admin routes (`admin.bot-user-avatar`, `admin.team-member-avatar`); deletion cleans the files.
- Profile enrichment dispatch is TTL-guarded (no queue spam): the job is only enqueued when a (re)sync is actually due.
- **AI / `telegram_group` authorship is deferred** — `SendReplyAction`'s author param defaults to `null`, so those paths are unchanged; documented in `messaging.md`.
- This branch is based on `dev` and does NOT include the separate issues-168 chat-thumbnail/PWA work.
- No significant risks otherwise identified.

---

_The task was generated using the MCP server — [prog-time/mcp-github-issues](https://github.com/prog-time/mcp-github-issues)._
