### PR TITLE
issues-179 | fix widget: External always-both persist + TGTextMessageDto chat_id

### DIFF
--- a/app/Models/BotUser.php
+++ b/app/Models/BotUser.php
@@ -286,10 +286,17 @@ class BotUser extends Model
                 throw new Exception('External user not found!');
             }
 
-            return BotUser::firstOrCreate([
-                'chat_id' => $this->externalUser->id,
-                'platform' => $this->externalUser->source,
-            ]);
+            return BotUser::firstOrCreate(
+                [
+                    'chat_id' => $this->externalUser->id,
+                    'platform' => $this->externalUser->source,
+                ],
+                [
+                    // External users are anonymous — give the admin card a readable
+                    // label instead of the raw internal chat_id (e.g. «-1»).
+                    'display_name' => 'Посетитель сайта',
+                ],
+            );
         } catch (\Throwable $e) {
             return null;
         }

--- a/app/Modules/External/Services/ExternalMessageService.php
+++ b/app/Modules/External/Services/ExternalMessageService.php
@@ -47,6 +47,15 @@ class ExternalMessageService extends ExternalService
      */
     protected function sendMessage(): void
     {
+        // Always-both: without a Telegram group the admin workspace is the only
+        // destination, so persist the incoming message directly. With a group
+        // configured, the existing job both forwards and persists (unchanged).
+        if (! $this->groupConfigured()) {
+            $this->persistIncoming($this->update->text);
+
+            return;
+        }
+
         $this->messageParamsDTO->text = $this->update->text;
 
         SendExternalTelegramMessageJob::dispatch(

--- a/app/Modules/External/Services/ExternalService.php
+++ b/app/Modules/External/Services/ExternalService.php
@@ -4,8 +4,11 @@ namespace App\Modules\External\Services;
 
 use App\Models\BotUser;
 use App\Models\ExternalUser;
+use App\Models\Message;
+use App\Modules\Admin\Services\ChannelStatusService;
 use App\Modules\External\DTOs\ExternalMessageDto;
 use App\Modules\Telegram\DTOs\TGTextMessageDto;
+use App\Services\Settings\SettingsService;
 
 abstract class ExternalService
 {
@@ -31,4 +34,47 @@ abstract class ExternalService
     }
 
     abstract public function handleUpdate(): void;
+
+    /**
+     * Whether the optional Telegram supergroup is configured (token/secret set
+     * and a group_id present). When false, the admin workspace is the only
+     * destination and incoming messages are persisted directly.
+     *
+     * @return bool
+     */
+    protected function groupConfigured(): bool
+    {
+        return app(ChannelStatusService::class)->telegram()['connected']
+            && (string) app(SettingsService::class)->get('telegram.group_id') !== '';
+    }
+
+    /**
+     * Persist an incoming external message directly to messages + external_messages.
+     *
+     * Always-both flow: when no Telegram group is configured the message must
+     * still appear in the admin workspace, independent of Telegram delivery.
+     * Mirrors the row shape produced by SendExternalTelegramMessageJob::saveMessage().
+     *
+     * @param string|null $text
+     *
+     * @return Message
+     */
+    protected function persistIncoming(?string $text): Message
+    {
+        $message = Message::create([
+            'bot_user_id' => $this->botUser->id,
+            'platform' => $this->botUser->platform,
+            'message_type' => 'incoming',
+            'from_id' => time(),
+            'to_id' => time(),
+        ]);
+
+        $message->externalMessage()->create([
+            'text' => $text,
+            'file_type' => $this->update->file_type ?? null,
+            'file_name' => $this->update->file_name ?? null,
+        ]);
+
+        return $message;
+    }
 }

--- a/app/Modules/Telegram/DTOs/TGTextMessageDto.php
+++ b/app/Modules/Telegram/DTOs/TGTextMessageDto.php
@@ -10,7 +10,7 @@ use Spatie\LaravelData\Data;
  *
  * @property string      $methodQuery
  * @property string|null $typeSource
- * @property int         $chat_id
+ * @property int|string  $chat_id
  * @property int|null    $message_id
  * @property int|null    $message_thread_id
  * @property string|null $text
@@ -35,7 +35,7 @@ class TGTextMessageDto extends Data
         public string         $methodQuery,
         public ?string        $token,
         public ?string        $typeSource,
-        public int            $chat_id,
+        public int|string     $chat_id,
         public ?int           $message_id,
         public ?int           $message_thread_id,
         public ?string        $text,

--- a/tests/Unit/Modules/External/Services/ExternalMessageServiceTest.php
+++ b/tests/Unit/Modules/External/Services/ExternalMessageServiceTest.php
@@ -54,4 +54,29 @@ class ExternalMessageServiceTest extends TestCase
         $this->assertEquals('private', $job->queryParams->typeSource, );
         $this->assertEquals($job->queryParams->message_thread_id, $this->botUser->topic_id);
     }
+
+    public function test_persists_incoming_directly_when_no_group(): void
+    {
+        // Always-both: without a Telegram group the message is saved directly
+        // for the admin workspace and NOT forwarded to any group.
+        $settings = app(\App\Services\Settings\SettingsService::class);
+        $settings->forget('telegram.token');
+        $settings->forget('telegram.secret_key');
+        $settings->forget('telegram.group_id');
+
+        (new ExternalMessageService($this->dto))->handleUpdate();
+
+        $this->assertDatabaseHas('external_messages', ['text' => $this->dto->text]);
+        $this->assertDatabaseHas('messages', [
+            'bot_user_id' => $this->botUser->id,
+            'message_type' => 'incoming',
+            'platform' => $this->botUser->platform,
+        ]);
+        Queue::assertNotPushed(SendExternalTelegramMessageJob::class);
+    }
+
+    public function test_external_bot_user_gets_readable_display_name(): void
+    {
+        $this->assertSame('Посетитель сайта', $this->botUser->display_name);
+    }
 }

--- a/tests/Unit/Modules/Telegram/DTOs/TGTextMessageDtoTest.php
+++ b/tests/Unit/Modules/Telegram/DTOs/TGTextMessageDtoTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Unit\Modules\Telegram\DTOs;
+
+use App\Modules\Telegram\DTOs\TGTextMessageDto;
+use Tests\TestCase;
+
+class TGTextMessageDtoTest extends TestCase
+{
+    /**
+     * Regression: telegram.group_id is stored/cast as a string in settings and
+     * passed as chat_id (e.g. ExternalMessageService). The DTO must accept it
+     * without a TypeError — Telegram's chat_id is int|string.
+     */
+    public function test_accepts_string_chat_id_from_group_id(): void
+    {
+        $dto = TGTextMessageDto::from([
+            'methodQuery' => 'sendMessage',
+            'typeSource' => 'private',
+            'chat_id' => '-1001234567890',
+            'message_thread_id' => 12,
+            'text' => 'hi',
+        ]);
+
+        $this->assertSame('-1001234567890', $dto->chat_id);
+        $this->assertSame('-1001234567890', $dto->toArray()['chat_id']);
+    }
+
+    public function test_accepts_int_chat_id(): void
+    {
+        $dto = TGTextMessageDto::from([
+            'methodQuery' => 'sendMessage',
+            'chat_id' => 123456789,
+            'text' => 'hi',
+        ]);
+
+        $this->assertSame(123456789, $dto->chat_id);
+    }
+}


### PR DESCRIPTION
Фиксы для работающего виджета в админке (продолжение #181, влитого в dev).

## 1. External-источники переведены на always-both
Раньше входящее от External (в т.ч. виджета) сохранялось в `messages` **только после успешной отправки в Telegram-группу** (`SendExternalTelegramMessageJob::saveMessage` при `response->ok`, плюс требовалось создать форум-топик). Без группы виджет-сообщение терялось → «Нет сообщений».
- `ExternalService`: хелперы `groupConfigured()` + `persistIncoming()`.
- `ExternalMessageService::sendMessage()`: **без группы — персист напрямую** в `messages`+`external_messages` (видно в админке и в `GET /api/widget/.../messages`); **с группой — прежний путь** (форвард+персист) без регресса для REST-потребителей.

## 2. TGTextMessageDto принимает string chat_id
`telegram.group_id` — строка; `$chat_id` был `int` → TypeError (после обновления spatie/laravel-data из-за удаления Sentry). Тип → `int|string` (Telegram chat_id и есть int|string).

## 3. Читаемое имя анонимного посетителя
Внешний юзер без имени показывался как «-1» (внутренний chat_id). Новым external-`BotUser` на создании ставится `display_name = «Посетитель сайта»`.

## Вне scope (follow-up)
Файлы от external без группы (`ExternalFileService`) — отдельная доработка (рендер вложений у external исторически неполный).

## Проверки
- PHPStan level 6 — 0 ошибок
- PHPUnit — 915 тестов / 2387 утверждений — OK
- Pint — чисто

🤖 Generated with [Claude Code](https://claude.com/claude-code)