### PR TITLE
issues-195 | Усилить CI: триггер dev, Pint, gitleaks, composer, vite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,13 @@ name: Laravel CI Optimized
 
 on:
   push:
-    branches: [ "main", "develop" ]
+    branches: [ "main", "dev" ]
   pull_request:
-    branches: [ "main", "develop" ]
+    branches: [ "main", "dev" ]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   hadolint:
@@ -228,3 +232,109 @@ jobs:
 
       - name: Run tests in parallel with isolation
         run: php artisan test
+
+  pint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.3"
+
+      - name: Cache Composer
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: composer-${{ hashFiles('composer.lock') }}
+          restore-keys: composer-
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run Pint (check only)
+        run: ./vendor/bin/pint --test
+
+  composer_validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.3"
+
+      - name: Validate composer.json against composer.lock
+        run: composer validate --strict --no-check-publish
+
+  composer_audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.3"
+
+      - name: Cache Composer
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: composer-${{ hashFiles('composer.lock') }}
+          restore-keys: composer-
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Audit dependencies for known vulnerabilities
+        run: composer audit --no-dev --abandoned=ignore
+
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        run: |
+          GITLEAKS_VERSION="8.18.4"
+          BASE="https://github.com/gitleaks/gitleaks/releases/download"
+          FILE="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -sSfL "${BASE}/v${GITLEAKS_VERSION}/${FILE}" \
+            | sudo tar -xz -C /usr/local/bin gitleaks
+
+      - name: Run gitleaks
+        run: |
+          set -euo pipefail
+
+          echo "ℹ️ Running gitleaks on the repository..."
+
+          if gitleaks detect --source . --no-banner --redact; then
+            echo "✅ No secrets found"
+          else
+            echo "❌ gitleaks found potential secrets"
+            exit 1
+          fi
+
+  vite_build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build front-end assets
+        run: npm run build

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,28 @@
+# gitleaks configuration for tg-support-bot
+# Used by the `gitleaks` CI job (.github/workflows/ci.yml).
+#
+# We extend gitleaks' default ruleset and allowlist a small set of KNOWN
+# false positives that the high-entropy `generic-api-key` heuristic flags in
+# git history. All four are non-secret example/fixture values:
+#   - test fixtures with fake API keys/tokens,
+#   - an example key in the rules documentation.
+# They are allowlisted by the exact commit that introduced them, so any
+# NEW secret in any NEW commit is still caught.
+
+title = "tg-support-bot gitleaks config"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Known false positives — test fixtures and docs example keys (high-entropy, not real credentials)"
+commits = [
+  # tests/Unit/Livewire/Settings/IntegrationChannelPageTest.php — fake channel token in a test
+  "a743189840972a5e2ba79a69ea883eee1f5137cf",
+  # rules/master-promt.md — example API key in documentation
+  "11644b094b313c7f736a75a43f7eecec64bd6fce",
+  # tests/Unit/Services/File/FileServiceTest.php — fixture value (file no longer in tree)
+  "7a01e6a522459ad7e271b802ff89c286bcf9078a",
+  # resources/views/preview/chat.blade.php — demo preview value (file no longer in tree)
+  "1bd097ea2cf2d9d2ce1ef451c1a15830f37600dc",
+]

--- a/composer.lock
+++ b/composer.lock
@@ -6949,16 +6949,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v7.4.6",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "58751048de17bae71c5aa0d13cb19d79bca26391"
+                "reference": "a7ec3b1156faf8815db7683ec7c1e7338e6f977c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/58751048de17bae71c5aa0d13cb19d79bca26391",
-                "reference": "58751048de17bae71c5aa0d13cb19d79bca26391",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/a7ec3b1156faf8815db7683ec7c1e7338e6f977c",
+                "reference": "a7ec3b1156faf8815db7683ec7c1e7338e6f977c",
                 "shasum": ""
             },
             "require": {
@@ -7001,7 +7001,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v7.4.6"
+                "source": "https://github.com/symfony/yaml/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -7021,7 +7021,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-09T09:33:46+00:00"
+            "time": "2026-05-25T06:06:12+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",

--- a/database/migrations/2026_06_03_005727_create_telescope_entries_table.php
+++ b/database/migrations/2026_06_03_005727_create_telescope_entries_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     /**
      * Get the migration connection name.
      */


### PR DESCRIPTION
## Summary

Расширяет `.github/workflows/ci.yml` недостающими проверками (стиль — один job на проверку, как в текущем CI и `prog-time/workflows`) и чинит критичный баг триггера.

**Изменения CI:**
- **Fix триггера:** `develop` → `dev` в `on.push`/`on.pull_request`. Интеграционная ветка — `dev`, а CI слушал несуществующий `develop`, поэтому PR в `dev` **не запускали пайплайн**. Добавлен `concurrency: cancel-in-progress`.
- **`pint`** — `vendor/bin/pint --test` (формат PSR-12+Laravel, раньше нигде не enforced).
- **`gitleaks`** — скан секретов (snippet из `prog-time/workflows`) + `.gitleaks.toml` с аллоулистом 4 известных false-positive (тест-фикстуры и пример ключа в доке, по конкретным историческим коммитам — новые секреты ловятся).
- **`composer_validate`** — `composer validate --strict --no-check-publish`.
- **`composer_audit`** — `composer audit --no-dev --abandoned=ignore` (CVE; abandoned-шум игнорируется).
- **`vite_build`** — `npm ci && npm run build` (ловит сломанные ассеты — ранее был `ViteManifestNotFoundException`).

**Сопутствующие фиксы (требуются, чтобы новые гейты были зелёными с первого прогона):**
- **`symfony/yaml` v7.4.6 → v7.4.13** — `composer audit` выявил 3 реальных low-severity CVE (CVE-2026-45304/45305/45133, «Billion Laughs»/ReDoS/stack-exhaustion в YAML-парсере). Бамп до пропатченной версии; lock-диф строго на один пакет.
- **Pint-форматирование** `database/migrations/...create_telescope_entries_table.php` — единственное нарушение, которое валило `pint --test`.

## Локальная проверка (все зелёные)
- `pint --test`: PASS (454 files) · `composer validate --strict`: valid · `composer audit --no-dev --abandoned=ignore`: no advisories · `gitleaks detect` (с `.gitleaks.toml`): no leaks · `yamllint` ci.yml: clean.

## Linked issues

Closes #195

## Notes for reviewer
- ⚠️ Бутстрап: этот PR идёт в `dev`, но **текущий** (ещё не пропатченный) триггер CI слушает `develop`, поэтому автоматический прогон на самом PR может не стартовать — проверки валидированы локально, заработают после мержа.
- gitleaks нашёл 4 «leaks» — все подтверждённо **fake** (тест-фикстуры `IntegrationChannelPageTest`/`FileServiceTest`, пример в `rules/master-promt.md`, демо-preview). Реальной утечки нет; аллоулист точечный по коммитам.

---

_The task was generated using the MCP server — [prog-time/mcp-github-issues](https://github.com/prog-time/mcp-github-issues)._