### PR TITLE
issues-186 | Fix CI test failures from missing Vite manifest

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -18,6 +18,13 @@ abstract class TestCase extends BaseTestCase
     {
         parent::setUp();
 
+        // Admin Blade layouts use @vite(...), which requires a built
+        // public/build/manifest.json. CI runs the PHP test suite without
+        // building front-end assets, so disable Vite for tests — @vite
+        // directives resolve to empty strings instead of throwing
+        // ViteManifestNotFoundException.
+        $this->withoutVite();
+
         $this->botToken = '123:ABC';
 
         // Seed common settings into the DB-backed SettingsService.


### PR DESCRIPTION
## Summary

The release CI run failed 11 admin feature tests with HTTP 500 / `ViteManifestNotFoundException`. The admin Blade layouts (`admin-auth`, `admin-chat`, `admin-settings`) call `@vite([...])`, which requires a built `public/build/manifest.json`. The CI PHP-test job never builds front-end assets, so the manifest is absent and every admin page render throws.

Fix: call `$this->withoutVite()` in the base `Tests\TestCase::setUp()`. With Vite disabled, `@vite` directives resolve to empty strings instead of throwing, decoupling the PHP test suite from a front-end build. This is the standard Laravel approach for feature tests that render `@vite`-using views.

Verified locally by moving `public/build/manifest.json` aside (mimicking CI) and running the 3 affected test files — all 19 tests pass. The full suite passes via the pre-push hook.

Note: the pre-push hook missed this originally because a stale `public/build/manifest.json` exists on local dev machines; CI is a clean checkout.

## Linked issues

Related to #186

## Checklist

- [x] Affected tests pass with no Vite manifest present
- [x] Full suite passes (pre-push)
- [x] No production code changed — test bootstrap only

---

_The task was generated using the MCP server — [prog-time/mcp-github-issues](https://github.com/prog-time/mcp-github-issues)._