### PR TITLE
issues-201 | widen bot_users.chat_id to string for pluggable platforms

### DIFF
--- a/app/Models/BotUser.php
+++ b/app/Models/BotUser.php
@@ -15,7 +15,7 @@ use phpDocumentor\Reflection\Exception;
 /**
  * @property int                             $id
  * @property int                             $topic_id
- * @property int                             $chat_id
+ * @property int|string                      $chat_id
  * @property string                          $platform
  * @property string|null                     $display_name
  * @property string|null                     $username
@@ -107,11 +107,11 @@ class BotUser extends Model
     /**
      * Get platform by chat id
      *
-     * @param int $chatId
+     * @param int|string $chatId
      *
      * @return string|null
      */
-    public static function getPlatformByChatId(int $chatId): ?string
+    public static function getPlatformByChatId(int|string $chatId): ?string
     {
         try {
             $botUser = self::select('platform')

--- a/database/migrations/2026_07_06_000001_change_bot_users_chat_id_to_string.php
+++ b/database/migrations/2026_07_06_000001_change_bot_users_chat_id_to_string.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Widen bot_users.chat_id from unsignedBigInteger to string so the core can
+     * natively store conversation ids of pluggable platforms whose id is a
+     * string (Avito "u2i-...", WhatsApp, …). Numeric ids (telegram/vk/max and the
+     * external_source FK to external_users.id) convert cleanly to text; the
+     * existing index is rebuilt by the database for the new type.
+     */
+    public function up(): void
+    {
+        Schema::table('bot_users', function (Blueprint $table) {
+            $table->string('chat_id')->change();
+        });
+    }
+
+    /**
+     * Revert to unsignedBigInteger.
+     *
+     * WARNING: irreversible once any non-numeric chat_id exists (e.g. an Avito
+     * "u2i-..." id) — casting varchar → bigint will fail. Safe only while every
+     * chat_id is numeric (the pre-Avito state).
+     */
+    public function down(): void
+    {
+        Schema::table('bot_users', function (Blueprint $table) {
+            $table->unsignedBigInteger('chat_id')->change();
+        });
+    }
+};

--- a/tests/Unit/Models/BotUserTest.php
+++ b/tests/Unit/Models/BotUserTest.php
@@ -101,4 +101,39 @@ class BotUserTest extends TestCase
         $profileUpdates = array_filter($updateQueries, static fn ($q) => str_contains($q['query'], 'display_name'));
         $this->assertCount(0, $profileUpdates);
     }
+
+    // ── String chat_id (pluggable platforms: Avito "u2i-...", WhatsApp, …) ─────
+
+    public function test_string_chat_id_round_trips_without_coercion(): void
+    {
+        $botUser = BotUser::create(['chat_id' => 'u2i-abc123', 'platform' => 'avito']);
+
+        $fresh = BotUser::findOrFail($botUser->id);
+
+        // Persisted and read back as the exact string — no int coercion, no
+        // dropped prefix (the whole point of widening chat_id to string).
+        $this->assertSame('u2i-abc123', $fresh->chat_id);
+        $this->assertSame($botUser->id, BotUser::where('chat_id', 'u2i-abc123')->first()?->id);
+    }
+
+    // ── external_source relation regression across the type change ─────────────
+    // bot_users.chat_id doubles as the FK to external_users.id (bigint). After
+    // widening chat_id to string, the varchar ↔ bigint join must still resolve.
+
+    public function test_external_user_relation_resolves_after_chat_id_widened_to_string(): void
+    {
+        $externalUser = \App\Models\ExternalUser::create([
+            'external_id' => 555,
+            'source' => 'regression-source',
+        ]);
+
+        $botUser = BotUser::create([
+            'chat_id' => (string) $externalUser->id,
+            'platform' => 'external_source',
+        ]);
+
+        // Forward relation (hasOne ExternalUser 'id' <- 'chat_id') joins the now
+        // varchar chat_id against the bigint external_users.id — must still resolve.
+        $this->assertTrue($botUser->externalUser->is($externalUser));
+    }
 }


### PR DESCRIPTION
Расширяет `bot_users.chat_id` с `unsignedBigInteger` до строки, чтобы ядро нативно хранило conversation id платформ, у которых он строковый (Avito `"u2i-..."`, в планах WhatsApp). После этого подключаемый модуль остаётся тонким — резолвит `BotUser` и отвечает прямо по `$botUser->chat_id`, без собственной таблицы-маппинга.

## Что входит
- **Миграция** `2026_07_06_000001_change_bot_users_chat_id_to_string`: `chat_id` `bigint → string` (индекс сохраняется, числовые значения конвертируются неявно). `down()` помечен как небезопасный при наличии нечисловых id.
- **`app/Models/BotUser.php`**: PHPDoc `@property int $chat_id` → `int|string`; `getPlatformByChatId(int $chatId)` → `int|string`; `chat_id` намеренно **не** в `$casts` (остаётся строкой).
- **Тесты** (`BotUserTest`): строковый `chat_id` (`"u2i-abc123"`) сохраняется и читается как строка без коэрсии/потери префикса; регресс-тест прямой связи `external_source` (`BotUser::externalUser()` — join `varchar chat_id` ↔ `bigint external_users.id` резолвится).

## Проверки
- PHPStan level 6 — 0 ошибок. Larastan разрешает атрибут модели как `mixed`, поэтому расширение `@property` не потребовало правки сигнатур в ~19 потребителях `->chat_id` (числовые платформы читают числовую строку, `(int)`-касты и Spatie-DTO её принимают).
- `pint` чистый. PHPUnit: **952 теста зелёные** (pre-push).

## Вне scope (отдельные задачи)
- Доработка модуля `prog-time/tg-support-avito` (сохранение входящих в `messages`, resolve/reply по `chat_id`).
- Контракт `PlatformChannel::sendManagerReply()`.
- Очистка перегрузки `chat_id` (id платформы + FK на `external_users.id`) — зафиксировано как техдолг.

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)
