### PR TITLE
Release 9.0.0 prep: version bump

### DIFF
--- a/resources/views/components/admin/sidebar.blade.php
+++ b/resources/views/components/admin/sidebar.blade.php
@@ -4,13 +4,13 @@
     Props:
       $title       — sidebar heading text (default "Настройки")
       $backUrl     — URL for the back chevron (default route('admin.chats') or '/admin')
-      $version     — version string shown in footer (default "v8.0.0")
+      $version     — version string shown in footer (default "v9.0.0")
       $docsUrl     — URL for "Документация" footer link (default "https://docs.tg-support-bot.ru/")
 --}}
 @props([
     'title'   => 'Настройки',
     'backUrl' => null,
-    'version' => 'v8.0.0',
+    'version' => 'v9.0.0',
     'docsUrl' => 'https://docs.tg-support-bot.ru/',
 ])
 


### PR DESCRIPTION
## Summary
- Bumps the admin sidebar footer version string from `v8.0.0` to `v9.0.0`, ahead of the v9.0.0 release (built-in Email + Avito channels, `bot_users.chat_id` widening, UX fixes)
- Checked `composer.json` (no `version` field — Laravel skeleton project, none was ever set) and `docs.tg-support-bot.ru` (no app-release-version mentions on the docs site) — neither needs a change

## Test plan
- [x] Pre-commit/pre-push checks (Pint, PHPStan, full `phpunit`) passed

Closes #225