### PR TITLE
issues-205 | fix: имя пользователя VK/MAX в названии форум-темы вместо id

### DIFF
--- a/app/Modules/Max/DTOs/MaxUpdateDto.php
+++ b/app/Modules/Max/DTOs/MaxUpdateDto.php
@@ -15,6 +15,8 @@ readonly class MaxUpdateDto
         public array $rawData,
         public array $listFileUrl,
         public array $listAttachments,
+        public ?string $senderName = null,
+        public ?string $senderUsername = null,
     ) {
     }
 
@@ -30,6 +32,8 @@ readonly class MaxUpdateDto
 
             $attachments = $data['message']['body']['attachments'] ?? [];
 
+            $sender = $data['message']['sender'] ?? [];
+
             return new self(
                 event_id: (string)($data['event_id'] ?? $data['timestamp']),
                 type: $data['update_type'] ?? $data['type'],
@@ -39,6 +43,11 @@ readonly class MaxUpdateDto
                 rawData: $data,
                 listFileUrl: self::getListUrlAttachments($attachments),
                 listAttachments: self::getListAttachments($attachments),
+                // MAX delivers the sender's display name and @username right in the
+                // webhook (per the Bot API sender object), so — unlike VK — no extra
+                // API call is needed to label the conversation.
+                senderName: isset($sender['name']) ? (string) $sender['name'] : null,
+                senderUsername: isset($sender['username']) ? (string) $sender['username'] : null,
             );
         } catch (\Throwable) {
             return null;

--- a/app/Modules/Max/Services/MaxMessageService.php
+++ b/app/Modules/Max/Services/MaxMessageService.php
@@ -51,6 +51,11 @@ class MaxMessageService extends ToTgMessageService
                 throw new \Exception('Unknown event type', 1);
             }
 
+            // Label the conversation with the real person, not just their id.
+            // MAX ships the name/username in the webhook, so this is stored before
+            // the forum topic is created (TopicCreateJob reads BotUser profile).
+            $this->captureProfile();
+
             Log::channel('app')->info('MaxMessageService: incoming update', [
                 'text' => $this->update->text,
                 'listFileUrl' => $this->update->listFileUrl,
@@ -79,6 +84,35 @@ class MaxMessageService extends ToTgMessageService
                 $e->getMessage(),
                 ['file' => $e->getFile(), 'line' => $e->getLine()]
             );
+        }
+    }
+
+    /**
+     * Persist the MAX sender's display name / username onto the BotUser.
+     *
+     * Fills the fields only when empty, so a name the operator may have set by
+     * hand is never overwritten. Fields absent from the webhook are left as-is.
+     *
+     * @return void
+     */
+    protected function captureProfile(): void
+    {
+        if ($this->botUser === null) {
+            return;
+        }
+
+        $changes = [];
+
+        if (empty($this->botUser->display_name) && !empty($this->update->senderName)) {
+            $changes['display_name'] = $this->update->senderName;
+        }
+
+        if (empty($this->botUser->username) && !empty($this->update->senderUsername)) {
+            $changes['username'] = $this->update->senderUsername;
+        }
+
+        if ($changes !== []) {
+            $this->botUser->update($changes);
         }
     }
 

--- a/app/Modules/Telegram/Jobs/TopicCreateJob.php
+++ b/app/Modules/Telegram/Jobs/TopicCreateJob.php
@@ -2,6 +2,7 @@
 
 namespace App\Modules\Telegram\Jobs;
 
+use App\Jobs\EnrichBotUserProfileJob;
 use App\Models\BotUser;
 use App\Models\ExternalUser;
 use App\Modules\Telegram\Actions\GetChat;
@@ -105,7 +106,7 @@ class TopicCreateJob implements ShouldQueue
                 $templateTopicName = str_replace('{platform}', $botUser->platform, $templateTopicName);
             }
 
-            $nameParts = $this->getPartsGenerateName($botUser->chat_id);
+            $nameParts = $this->getPartsGenerateName($botUser);
             if (empty($nameParts)) {
                 throw new \Exception('Name parts not found');
             }
@@ -116,14 +117,20 @@ class TopicCreateJob implements ShouldQueue
                 throw new \Exception('Params template topic name not found');
             }
 
-            $paramsParts = array_combine($matches[0], $matches[1]);
-
             $topicName = $templateTopicName;
-            foreach ($paramsParts as $key => $param) {
-                if (empty($nameParts[$param])) {
-                    throw new \Exception('Params template topic name not found');
-                }
-                $topicName = str_replace($key, $nameParts[$param], $topicName);
+            foreach (array_unique($matches[1]) as $param) {
+                // Missing params collapse to an empty string instead of aborting
+                // the whole name: a template like «{first_name} {last_name}» must
+                // still work for a user who has no surname (or a VK/MAX profile
+                // that only carries a single display name).
+                $value = (string) ($nameParts[$param] ?? '');
+                $topicName = str_replace('{' . $param . '}', $value, $topicName);
+            }
+
+            // Tidy up the whitespace left where empty params used to be.
+            $topicName = trim((string) preg_replace('/\s{2,}/', ' ', $topicName));
+            if ($topicName === '') {
+                throw new \Exception('Empty topic name');
             }
 
             return $topicName;
@@ -135,13 +142,67 @@ class TopicCreateJob implements ShouldQueue
     /**
      * Get parts for chat name generation.
      *
+     * Telegram is resolved live from getChat. Every other platform (vk, max,
+     * avito, …) is labelled from the BotUser profile stored on the row — getChat
+     * only understands Telegram ids, so calling it for a VK/MAX id fails and the
+     * topic used to fall back to the bare «#id (platform)» (issue #205). VK is
+     * enriched here on demand (users.get) if it has not been synced yet; MAX is
+     * already captured from its webhook by MaxMessageService.
+     *
+     * The stored single display name is exposed under every name-ish template
+     * param so a Telegram-style template still resolves to something readable.
+     *
+     * @param BotUser $botUser
+     *
+     * @return array<string, string>
+     */
+    protected function getPartsGenerateName(BotUser $botUser): array
+    {
+        if ($botUser->platform === 'telegram') {
+            return $this->telegramNameParts((int) $botUser->chat_id);
+        }
+
+        // Pull a profile for platforms that fetch it asynchronously (VK) so the
+        // name is available at topic-creation time rather than on the next sync.
+        if (empty($botUser->display_name)) {
+            try {
+                (new EnrichBotUserProfileJob($botUser))->handle();
+                $botUser->refresh();
+            } catch (\Throwable) {
+                // Best effort — fall through to whatever is already stored.
+            }
+        }
+
+        $displayName = (string) ($botUser->display_name ?? '');
+        $username = (string) ($botUser->username ?? '');
+
+        // No name and no username: there is nothing readable to label the topic
+        // with, so signal the caller to use the «#id (platform)» fallback rather
+        // than render a template down to just the bare platform literal.
+        if ($displayName === '' && $username === '') {
+            return [];
+        }
+
+        $parts = [
+            'id' => (string) $botUser->chat_id,
+            'username' => $username,
+            'name' => $displayName,
+            'display_name' => $displayName,
+            'first_name' => $displayName,
+            'last_name' => '',
+        ];
+
+        return array_filter($parts, static fn (string $value): bool => $value !== '');
+    }
+
+    /**
+     * Name parts resolved live from the Telegram getChat API.
+     *
      * @param int $chatId
      *
-     * @return array
-     *
-     * @throws \Exception
+     * @return array<string, string>
      */
-    protected function getPartsGenerateName(int $chatId): array
+    protected function telegramNameParts(int $chatId): array
     {
         try {
             $chatDataQuery = app(GetChat::class)->execute($chatId);
@@ -161,7 +222,17 @@ class TopicCreateJob implements ShouldQueue
                 'last_name',
                 'username',
             ];
-            return array_intersect_key($chatData, array_flip($neededKeys));
+            $parts = array_intersect_key($chatData, array_flip($neededKeys));
+
+            // Expose a combined «name»/«display_name» too, so a template written
+            // with those params works the same across every platform.
+            $combined = trim(($chatData['first_name'] ?? '') . ' ' . ($chatData['last_name'] ?? ''));
+            if ($combined !== '') {
+                $parts['name'] = $combined;
+                $parts['display_name'] = $combined;
+            }
+
+            return array_map(static fn ($value): string => (string) $value, $parts);
         } catch (Exception $e) {
             return [];
         }

--- a/rules/domain/messaging.md
+++ b/rules/domain/messaging.md
@@ -95,6 +95,9 @@ _Enforced in:_ `app/Modules/Admin/Actions/SendReplyAction.php @ sendAvitoReply()
 **BR-005a** — Each user has at most one Telegram forum topic (`BotUser.topic_id`). The topic is created lazily: when the supergroup is configured and a message arrives for a user without a topic, `TopicCreateJob` is dispatched.
 _Enforced in:_ `app/Modules/Telegram/Jobs/TopicCreateJob.php`, `app/Models/BotUser.php @ topic_id`
 
+**BR-005b** — The forum-topic name is rendered from the `telegram.template_topic_name` template (params `{first_name} {last_name} {username} {name} {display_name} {id} {platform}`) against the user's identity. The identity is resolved **per platform**, NOT via Telegram `getChat` for everyone: `telegram` is fetched live from `getChat`; every other platform (`vk`, `max`, `avito`, …) is labelled from the stored `BotUser` profile (`display_name` / `username`). MAX captures the name/`username` straight from its webhook (`MaxMessageService::captureProfile()`); VK is enriched on demand via `users.get` inside `TopicCreateJob` when `display_name` is still empty. A template param that has no value collapses to an empty string (a single-name profile against `{first_name} {last_name}` still resolves), and only when NO name and NO username exist does the topic fall back to `#{chat_id} ({platform})`. Before, `getChat` was called for every platform and failed for non-Telegram ids, so VK/MAX topics always fell back to the bare id (issue #205).
+_Enforced in:_ `app/Modules/Telegram/Jobs/TopicCreateJob.php @ generateNameTopic/getPartsGenerateName`, `app/Modules/Max/Services/MaxMessageService.php @ captureProfile`, `app/Jobs/EnrichBotUserProfileJob.php`
+
 **BR-006** — If a forum topic does not exist when forwarding a message to the supergroup, `TopicCreateJob` must be dispatched before the message send job to ensure the topic is ready.
 _Enforced in:_ `app/Modules/Telegram/Jobs/TopicCreateJob.php`
 

--- a/tests/Feature/Jobs/TopicCreateJobProfileNameTest.php
+++ b/tests/Feature/Jobs/TopicCreateJobProfileNameTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Tests\Feature\Jobs;
+
+use App\Models\BotUser;
+use App\Modules\Telegram\Jobs\TopicCreateJob;
+use App\Services\Settings\SettingsService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+/**
+ * Covers the cross-platform forum-topic name (issue #205).
+ *
+ * The topic name used to be built only from Telegram's getChat, so a VK or MAX
+ * conversation — whose id getChat cannot resolve — fell back to the bare
+ * «#id (platform)». These tests pin that the stored BotUser profile now labels
+ * the topic for non-Telegram platforms.
+ *
+ * The base TestCase seeds the template as «{first_name} {last_name} {platform}».
+ */
+class TopicCreateJobProfileNameTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // createForumTopic must succeed; sendContact (SendContactMessage) and any
+        // other Telegram call is stubbed so the job never touches the network.
+        Http::fake([
+            'https://api.telegram.org/bot*/createForumTopic*' => Http::response([
+                'ok' => true,
+                'result' => ['message_thread_id' => 555],
+            ], 200),
+            'https://api.telegram.org/bot*' => Http::response(['ok' => true, 'result' => []], 200),
+        ]);
+    }
+
+    /**
+     * @return string The `name` sent to createForumTopic for the given BotUser.
+     */
+    private function topicNameFor(BotUser $botUser): string
+    {
+        (new TopicCreateJob($botUser->id))->handle();
+
+        $name = null;
+        Http::assertSent(function ($request) use (&$name) {
+            if (str_contains($request->url(), '/createForumTopic')) {
+                $name = $request->data()['name'] ?? null;
+
+                return true;
+            }
+
+            return false;
+        });
+
+        return (string) $name;
+    }
+
+    public function test_max_topic_uses_stored_display_name(): void
+    {
+        $botUser = BotUser::create([
+            'chat_id' => '77771111',
+            'platform' => 'max',
+            'display_name' => 'Иван Петров',
+        ]);
+
+        $name = $this->topicNameFor($botUser);
+
+        $this->assertStringContainsString('Иван Петров', $name);
+        $this->assertStringNotContainsString('#77771111', $name);
+    }
+
+    public function test_missing_last_name_does_not_collapse_the_topic_to_the_bare_id(): void
+    {
+        // Only a single name is stored (typical for VK/MAX), yet the template has
+        // a {last_name} slot. It must resolve to the name, not the #id fallback.
+        $botUser = BotUser::create([
+            'chat_id' => '88882222',
+            'platform' => 'max',
+            'display_name' => 'Мария',
+        ]);
+
+        $name = $this->topicNameFor($botUser);
+
+        $this->assertStringContainsString('Мария', $name);
+        $this->assertStringNotContainsString('  ', $name, 'Whitespace from the empty {last_name} must be collapsed.');
+    }
+
+    public function test_vk_profile_is_enriched_on_demand_when_missing(): void
+    {
+        // VK carries no name in the webhook; it is fetched via users.get. The job
+        // must pull it synchronously so the very first topic is already labelled.
+        Http::fake([
+            'https://api.vk.com/method/users.get*' => Http::response([
+                'response' => [[
+                    'id' => 99993333,
+                    'first_name' => 'Пётр',
+                    'last_name' => 'Сидоров',
+                ]],
+            ], 200),
+            'https://api.telegram.org/bot*/createForumTopic*' => Http::response([
+                'ok' => true,
+                'result' => ['message_thread_id' => 556],
+            ], 200),
+            'https://api.telegram.org/bot*' => Http::response(['ok' => true, 'result' => []], 200),
+        ]);
+
+        $botUser = BotUser::create([
+            'chat_id' => '99993333',
+            'platform' => 'vk',
+        ]);
+
+        $name = $this->topicNameFor($botUser);
+
+        $this->assertStringContainsString('Пётр', $name);
+        $this->assertSame('Пётр Сидоров', $botUser->fresh()->display_name);
+    }
+
+    public function test_topic_falls_back_to_id_when_no_profile_is_available(): void
+    {
+        // MAX with no stored name and nothing to enrich → the safe fallback.
+        $botUser = BotUser::create([
+            'chat_id' => '12121212',
+            'platform' => 'max',
+        ]);
+
+        $name = $this->topicNameFor($botUser);
+
+        $this->assertStringContainsString('#12121212', $name);
+        $this->assertStringContainsString('max', $name);
+    }
+
+    public function test_empty_template_falls_back_to_id(): void
+    {
+        app(SettingsService::class)->set('telegram.template_topic_name', '');
+
+        $botUser = BotUser::create([
+            'chat_id' => '34343434',
+            'platform' => 'max',
+            'display_name' => 'Анна',
+        ]);
+
+        $name = $this->topicNameFor($botUser);
+
+        $this->assertStringContainsString('#34343434', $name);
+    }
+}

--- a/tests/Unit/Modules/Max/Services/MaxMessageServiceTest.php
+++ b/tests/Unit/Modules/Max/Services/MaxMessageServiceTest.php
@@ -52,6 +52,35 @@ class MaxMessageServiceTest extends TestCase
         });
     }
 
+    // ── Profile capture (issue #205) ────────────────────────────────────────────
+
+    public function test_incoming_message_stores_sender_name_and_username(): void
+    {
+        // MAX carries the sender's name and @username in the webhook, so the
+        // conversation is labelled with the person rather than a bare id.
+        $payload = $this->basicPayload;
+        $payload['message']['sender']['name'] = 'Иван Петров';
+        $payload['message']['sender']['username'] = 'ivan_p';
+
+        (new MaxMessageService(MaxUpdateDtoMock::getDto($payload)))->handleUpdate();
+
+        $this->botUser->refresh();
+        $this->assertSame('Иван Петров', $this->botUser->display_name);
+        $this->assertSame('ivan_p', $this->botUser->username);
+    }
+
+    public function test_profile_capture_does_not_overwrite_an_existing_name(): void
+    {
+        $this->botUser->update(['display_name' => 'Имя оператора']);
+
+        $payload = $this->basicPayload;
+        $payload['message']['sender']['name'] = 'Иван Петров';
+
+        (new MaxMessageService(MaxUpdateDtoMock::getDto($payload)))->handleUpdate();
+
+        $this->assertSame('Имя оператора', $this->botUser->fresh()->display_name);
+    }
+
     public function test_send_photo_attachment(): void
     {
         $payload = $this->basicPayload;


### PR DESCRIPTION
Closes #205

## Проблема

Имя форум-темы всегда строилось через Telegram `getChat`, а он понимает только Telegram-id. Для диалога из VK или MAX вызов падал, и вся генерация имени откатывалась к голому `#id (platform)` — поэтому тема из Макса показывала только числовой id без имени и профиля.

## Фикс

Именование темы стало **платформо-зависимым**:

- **telegram** — как раньше, живой `getChat`
- **все остальные платформы** — имя берётся из сохранённого профиля `BotUser`

**MAX** передаёт имя и `@username` прямо в вебхуке, поэтому `MaxMessageService::captureProfile()` кладёт их в `BotUser` (только если пусто — заданное вручную имя не перезатирается) до создания темы.

**VK** имени в вебхуке не несёт, поэтому `TopicCreateJob` до-обогащает профиль через существующий `users.get`-джоб, когда `display_name` ещё пуст — чтобы уже первая тема была с именем.

Резолвинг шаблона стал терпимым: отсутствующий параметр (например `{last_name}` для профиля с одним именем) схлопывается в пустую строку, лишние пробелы убираются — вместо обрушения всего имени в fallback. Fallback `#id (platform)` сохранён для честного случая «нет ни имени, ни username».

## Тесты

- `TopicCreateJobProfileNameTest` — имя MAX из профиля, отсутствие фамилии не ломает имя, до-обогащение VK, fallback без профиля и при пустом шаблоне
- Два теста захвата профиля в `MaxMessageServiceTest`

## Проверка

1000 тестов зелёные, Pint и PHPStan level 6 чистые. Бэкенд-правка — пересборка ассетов не требуется.

## Оговорка

Реальные вебхуки VK/MAX я не прогонял — фикс проверен на смоделированных пейлоадах (структура `sender` из MAX подтверждена по `prog-time/max-php-sdk`). Стоит глазами проверить на стенде, что имя из Макса и VK реально появляется в названии темы.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
