### PR TITLE
issues-186 | Release 8.0.0 prep: upgrade guide & version bump

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,67 @@
+# Upgrade Guide
+
+## Upgrading to 8.0.0 from 7.x
+
+Release 8.0.0 is a **major release** with breaking changes to configuration and
+the manager-interface model. Read this guide fully before deploying to a running
+environment.
+
+### Breaking changes
+
+1. **Channel & AI credentials moved from `.env` to the database.**
+   All `telegram.*`, `telegram_ai.*`, `vk.*`, `max.*` and AI provider
+   credentials/behaviour keys are now stored exclusively in the `settings` table
+   and read via `SettingsService` (registry entries declare `config => null`, so
+   there is **no `.env`/`config()` fallback**). After upgrading, these values
+   return `null` until they are re-entered through the admin panel — the bot will
+   not send or receive messages and AI replies will fail until then.
+
+2. **`MANAGER_INTERFACE` removed.** The manager-interface mode switch and the
+   `ManagerInterfaceContract` abstraction were removed. The admin panel
+   (`/admin/chats`) is now always-active; incoming and outgoing messages persist
+   to the panel independently of the Telegram group. Remove `MANAGER_INTERFACE`
+   from your `.env` (it is ignored).
+
+3. **Filament removed.** The admin panel is now custom Livewire + standard
+   Laravel `web`/`auth` guard. Routes are unchanged for end users
+   (`/admin/login`, `/admin/chats`, `/admin/settings/*`).
+
+4. **Telescope basic-auth removed.** The Telescope dashboard is now gated by
+   session-based admin auth (logged-in admin), not HTTP Basic auth. Remove
+   `TELESCOPE_AUTH_USER` / `TELESCOPE_AUTH_PASSWORD` from your `.env`.
+
+5. **Sentry and the Loki/Grafana logging stack removed.** Application logs now
+   go to rotating files (`storage/logs/`), viewable via `php artisan pail` or
+   Telescope. Drop the corresponding `.env` keys and infrastructure.
+
+### Deployment steps
+
+```bash
+# 1. Pull the release and install dependencies
+composer install --no-dev --optimize-autoloader
+
+# 2. Run the new migrations (all additive: nullable / default columns)
+php artisan migrate
+
+# 3. Clear and rebuild caches
+php artisan config:clear
+php artisan cache:clear
+
+# 4. Re-enter all secrets via the admin panel (REQUIRED — no .env fallback):
+#    /admin/settings/integrations  → Telegram, Telegram AI bot, VK, MAX tokens
+#    /admin/settings/ai/{provider} → OpenAI / DeepSeek / GigaChat credentials
+#    /admin/settings/general       → Telegram group_id, topic-name template
+
+# 5. Re-register webhooks once credentials are saved
+php artisan ai-bot:set-webhook
+```
+
+### Migration safety
+
+All ten new migrations are additive — new columns are `nullable()` or carry a
+`default()`, no data backfill is required, and each defines a `down()`.
+
+> Rollback caveat: `add_status_to_ai_messages_table` restores
+> `ai_messages.message_id` to `NOT NULL` in `down()`. If any AI draft rows have a
+> `NULL message_id` at rollback time, the rollback will fail. This affects
+> rollback only, never the forward migration.

--- a/resources/views/components/admin/sidebar.blade.php
+++ b/resources/views/components/admin/sidebar.blade.php
@@ -4,13 +4,13 @@
     Props:
       $title       — sidebar heading text (default "Настройки")
       $backUrl     — URL for the back chevron (default route('admin.chats') or '/admin')
-      $version     — version string shown in footer (default "v7.2.0")
+      $version     — version string shown in footer (default "v8.0.0")
       $docsUrl     — URL for "Документация" footer link (default "https://docs.tg-support-bot.ru/")
 --}}
 @props([
     'title'   => 'Настройки',
     'backUrl' => null,
-    'version' => 'v7.2.0',
+    'version' => 'v8.0.0',
     'docsUrl' => 'https://docs.tg-support-bot.ru/',
 ])
 


### PR DESCRIPTION
## Summary

Corrects the confirmed risks of the 8.0.0 release: adds `UPGRADE.md` documenting the breaking changes (credentials moved from `.env` to the DB, `MANAGER_INTERFACE`/Filament/Telescope-basic-auth/Sentry/Loki removed) with concrete deploy steps, and bumps the displayed admin version `v7.2.0` → `v8.0.0`. No behavioural code changes.

The other risks from the release review were verified and dismissed: the remaining widget is the intentional in-app gateway (not the removed site widget); the leftover Filament public assets are gitignored/untracked and were never part of the release; all ten new migrations are additive and reversible; the `env()` calls that remain are rate-limit/test config, not migrated credentials.

## Linked issues

Closes #186

## Checklist

- [ ] Tests pass locally
- [ ] Docs / CHANGELOG updated if behavior changed
- [ ] No leftover debug code, prints, or stale TODOs
- [ ] Breaking changes flagged in the summary

## Notes for reviewer

`UPGRADE.md` is the operational gate for this release — after deploy, **all channel/AI secrets must be re-entered via `/admin/settings/*`** (no `.env` fallback) and migrations must be run. The rollback caveat for `add_status_to_ai_messages_table` (restores `message_id` NOT NULL) is documented but affects rollback only.

---

_The task was generated using the MCP server — [prog-time/mcp-github-issues](https://github.com/prog-time/mcp-github-issues)._