### PR TITLE
issues-211 | fix: поле ввода схлопывается при наборе второй строки

### DIFF
--- a/resources/views/livewire/chat/conversation-page.blade.php
+++ b/resources/views/livewire/chat/conversation-page.blade.php
@@ -810,22 +810,41 @@
                         @endif
 
                         {{-- Text input --}}
-                        <div class="relative flex-1 flex">
-                            {{-- Auto-growing textarea: 1 line by default, grows with
-                                 content up to max-height, then scrolls. autosize() runs
-                                 on input (instant, client-side) and whenever replyText
-                                 changes programmatically (insertQuickReply / clear after
-                                 send) via $wire.$watch. --}}
+                        {{-- Auto-growing textarea: 1 line by default, grows with content
+                             up to max-height, then scrolls.
+
+                             The textarea carries wire:ignore and is bound through
+                             @entangle instead of wire:model. This is deliberate: the
+                             thread polls every 5 s (wire:poll), and a plain
+                             wire:model.live re-rendered the textarea on every keystroke
+                             AND every poll, so Livewire's morph reverted the inline
+                             height Alpine had set — collapsing the field back to one
+                             line and jerking the caret to the top (issue #211). With
+                             wire:ignore the morph never touches the field, so height and
+                             draft both survive typing and polls; @entangle keeps the
+                             value synced with $replyText, so send/clear, quick replies
+                             and AI drafts still drive it. autosize() runs on input and
+                             whenever the entangled value changes (programmatic writes). --}}
+                        <div class="relative flex-1 flex"
+                             x-data="{
+                                text: @entangle('replyText'),
+                                autosize() {
+                                    const el = this.$refs.ta;
+                                    el.style.height = 'auto';
+                                    el.style.height = Math.min(el.scrollHeight, 160) + 'px';
+                                },
+                             }"
+                             x-init="$nextTick(() => autosize()); $watch('text', () => $nextTick(() => autosize()))">
                             <textarea
-                                wire:model.live="replyText"
+                                wire:ignore
+                                x-ref="ta"
+                                x-model="text"
                                 rows="1"
                                 placeholder="Напишите сообщение..."
                                 class="w-full resize-none text-sm text-text-primary placeholder-text-secondary outline-none border-none bg-transparent"
                                 style="background:#F1F3F5; border-radius:12px; padding:12px 16px; line-height:1.25; min-height:44px; max-height:160px; overflow-y:auto;"
-                                x-data="{ autosize() { this.$el.style.height = 'auto'; this.$el.style.height = Math.min(this.$el.scrollHeight, 160) + 'px'; } }"
-                                x-init="$nextTick(() => autosize()); $wire.$watch('replyText', () => $nextTick(() => autosize()))"
                                 x-on:input="autosize()"
-                                x-on:keydown.enter="if (! $event.shiftKey) { $event.preventDefault(); if (! $el.value.trim()) return; $wire.sendReply(); }"
+                                x-on:keydown.enter="if (! $event.shiftKey) { $event.preventDefault(); if (! $refs.ta.value.trim()) return; $wire.sendReply(); }"
                                 aria-label="Текст сообщения"
                             ></textarea>
                             @error('replyText')

--- a/tests/Feature/Admin/ConversationWorkspaceTest.php
+++ b/tests/Feature/Admin/ConversationWorkspaceTest.php
@@ -47,6 +47,33 @@ class ConversationWorkspaceTest extends TestCase
 
     // ── Render ─────────────────────────────────────────────────────────────────
 
+    /**
+     * Regression guard for #211: the reply textarea collapsed to one line while
+     * typing because wire:model.live re-rendered it on every keystroke (and every
+     * 5 s poll), letting Livewire's morph revert the height Alpine had set.
+     *
+     * The fix isolates the field from morphing with wire:ignore and binds it with
+     * Livewire entangle instead. This can't be exercised in a browser here (no
+     * Dusk), so the structural markers are pinned: reverting to wire:model.live on
+     * the reply field brings the bug back and fails this test.
+     */
+    public function test_reply_textarea_is_isolated_from_livewire_morphing(): void
+    {
+        $botUser = BotUser::create(['chat_id' => '211', 'platform' => 'telegram']);
+
+        $html = Livewire::test(ConversationPage::class)
+            ->call('selectChat', $botUser->id)
+            ->assertSee('wire:ignore', false)
+            ->assertSee('x-model="text"', false)
+            ->html();
+
+        $this->assertStringNotContainsString(
+            'wire:model.live="replyText"',
+            $html,
+            'The reply textarea must not use wire:model.live — it re-renders on every keystroke and collapses the field (#211).'
+        );
+    }
+
     public function test_page_renders_under_auth(): void
     {
         Livewire::test(ConversationPage::class)


### PR DESCRIPTION
Closes #211

## Симптом

В админ-чате при наборе второй строки поле схлопывалось обратно к первой, каретку всегда утягивало наверх — печатать многострочный ответ было невозможно.

## Причина

Textarea использовала `wire:model.live`, поэтому **каждое нажатие** — и `wire:poll.5s` на треде — перерисовывали компонент. Морфинг Livewire откатывал inline-высоту, которую выставлял Alpine `autosize()` (в серверном шаблоне явной высоты нет), схлопывая поле к одной строке и сбрасывая скролл наверх.

Просто убрать `.live` было нельзя: именно живая синхронизация не давала 5-секундному опросу стереть набранный черновик.

## Фикс

Изолировал поле от морфинга через `wire:ignore` и связал значение через `@entangle('replyText')` вместо `wire:model`:

- Livewire больше **не трогает** textarea → высота и черновик переживают и ввод, и опрос
- `@entangle` держит значение в синхроне → отправка/очистка, быстрые ответы и вставка AI-черновика по-прежнему им управляют
- enter-to-send, autosize по вводу и autosize при программном изменении — сохранены

## Тест

Dusk в проекте нет, поэтому само поведение в браузере не проверить. Добавлен структурный регресс-тест: он закрепляет `wire:ignore` + `x-model="text"` и падает, если на поле вернут `wire:model.live` — то есть если баг вернётся.

## Проверка

994 теста зелёные, Pint и PHPStan level 6 чистые.

Деплой сборки не требует — правка только в Blade/Alpine-директивах, новых Tailwind-классов нет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
