### PR TITLE
Release 9.0.0 — Email channel, Avito core, security & version bump

### DIFF
--- a/resources/views/components/admin/sidebar.blade.php
+++ b/resources/views/components/admin/sidebar.blade.php
@@ -4,13 +4,13 @@
     Props:
       $title       — sidebar heading text (default "Настройки")
       $backUrl     — URL for the back chevron (default route('admin.chats') or '/admin')
-      $version     — version string shown in footer (default "v8.0.0")
+      $version     — version string shown in footer (default "v9.0.0")
       $docsUrl     — URL for "Документация" footer link (default "https://docs.tg-support-bot.ru/")
 --}}
 @props([
     'title'   => 'Настройки',
     'backUrl' => null,
-    'version' => 'v8.0.0',
+    'version' => 'v9.0.0',
     'docsUrl' => 'https://docs.tg-support-bot.ru/',
 ])
 


### PR DESCRIPTION
## Summary

Follow-up release PR — brings the small fixes that landed on `dev` after #220 was merged into `main`.

- #221 — remove stale "Активируйте лицензию в разделе «Подписки»" instruction from the Avito integration page (dead reference to the internal licensing system removed in #141)
- #222 — update `guzzlehttp/guzzle` (7.12.1 → 7.15.1) and `guzzlehttp/psr7` (2.12.1 → 2.13.0), clearing 6 medium-severity advisories disclosed 2026-07-20/21 (incl. CVE-2026-59883, CVE-2026-59882)
- #225 — bump the admin sidebar footer version string to `v9.0.0`

## Test plan
- [x] All CI checks green on each source PR (#223, #224, #226)
- [x] Full `phpunit` suite (1090 tests) passing

Closes #221, #222, #225
