### PR TITLE
issues-46 | notice on unsupported Telegram message types instead of silent drop

### DIFF
--- a/app/Helpers/TelegramHelper.php
+++ b/app/Helpers/TelegramHelper.php
@@ -103,4 +103,55 @@ class TelegramHelper
 
         return null;
     }
+
+    /**
+     * Detect a Telegram message content type this bot does not handle
+     * (video, GIF, audio, poll, dice, venue, game), returning a
+     * human-readable Russian label for the unsupported-message notice.
+     *
+     * Returns null for any recognized/handled type, so callers can tell
+     * "genuinely unsupported" apart from "just has no text" (e.g. service
+     * messages).
+     *
+     * @param array $data
+     *
+     * @return string|null
+     */
+    public static function detectUnsupportedType(array $data): ?string
+    {
+        $message = $data['message'] ?? [];
+
+        return match (true) {
+            !empty($message['video']) => 'видео',
+            !empty($message['animation']) => 'GIF-анимация',
+            !empty($message['audio']) => 'аудио',
+            !empty($message['poll']) => 'опрос',
+            !empty($message['dice']) => 'игральная кость',
+            !empty($message['venue']) => 'место (геометка)',
+            !empty($message['game']) => 'игра',
+            default => null,
+        };
+    }
+
+    /**
+     * Build the placeholder notice text for a message content type this
+     * bot does not handle, so the conversation is not silently dropped
+     * (issue #46). Returns null when the update is not one of the
+     * recognized unsupported types — callers should fall back to their
+     * normal text/caption resolution in that case.
+     *
+     * @param array $data
+     *
+     * @return string|null
+     */
+    public static function buildUnsupportedTypeNotice(array $data): ?string
+    {
+        $type = self::detectUnsupportedType($data);
+
+        if ($type === null) {
+            return null;
+        }
+
+        return "⚠️ Клиент отправил сообщение неподдерживаемого типа ({$type}). Попросите переслать текстом, фото, документом или голосовым.";
+    }
 }

--- a/app/Modules/Telegram/Controllers/TelegramBotController.php
+++ b/app/Modules/Telegram/Controllers/TelegramBotController.php
@@ -2,6 +2,7 @@
 
 namespace App\Modules\Telegram\Controllers;
 
+use App\Helpers\TelegramHelper;
 use App\Models\BotUser;
 use App\Models\Message;
 use App\Modules\Admin\Services\ChannelStatusService;
@@ -30,6 +31,7 @@ use App\Modules\Telegram\Services\TgVk\TgVkEditService;
 use App\Modules\Telegram\Services\TgVk\TgVkMessageService;
 use App\Services\Settings\SettingsService;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 
 class TelegramBotController
 {
@@ -39,10 +41,21 @@ class TelegramBotController
 
     private ?BotUser $botUser;
 
+    /**
+     * Resolves the sender from the Telegram update. When the update type
+     * can't be parsed, or no matching BotUser is found, logs to the
+     * `telegram` channel instead of a silent drop, then aborts with 200 so
+     * Telegram doesn't retry indefinitely (issue #46).
+     *
+     * @param Request $request
+     */
     public function __construct(Request $request)
     {
         $dataHook = TelegramUpdateDto::fromRequest($request);
         if (empty($dataHook)) {
+            Log::channel('telegram')->warning('TelegramBotController: unrecognized update, could not parse sender', [
+                'keys' => array_keys($request->all()),
+            ]);
             abort(200);
         }
         $this->dataHook = $dataHook;
@@ -56,6 +69,12 @@ class TelegramBotController
         }
 
         if (empty($this->botUser) || empty($this->platform)) {
+            Log::channel('telegram')->warning('TelegramBotController: could not resolve BotUser for update', [
+                'type_query' => $this->dataHook->typeQuery,
+                'type_source' => $this->dataHook->typeSource,
+                'chat_id' => $this->dataHook->chatId,
+                'message_thread_id' => $this->dataHook->messageThreadId,
+            ]);
             abort(200);
         }
     }
@@ -205,21 +224,15 @@ class TelegramBotController
      */
     private function notifyIncomingMessage(): void
     {
-        // Forward to supergroup only when Telegram channel is fully configured.
         if (app(ChannelStatusService::class)->telegram()['connected']
             && !empty((string) app(SettingsService::class)->get('telegram.group_id'))
         ) {
-            // Ensure the forum topic exists first.
             if (empty($this->botUser->topic_id)) {
                 TopicCreateJob::dispatch($this->botUser->id);
             }
 
-            // Group path: TgMessageService dispatches SendTelegramMessageJob which
-            // calls saveMessage() after the group API call succeeds.
             (new TgMessageService($this->dataHook))->handleUpdate();
         } else {
-            // Group-OFF path: persist the incoming message directly so the admin
-            // workspace shows it even when no supergroup is configured.
             $this->persistIncomingTelegramMessage();
         }
     }
@@ -232,25 +245,33 @@ class TelegramBotController
      * persists via SendTelegramMessageJob::saveMessage() instead, so the two
      * branches are mutually exclusive and produce exactly one row each.
      *
+     * Text resolution falls back from `text` to `caption` (media messages)
+     * to a placeholder notice built by TelegramHelper::buildUnsupportedTypeNotice()
+     * for content types Telegram gives no text/caption for — video, GIF,
+     * audio, poll, dice, venue, game (issue #46); it returns null for
+     * genuinely recognized/handled types, leaving normal behavior unchanged.
+     * `from_id` stores the user's Telegram message_id, matching the column
+     * semantics SendTelegramMessageJob uses, so reply threading stays
+     * consistent if the group is enabled later.
+     *
      * @return void
      */
     private function persistIncomingTelegramMessage(): void
     {
         try {
+            $text = $this->dataHook->text
+                ?? $this->dataHook->caption
+                ?? TelegramHelper::buildUnsupportedTypeNotice($this->dataHook->rawData ?? []);
+
             $message = Message::create([
                 'bot_user_id' => $this->botUser->id,
                 'platform' => $this->botUser->platform,
                 'message_type' => 'incoming',
-                // from_id: the user's Telegram message_id — matches the column
-                // semantics used by SendTelegramMessageJob (where from_id = updateDto->messageId)
-                // so in-group reply threading stays consistent if the group is later enabled.
                 'from_id' => $this->dataHook->messageId ?? 0,
                 'to_id' => 0,
-                // Capture caption for media messages (photo / document) per BR-002a.
-                'text' => $this->dataHook->text ?? $this->dataHook->caption ?? null,
+                'text' => $text,
             ]);
 
-            // Persist any media attachment so the admin can preview it.
             if (!empty($this->dataHook->fileId)) {
                 $message->attachments()->create([
                     'file_id' => $this->dataHook->fileId,

--- a/app/Modules/Telegram/Jobs/SendTelegramMessageJob.php
+++ b/app/Modules/Telegram/Jobs/SendTelegramMessageJob.php
@@ -124,6 +124,11 @@ class SendTelegramMessageJob extends AbstractSendMessageJob
     /**
      * Save message to database after successful sending.
      *
+     * Incoming text falls back from `text` to `caption` (photo/document
+     * carry it there) to `queryParams->text` — the latter covers content
+     * types Telegram gives no text/caption for at all: contacts, and the
+     * unsupported-type placeholder from TgMessageService::sendUnsupportedTypeNotice().
+     *
      * @param BotUser $botUser
      * @param mixed   $resultQuery
      *
@@ -141,10 +146,8 @@ class SendTelegramMessageJob extends AbstractSendMessageJob
             'message_type' => $this->typeMessage,
             'from_id' => $this->updateDto->messageId,
             'to_id' => $resultQuery->message_id,
-            // Photos/documents carry their text in `caption`, not `text` —
-            // fall back to it so the caption is persisted (and shown in the admin).
             'text' => $this->typeMessage === 'incoming'
-                ? ($this->updateDto->text ?? $this->updateDto->caption ?? null)
+                ? ($this->updateDto->text ?? $this->updateDto->caption ?? $this->queryParams->text ?? null)
                 : ($this->queryParams->text ?? $this->queryParams->caption ?? null),
         ]);
 
@@ -191,6 +194,5 @@ class SendTelegramMessageJob extends AbstractSendMessageJob
      */
     protected function editMessage(BotUser $botUser, mixed $resultQuery): void
     {
-        //
     }
 }

--- a/app/Modules/Telegram/Services/Tg/TgMessageService.php
+++ b/app/Modules/Telegram/Services/Tg/TgMessageService.php
@@ -2,6 +2,7 @@
 
 namespace App\Modules\Telegram\Services\Tg;
 
+use App\Helpers\TelegramHelper;
 use App\Models\Message;
 use App\Modules\Telegram\Actions\ConversionMessageText;
 use App\Modules\Telegram\DTOs\TelegramUpdateDto;
@@ -44,6 +45,8 @@ class TgMessageService extends FromTgMessageService
                 $this->sendContact();
             } elseif (!empty($this->update->text)) {
                 $this->sendMessage();
+            } else {
+                $this->sendUnsupportedTypeNotice();
             }
 
             $this->setReplyParameters();
@@ -200,6 +203,30 @@ class TgMessageService extends FromTgMessageService
     }
 
     /**
+     * Fallback for a Telegram message content type this bot does not
+     * handle (video, GIF, audio, poll, dice, venue, game): instead of
+     * silently dispatching a job with no text, fill in a placeholder
+     * notice so the manager sees that the client sent something and is
+     * waiting (issue #46).
+     *
+     * methodQuery/chat_id/message_thread_id are already set to sendMessage
+     * routing by the parent constructor — only text needs filling in here.
+     *
+     * @return void
+     */
+    protected function sendUnsupportedTypeNotice(): void
+    {
+        $notice = TelegramHelper::buildUnsupportedTypeNotice($this->update->rawData ?? []);
+
+        if ($notice !== null) {
+            $this->messageParamsDTO->text = $notice;
+        }
+    }
+
+    /**
+     * Telegram rejects sendMessage with empty text, so when the manager's
+     * message is only button syntax, substitute a non-breaking space.
+     *
      * @return void
      */
     protected function sendMessage(): void
@@ -215,8 +242,6 @@ class TgMessageService extends FromTgMessageService
             $text = $parsedMessage->text;
             $keyboard = $keyboardBuilder->buildTelegramKeyboard($parsedMessage);
 
-            // Telegram rejects sendMessage with empty text.
-            // When manager sends only button syntax, use a non-breaking space.
             if ($text === '' && $keyboard !== null) {
                 $text = "\u{200B}";
             }

--- a/app/Modules/Telegram/Services/TgEmail/TgEmailMessageService.php
+++ b/app/Modules/Telegram/Services/TgEmail/TgEmailMessageService.php
@@ -8,7 +8,10 @@ use App\Modules\Email\DTOs\EmailMessageDto;
 use App\Modules\Email\Jobs\SendEmailMessageJob;
 use App\Modules\Email\Services\EmailThreadStore;
 use App\Modules\Telegram\DTOs\TelegramUpdateDto;
+use App\Modules\Telegram\DTOs\TGTextMessageDto;
+use App\Modules\Telegram\Jobs\SendTelegramSimpleQueryJob;
 use App\Modules\Telegram\Services\ActionService\Send\FromTgMessageService;
+use App\Services\Settings\SettingsService;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
@@ -25,6 +28,11 @@ use Illuminate\Support\Str;
  * typed into the topic is forwarded as a real SMTP attachment (see
  * {@see self::sendFileReply()}) — mirrors `SendReplyAction::sendEmailReply()`,
  * the admin-panel counterpart of this same capability.
+ *
+ * Contacts are detected via the raw payload (`rawData['message']['contact']`)
+ * rather than `fileId`/`fileType`, matching {@see \App\Modules\Telegram\Services\Tg\TgMessageService}'s
+ * own contact check — Telegram contacts have no `file_id`, so
+ * `TelegramHelper::extractFileId()` has no branch for them.
  */
 class TgEmailMessageService extends FromTgMessageService
 {
@@ -49,8 +57,20 @@ class TgEmailMessageService extends FromTgMessageService
                 $this->sendPhoto();
             } elseif (!empty($this->update->fileId) && $this->update->fileType === 'document') {
                 $this->sendDocument();
+            } elseif (!empty($this->update->fileId) && $this->update->fileType === 'voice') {
+                $this->sendVoice();
+            } elseif (!empty($this->update->fileId) && $this->update->fileType === 'sticker') {
+                $this->sendSticker();
+            } elseif (!empty($this->update->fileId) && $this->update->fileType === 'video_note') {
+                $this->sendVideoNote();
+            } elseif (!empty($this->update->rawData['message']['contact'] ?? null)) {
+                $this->sendContact();
+            } elseif (!empty($this->update->location)) {
+                $this->sendLocation();
             } elseif (!empty($text)) {
                 $this->sendMessage($text);
+            } else {
+                $this->notifyUnsupportedReplyType('это сообщение');
             }
         } catch (\Throwable $e) {
             Log::channel('app')->log(
@@ -62,6 +82,10 @@ class TgEmailMessageService extends FromTgMessageService
     }
 
     /**
+     * The send job only sends — this handler records the outgoing row
+     * itself (BR-002: every sent message stored), which is also what makes
+     * the reply visible in /admin/chats.
+     *
      * @param string $text
      *
      * @return void
@@ -72,10 +96,6 @@ class TgEmailMessageService extends FromTgMessageService
             return;
         }
 
-        // The send job only sends; the /admin/chats path records the row via
-        // SendReplyAction, so the group-topic path records it here to keep
-        // BR-002 (every sent message stored) and to surface the reply in the
-        // admin workspace.
         Message::create([
             'bot_user_id' => $this->botUser->id,
             'platform' => $this->botUser->platform,
@@ -129,6 +149,9 @@ class TgEmailMessageService extends FromTgMessageService
      * and a permanent `local`-disk copy under `chat-attachments/` for the
      * admin workspace.
      *
+     * Mirrors sendMessage(): the send job only sends, so this records the
+     * outgoing row itself (BR-002, admin workspace).
+     *
      * @param string|null $fallbackExtension Used when neither the original filename nor the CDN URL has one (Telegram photos).
      * @param string|null $originalName      The document's original filename, if Telegram sent one.
      *
@@ -173,8 +196,6 @@ class TgEmailMessageService extends FromTgMessageService
 
         $caption = $this->update->caption ?? '';
 
-        // Mirrors sendMessage(): the send job only sends, so the group-topic
-        // path records the outgoing row itself (BR-002, admin workspace).
         $message = Message::create([
             'bot_user_id' => $this->botUser->id,
             'platform' => $this->botUser->platform,
@@ -211,7 +232,7 @@ class TgEmailMessageService extends FromTgMessageService
      */
     protected function sendLocation(): void
     {
-        //
+        $this->notifyUnsupportedReplyType('геолокацию');
     }
 
     /**
@@ -219,7 +240,7 @@ class TgEmailMessageService extends FromTgMessageService
      */
     protected function sendVoice(): void
     {
-        //
+        $this->notifyUnsupportedReplyType('голосовое сообщение');
     }
 
     /**
@@ -227,7 +248,7 @@ class TgEmailMessageService extends FromTgMessageService
      */
     protected function sendSticker(): void
     {
-        //
+        $this->notifyUnsupportedReplyType('стикер');
     }
 
     /**
@@ -235,7 +256,7 @@ class TgEmailMessageService extends FromTgMessageService
      */
     protected function sendVideoNote(): void
     {
-        //
+        $this->notifyUnsupportedReplyType('видеосообщение (кружок)');
     }
 
     /**
@@ -243,6 +264,41 @@ class TgEmailMessageService extends FromTgMessageService
      */
     protected function sendContact(): void
     {
-        //
+        $this->notifyUnsupportedReplyType('контакт');
+    }
+
+    /**
+     * A manager's reply typed in the topic used a message type Email delivery
+     * doesn't support (only text or a single photo/document attachment can be
+     * delivered — see sendPhoto()/sendDocument()). Rather than silently
+     * dropping it (issue #46 follow-up), post an informational notice back
+     * into the SAME supergroup topic so the manager knows nothing reached
+     * the customer and can resend in a supported format.
+     *
+     * Deliberately does NOT create a `messages` row — nothing was actually
+     * sent to/from the customer, so recording an "outgoing" row would be
+     * misleading.
+     *
+     * @param string $typeLabel Human-readable Russian label for what was sent, e.g. "стикер".
+     *
+     * @return void
+     */
+    protected function notifyUnsupportedReplyType(string $typeLabel): void
+    {
+        if ($this->botUser === null || empty($this->botUser->topic_id)) {
+            return;
+        }
+
+        $groupId = (string) app(SettingsService::class)->get('telegram.group_id');
+        if ($groupId === '') {
+            return;
+        }
+
+        SendTelegramSimpleQueryJob::dispatch(TGTextMessageDto::from([
+            'methodQuery' => 'sendMessage',
+            'chat_id' => $groupId,
+            'message_thread_id' => $this->botUser->topic_id,
+            'text' => "⚠️ Email не поддерживает {$typeLabel} — только текст, фото или документ. Сообщение клиенту не доставлено.",
+        ]));
     }
 }

--- a/rules/domain/messaging.md
+++ b/rules/domain/messaging.md
@@ -2,7 +2,7 @@
 
 > **Purpose:** This file defines business rules, state machines, and invariants for the core messaging domain — the routing of messages between users (Telegram, VK, External) and the support team.
 > **Context:** Read this file before modifying anything related to message sending, editing, routing, or platform integrations.
-> **Version:** 1.1
+> **Version:** 1.3
 
 ---
 
@@ -139,6 +139,18 @@ _Enforced in:_ `app/Modules/Telegram/Services/Tg/TgMessageService.php`
 
 **BR-014 (DEFERRED, issue #172)** — AI Accept-callback operator attribution (`DeliverAiAnswerToUser`, `TelegramBotController` Accept handler) — AI paths continue to pass `null` as the author until a dedicated task implements it.
 
+**BR-018 (issue #46, unsupported Telegram content types)** — A Telegram message content type this bot does not handle (`video`, `animation`/GIF, `audio`, `poll`, `dice`, `venue`, `game`) must not be silently dropped. `TelegramHelper::detectUnsupportedType()`/`buildUnsupportedTypeNotice()` recognize these seven types from the raw update and produce a human-readable Russian placeholder notice (e.g. "⚠️ Клиент отправил сообщение неподдерживаемого типа (видео). Попросите переслать текстом, фото, документом или голосовым."). The notice is injected wherever the normal text/caption would have gone, so it flows through the **existing** incoming-message pipeline unchanged:
+- **Group ON:** `TgMessageService::sendUnsupportedTypeNotice()` fills `messageParamsDTO->text` (the group-forward message body). `SendTelegramMessageJob::saveMessage()` falls back to `queryParams->text` when `updateDto->text`/`caption` are both empty, so the same notice is also what lands in `messages.text` — visible in both the supergroup topic and `/admin/chats`.
+- **Group OFF:** `TelegramBotController::persistIncomingTelegramMessage()` falls back to `TelegramHelper::buildUnsupportedTypeNotice()` when `text`/`caption` are both empty.
+- **Unresolvable sender** (unrecognized top-level update type, or no matching `BotUser`): `TelegramBotController::__construct()` logs to `Log::channel('telegram')` (the `prog-time/tg-logger` ops channel — previously configured but unused anywhere in the codebase) instead of a bare `abort(200)`. Only non-PII context is logged (update keys, `type_source`, `chat_id`, `message_thread_id` — never the message text itself).
+- No manager-facing auto-reply is sent to the customer — the notice is informational only, for the support team to see and act on manually.
+- Out of scope for this rule: actually implementing real `video`/`audio` sending (the Telegram API methods exist in `TelegramMethods.php` but nothing calls them); the equivalent fall-through in `VkUpdateDto`/`MaxUpdateDto` (separate, not yet addressed).
+
+_Enforced in:_ `app/Helpers/TelegramHelper.php @ detectUnsupportedType()/buildUnsupportedTypeNotice()`, `app/Modules/Telegram/Services/Tg/TgMessageService.php @ sendUnsupportedTypeNotice()`, `app/Modules/Telegram/Jobs/SendTelegramMessageJob.php @ saveMessage()`, `app/Modules/Telegram/Controllers/TelegramBotController.php @ __construct()/persistIncomingTelegramMessage()`
+
+**BR-019 (issue #46 follow-up, unsupported Email reply types)** — The mirror-image case of BR-018: a **manager's** reply typed in the Telegram supergroup topic for an `email`-platform `BotUser` must not be silently dropped either. `TgEmailMessageService` only knows how to deliver text or a single photo/document as SMTP (mirrors `SendReplyAction::sendEmailReply()`'s admin-panel capability). For `voice`, `sticker`, `video_note`, `contact`, and `location` — previously empty no-op stubs that `handleUpdate()` never even called — the manager now gets an informational notice posted back into the **same** topic ("⚠️ Email не поддерживает {тип} — только текст, фото или документ. Сообщение клиенту не доставлено."), via `SendTelegramSimpleQueryJob` targeting `telegram.group_id` + the `BotUser`'s `topic_id`. Unlike BR-018, this notice is **not** persisted to `messages` — nothing was actually sent to or from the customer, so an "outgoing" row would misrepresent what happened. Contact detection uses the raw payload (`rawData['message']['contact']`), not `fileId`/`fileType`, because Telegram contacts have no `file_id` — `TelegramHelper::extractFileId()` never sets one for them.
+_Enforced in:_ `app/Modules/Telegram/Services/TgEmail/TgEmailMessageService.php @ handleUpdate()/notifyUnsupportedReplyType()/sendVoice()/sendSticker()/sendVideoNote()/sendContact()/sendLocation()`
+
 ---
 
 ## 5. Message Type State Machine
@@ -189,7 +201,8 @@ stateDiagram-v2
 - Files are downloaded from Telegram and stored locally in `storage/app/`
 - Files are served via `FilesController` (`GET /api/files/{file_id}`)
 - File metadata (file_id, file_type, file_name) is stored in `external_messages` table
-- Supported file types: photo, document, audio, video, voice
+- Fully handled incoming/outgoing file types: photo, document, voice, sticker, video_note, contact (location has partial support — no attachment file, just coordinates)
+- **`audio` and `video` are NOT actually handled** despite earlier claims in this file — no code path in `TgMessageService`, `TgEmailMessageService`, `TgExternalMessageService`, `TgVkMessageService`, or `TgMaxMessageService` sends them, even though `TelegramMethods.php` defines the `sendAudio`/`sendVideo` API method mappings. As of issue #46, an incoming `video`/`audio` update produces the unsupported-type placeholder notice (BR-018) instead of silently dropping — but real video/audio sending is still unimplemented
 
 ---
 
@@ -238,3 +251,10 @@ $keyboard = ['inline_keyboard' => [[['text' => 'Yes', 'callback_data' => 'yes']]
 - [ ] File handling rules documented
 - [ ] Button rules documented
 - [ ] No forbidden behaviors
+
+---
+
+## Changelog
+
+- 1.3 — Added BR-019 (issue #46 follow-up): manager replies to Email users via voice/sticker/video_note/contact/location, typed in the Telegram group topic, previously vanished silently (empty no-op stubs `handleUpdate()` never called) — now post an informational notice back into the topic instead
+- 1.2 — Added BR-018 (issue #46): unsupported Telegram content types (video/animation/audio/poll/dice/venue/game) now produce a placeholder notice instead of being silently dropped; unresolvable-sender cases log to `Log::channel('telegram')` instead of a bare `abort(200)`. Corrected §8 File Handling — `audio`/`video` were never actually handled despite being listed as "supported"

--- a/tests/Feature/Jobs/SendTelegramMessageJobIncomingMediaTest.php
+++ b/tests/Feature/Jobs/SendTelegramMessageJobIncomingMediaTest.php
@@ -122,6 +122,35 @@ class SendTelegramMessageJobIncomingMediaTest extends TestCase
         ]);
     }
 
+    /**
+     * issue #46 — when Telegram gives no text/caption at all (e.g. video,
+     * poll, GIF), the unsupported-type placeholder built into
+     * queryParams->text by TgMessageService::sendUnsupportedTypeNotice()
+     * must still end up in messages.text — it's the only "real" content
+     * we have to show the manager.
+     */
+    public function test_incoming_unsupported_type_falls_back_to_query_params_text(): void
+    {
+        $botUser = $this->makeBotUser();
+
+        // No 'text', no 'caption' — mirrors a video/poll/etc. update.
+        $dto = $this->incomingDtoWith([], $botUser);
+
+        $params = TGTextMessageDto::from([
+            'methodQuery' => 'sendMessage',
+            'chat_id' => '-100123456',
+            'text' => '⚠️ Клиент отправил сообщение неподдерживаемого типа (видео). Попросите переслать текстом, фото, документом или голосовым.',
+        ]);
+
+        (new SendTelegramMessageJob($botUser->id, $dto, $params, 'incoming', $this->mockTelegram()))->handle();
+
+        $this->assertDatabaseHas('messages', [
+            'bot_user_id' => $botUser->id,
+            'message_type' => 'incoming',
+            'text' => '⚠️ Клиент отправил сообщение неподдерживаемого типа (видео). Попросите переслать текстом, фото, документом или голосовым.',
+        ]);
+    }
+
     public function test_incoming_plain_text_still_saved(): void
     {
         $botUser = $this->makeBotUser();

--- a/tests/Feature/Modules/Telegram/IncomingMessagePersistenceTest.php
+++ b/tests/Feature/Modules/Telegram/IncomingMessagePersistenceTest.php
@@ -219,6 +219,44 @@ class IncomingMessagePersistenceTest extends TestCase
         ]);
     }
 
+    /**
+     * issue #46 — a Telegram content type this bot doesn't handle (video,
+     * GIF, audio, poll, dice, venue, game) must not be silently dropped:
+     * with the group OFF, persistIncomingTelegramMessage() must fall back
+     * to the unsupported-type placeholder notice instead of null text.
+     */
+    public function test_telegram_incoming_unsupported_type_with_group_off_persists_notice(): void
+    {
+        Queue::fake();
+
+        $this->seedSettings([
+            'telegram.token' => 'bot:TOKEN',
+            'telegram.secret_key' => 'test-secret',
+        ]);
+        $this->clearGroupId();
+
+        $botUser = BotUser::create(['chat_id' => 789012, 'platform' => 'telegram']);
+
+        $payload = $this->telegramPayload($botUser, [
+            'video' => ['file_id' => 'VIDEO_FILE_ID', 'duration' => 12],
+        ]);
+        // Videos carry no 'text' field.
+        unset($payload['message']['text']);
+
+        $this->postTgWebhook($payload)->assertOk();
+
+        $message = Message::where('bot_user_id', $botUser->id)->where('message_type', 'incoming')->first();
+        $this->assertNotNull($message, 'Expected an incoming message row even for an unsupported content type');
+        $this->assertNotNull($message->text, 'Expected the unsupported-type placeholder, not null');
+        $this->assertStringContainsString('видео', $message->text);
+
+        // Exactly one row — no duplicate.
+        $this->assertSame(
+            1,
+            Message::where('bot_user_id', $botUser->id)->where('message_type', 'incoming')->count()
+        );
+    }
+
     // ── Telegram — group ON ───────────────────────────────────────────────────
 
     /**

--- a/tests/Unit/Helpers/TelegramHelperTest.php
+++ b/tests/Unit/Helpers/TelegramHelperTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\Helpers;
 
 use App\Helpers\TelegramHelper;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class TelegramHelperTest extends TestCase
@@ -208,5 +209,66 @@ class TelegramHelperTest extends TestCase
         $fileId = TelegramHelper::extractFileId($data);
 
         $this->assertEquals('photo_id', $fileId);
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function unsupportedTypeProvider(): array
+    {
+        return [
+            'video' => ['video', 'видео'],
+            'animation (GIF)' => ['animation', 'GIF-анимация'],
+            'audio' => ['audio', 'аудио'],
+            'poll' => ['poll', 'опрос'],
+            'dice' => ['dice', 'игральная кость'],
+            'venue' => ['venue', 'место (геометка)'],
+            'game' => ['game', 'игра'],
+        ];
+    }
+
+    /**
+     * issue #46 — each of the seven unhandled Telegram content types must
+     * resolve to a distinct, human-readable Russian label.
+     */
+    #[DataProvider('unsupportedTypeProvider')]
+    public function test_detect_unsupported_type_for_each_known_type(string $telegramKey, string $expectedLabel): void
+    {
+        $data = [
+            'message' => [
+                $telegramKey => ['some' => 'payload'],
+            ],
+        ];
+
+        $this->assertEquals($expectedLabel, TelegramHelper::detectUnsupportedType($data));
+    }
+
+    public function test_detect_unsupported_type_returns_null_for_recognized_types(): void
+    {
+        $data = ['message' => ['text' => 'Hello world']];
+
+        $this->assertNull(TelegramHelper::detectUnsupportedType($data));
+    }
+
+    public function test_detect_unsupported_type_returns_null_when_no_message(): void
+    {
+        $this->assertNull(TelegramHelper::detectUnsupportedType([]));
+    }
+
+    public function test_build_unsupported_type_notice_includes_the_label(): void
+    {
+        $data = ['message' => ['video' => ['file_id' => 'v1']]];
+
+        $notice = TelegramHelper::buildUnsupportedTypeNotice($data);
+
+        $this->assertNotNull($notice);
+        $this->assertStringContainsString('видео', $notice);
+    }
+
+    public function test_build_unsupported_type_notice_returns_null_for_recognized_types(): void
+    {
+        $data = ['message' => ['photo' => [['file_id' => 'p1']]]];
+
+        $this->assertNull(TelegramHelper::buildUnsupportedTypeNotice($data));
     }
 }

--- a/tests/Unit/Modules/Telegram/Controllers/TelegramBotControllerTest.php
+++ b/tests/Unit/Modules/Telegram/Controllers/TelegramBotControllerTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Unit\Modules\Telegram\Controllers;
+
+use App\Modules\Telegram\Controllers\TelegramBotController;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Tests\TestCase;
+
+/**
+ * issue #46 — when a Telegram webhook update can't be resolved to a known
+ * sender (unrecognized top-level update type, or no matching BotUser),
+ * TelegramBotController must log to the `telegram` channel instead of
+ * silently dropping the update, while still aborting with 200 (a non-2xx
+ * response makes Telegram retry indefinitely).
+ *
+ * Constructed directly (bypassing the HTTP kernel / TelegramQuery
+ * middleware) so the only Log:: call in play is the one under test —
+ * TelegramQuery::logRequest() also calls Log::channel('app') on every
+ * request, which would collide with a full-request Log mock.
+ */
+class TelegramBotControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function assertAbortsWith200(Request $request): void
+    {
+        try {
+            new TelegramBotController($request);
+            $this->fail('Expected the constructor to abort(200)');
+        } catch (HttpException $e) {
+            $this->assertSame(200, $e->getStatusCode());
+        }
+    }
+
+    public function test_unrecognized_update_type_logs_to_telegram_channel(): void
+    {
+        Log::shouldReceive('channel')->once()->with('telegram')->andReturnSelf();
+        Log::shouldReceive('warning')->once()->withArgs(
+            fn (string $message, array $context) => str_contains($message, 'unrecognized update')
+                && array_key_exists('keys', $context)
+        );
+
+        // No 'message' / 'edited_message' / 'callback_query' / 'inline_query' /
+        // 'chat_member' key — TelegramUpdateDto::detectType() returns 'unknown'.
+        $request = Request::create('api/telegram/bot', 'POST', [
+            'update_id' => 999001,
+            'poll_answer' => ['poll_id' => 'abc'],
+        ]);
+
+        $this->assertAbortsWith200($request);
+    }
+
+    public function test_unresolvable_bot_user_logs_to_telegram_channel(): void
+    {
+        Log::shouldReceive('channel')->once()->with('telegram')->andReturnSelf();
+        Log::shouldReceive('warning')->once()->withArgs(
+            fn (string $message, array $context) => str_contains($message, 'could not resolve BotUser')
+                && $context['type_source'] === 'supergroup'
+        );
+
+        // A supergroup message whose message_thread_id matches no existing
+        // BotUser topic — getByTopicId() returns null.
+        $request = Request::create('api/telegram/bot', 'POST', [
+            'update_id' => 999002,
+            'message' => [
+                'message_id' => 1,
+                'message_thread_id' => 999999999,
+                'from' => [
+                    'id' => 555,
+                    'is_bot' => false,
+                    'first_name' => 'Test',
+                ],
+                'chat' => [
+                    'id' => -100999999,
+                    'type' => 'supergroup',
+                ],
+                'date' => time(),
+                'text' => 'orphaned topic message',
+            ],
+        ]);
+
+        $this->assertAbortsWith200($request);
+    }
+}

--- a/tests/Unit/Modules/Telegram/Jobs/SendTelegramMessageJobTest.php
+++ b/tests/Unit/Modules/Telegram/Jobs/SendTelegramMessageJobTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Tests\Unit\Modules\Telegram\Jobs;
+
+use App\Models\BotUser;
+use App\Modules\Telegram\Api\TelegramMethods;
+use App\Modules\Telegram\DTOs\TGTextMessageDto;
+use App\Modules\Telegram\Jobs\SendTelegramMessageJob;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Mocks\Tg\Answer\TelegramAnswerDtoMock;
+use Tests\Mocks\Tg\TelegramUpdateDtoMock;
+use Tests\TestCase;
+
+/**
+ * issue #46 — SendTelegramMessageJob::saveMessage() must fall back to
+ * queryParams->text for incoming messages when Telegram gave no text/caption
+ * at all (video, poll, GIF, dice, venue, game): that's where
+ * TgMessageService::sendUnsupportedTypeNotice() puts its placeholder, and
+ * without the fallback the notice would reach the topic but never land in
+ * the messages table.
+ */
+class SendTelegramMessageJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeBotUser(): BotUser
+    {
+        return BotUser::create([
+            'chat_id' => 800800,
+            'platform' => 'telegram',
+            'topic_id' => 5252,
+        ]);
+    }
+
+    private function mockTelegram(): TelegramMethods
+    {
+        /** @var TelegramMethods&\Mockery\MockInterface $mock */
+        $mock = \Mockery::mock(TelegramMethods::class);
+        $mock->shouldReceive('sendQueryTelegram')->andReturn(TelegramAnswerDtoMock::getDto());
+
+        return $mock;
+    }
+
+    public function test_incoming_message_prefers_update_text_over_query_params_text(): void
+    {
+        $botUser = $this->makeBotUser();
+
+        $dto = TelegramUpdateDtoMock::getDto([
+            'update_id' => time(),
+            'message' => [
+                'message_id' => 1,
+                'from' => ['id' => 1, 'is_bot' => false, 'first_name' => 'Test'],
+                'chat' => ['id' => $botUser->chat_id, 'type' => 'private'],
+                'date' => time(),
+                'text' => 'исходный текст клиента',
+            ],
+        ]);
+
+        $params = TGTextMessageDto::from([
+            'methodQuery' => 'sendMessage',
+            'chat_id' => '-100123456',
+            'text' => 'исходный текст клиента',
+        ]);
+
+        (new SendTelegramMessageJob($botUser->id, $dto, $params, 'incoming', $this->mockTelegram()))->handle();
+
+        $this->assertDatabaseHas('messages', [
+            'bot_user_id' => $botUser->id,
+            'message_type' => 'incoming',
+            'text' => 'исходный текст клиента',
+        ]);
+    }
+
+    public function test_incoming_message_with_no_update_text_or_caption_falls_back_to_query_params_text(): void
+    {
+        $botUser = $this->makeBotUser();
+
+        $dto = TelegramUpdateDtoMock::getDto([
+            'update_id' => time(),
+            'message' => [
+                'message_id' => 2,
+                'from' => ['id' => 1, 'is_bot' => false, 'first_name' => 'Test'],
+                'chat' => ['id' => $botUser->chat_id, 'type' => 'private'],
+                'date' => time(),
+            ],
+        ]);
+
+        $params = TGTextMessageDto::from([
+            'methodQuery' => 'sendMessage',
+            'chat_id' => '-100123456',
+            'text' => '⚠️ Клиент отправил сообщение неподдерживаемого типа (видео). Попросите переслать текстом, фото, документом или голосовым.',
+        ]);
+
+        (new SendTelegramMessageJob($botUser->id, $dto, $params, 'incoming', $this->mockTelegram()))->handle();
+
+        $this->assertDatabaseHas('messages', [
+            'bot_user_id' => $botUser->id,
+            'message_type' => 'incoming',
+            'text' => '⚠️ Клиент отправил сообщение неподдерживаемого типа (видео). Попросите переслать текстом, фото, документом или голосовым.',
+        ]);
+    }
+
+    public function test_outgoing_message_saves_query_params_text(): void
+    {
+        $botUser = $this->makeBotUser();
+
+        $dto = TelegramUpdateDtoMock::getDto([
+            'update_id' => time(),
+            'message' => [
+                'message_id' => 3,
+                'message_thread_id' => 5252,
+                'from' => ['id' => 999, 'is_bot' => false, 'first_name' => 'Manager'],
+                'chat' => ['id' => -100999999, 'type' => 'supergroup'],
+                'date' => time(),
+                'text' => 'ответ менеджера',
+            ],
+        ]);
+
+        $params = TGTextMessageDto::from([
+            'methodQuery' => 'sendMessage',
+            'chat_id' => $botUser->chat_id,
+            'text' => 'ответ менеджера',
+        ]);
+
+        (new SendTelegramMessageJob($botUser->id, $dto, $params, 'outgoing', $this->mockTelegram()))->handle();
+
+        $this->assertDatabaseHas('messages', [
+            'bot_user_id' => $botUser->id,
+            'message_type' => 'outgoing',
+            'text' => 'ответ менеджера',
+        ]);
+    }
+}

--- a/tests/Unit/Modules/Telegram/Services/Tg/TgMessageServiceTest.php
+++ b/tests/Unit/Modules/Telegram/Services/Tg/TgMessageServiceTest.php
@@ -227,6 +227,59 @@ class TgMessageServiceTest extends TestCase
         $this->assertEquals($this->botUser->id, $firstJob->botUserId);
     }
 
+    /**
+     * issue #46 — a Telegram content type this bot doesn't handle (video,
+     * GIF, audio, poll, dice, venue, game) must produce a placeholder
+     * notice instead of an empty dispatched job.
+     */
+    public function test_send_video_produces_unsupported_type_notice(): void
+    {
+        $payload = $this->basicPayload;
+        unset($payload['message']['text']);
+        $payload['message']['video'] = [
+            'file_id' => 'test_video_id',
+            'duration' => 10,
+        ];
+
+        $dto = TelegramUpdateDtoMock::getDto($payload);
+        (new TgMessageService($dto))->handleUpdate();
+
+        /** @phpstan-ignore-next-line */
+        $pushed = Queue::pushedJobs()[SendTelegramMessageJob::class] ?? [];
+        $this->assertCount(1, $pushed);
+
+        $firstJob = $pushed[0]['job'];
+        $this->assertEquals('sendMessage', $firstJob->queryParams->methodQuery);
+        $this->assertNotEmpty($firstJob->queryParams->text);
+        $this->assertStringContainsString('видео', $firstJob->queryParams->text);
+    }
+
+    /**
+     * issue #46 — same as above for a poll, which (unlike video) has
+     * neither a caption-bearing field nor a file_id at all.
+     */
+    public function test_send_poll_produces_unsupported_type_notice(): void
+    {
+        $payload = $this->basicPayload;
+        unset($payload['message']['text']);
+        $payload['message']['poll'] = [
+            'id' => 'poll1',
+            'question' => 'Нравится?',
+            'options' => [],
+        ];
+
+        $dto = TelegramUpdateDtoMock::getDto($payload);
+        (new TgMessageService($dto))->handleUpdate();
+
+        /** @phpstan-ignore-next-line */
+        $pushed = Queue::pushedJobs()[SendTelegramMessageJob::class] ?? [];
+        $this->assertCount(1, $pushed);
+
+        $firstJob = $pushed[0]['job'];
+        $this->assertEquals('sendMessage', $firstJob->queryParams->methodQuery);
+        $this->assertStringContainsString('опрос', $firstJob->queryParams->text);
+    }
+
     public function test_send_message_with_inline_keyboard_from_supergroup(): void
     {
         $payload = $this->basicPayload;

--- a/tests/Unit/Modules/Telegram/Services/TgEmail/TgEmailMessageServiceTest.php
+++ b/tests/Unit/Modules/Telegram/Services/TgEmail/TgEmailMessageServiceTest.php
@@ -6,11 +6,13 @@ use App\Models\BotUser;
 use App\Models\Message;
 use App\Models\MessageAttachment;
 use App\Modules\Email\Jobs\SendEmailMessageJob;
+use App\Modules\Telegram\Jobs\SendTelegramSimpleQueryJob;
 use App\Modules\Telegram\Services\TgEmail\TgEmailMessageService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Storage;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\Mocks\Tg\TelegramUpdateDto_VKMock;
 use Tests\TestCase;
 
@@ -80,6 +82,65 @@ class TgEmailMessageServiceTest extends TestCase
 
         Queue::assertNotPushed(SendEmailMessageJob::class);
         $this->assertDatabaseCount('messages', 0);
+    }
+
+    // ── Unsupported reply types → manager notice, not silent drop ───────────
+
+    /**
+     * @return array<string, array{0: string, 1: array<string, mixed>, 2: string}>
+     */
+    public static function unsupportedReplyTypeProvider(): array
+    {
+        return [
+            'voice' => ['voice', ['file_id' => 'voice_1', 'duration' => 3], 'голосовое сообщение'],
+            'sticker' => ['sticker', ['file_id' => 'sticker_1'], 'стикер'],
+            'video_note' => ['video_note', ['file_id' => 'vn_1', 'duration' => 5, 'length' => 240], 'видеосообщение (кружок)'],
+            'contact' => ['contact', ['phone_number' => '79999999999', 'first_name' => 'Тест'], 'контакт'],
+        ];
+    }
+
+    /**
+     * issue #46 follow-up — a reply type Email can't carry (voice, sticker,
+     * video_note, contact, location) must not be silently dropped: the
+     * manager gets a notice back in the SAME topic, nothing is sent to the
+     * customer, and no `messages` row is created (nothing was delivered).
+     */
+    #[DataProvider('unsupportedReplyTypeProvider')]
+    public function test_unsupported_reply_type_notifies_manager_instead_of_silent_drop(
+        string $telegramKey,
+        array $payloadValue,
+        string $expectedLabel
+    ): void {
+        $payload = $this->basicPayload;
+        unset($payload['message']['text']);
+        $payload['message'][$telegramKey] = $payloadValue;
+
+        (new TgEmailMessageService(TelegramUpdateDto_VKMock::getDto($payload)))->handleUpdate();
+
+        Queue::assertNotPushed(SendEmailMessageJob::class);
+        $this->assertDatabaseCount('messages', 0);
+
+        Queue::assertPushed(SendTelegramSimpleQueryJob::class, function ($job) use ($expectedLabel) {
+            return $job->queryParams->chat_id === $this->defaultGroupId
+                && $job->queryParams->message_thread_id === $this->botUser->topic_id
+                && str_contains((string) $job->queryParams->text, $expectedLabel);
+        });
+    }
+
+    public function test_location_reply_notifies_manager_instead_of_silent_drop(): void
+    {
+        $payload = $this->basicPayload;
+        unset($payload['message']['text']);
+        $payload['message']['location'] = ['latitude' => 55.7, 'longitude' => 37.6];
+
+        (new TgEmailMessageService(TelegramUpdateDto_VKMock::getDto($payload)))->handleUpdate();
+
+        Queue::assertNotPushed(SendEmailMessageJob::class);
+        $this->assertDatabaseCount('messages', 0);
+
+        Queue::assertPushed(SendTelegramSimpleQueryJob::class, function ($job) {
+            return str_contains((string) $job->queryParams->text, 'геолокацию');
+        });
     }
 
     // ── Photo/document reply → SMTP attachment ──────────────────────────────


### PR DESCRIPTION
## Summary
- Customer messages of a Telegram content type the bot doesn't handle (video, animation/GIF, poll, dice, venue, game) no longer vanish silently — a placeholder notice is now persisted/forwarded through the existing incoming-message pipeline, both when the supergroup is configured and when it isn't.
- `TelegramBotController`'s two silent `abort(200)` points (unrecognized update type, unresolvable `BotUser`) now log to `Log::channel('telegram')` first, with non-PII context.
- Mirror-image fix for a follow-up found during manual testing: a manager's reply typed in the group topic that Email can't carry (voice/sticker/video_note/contact/location) now posts a notice back into the same topic instead of being silently dropped by `TgEmailMessageService`.
- `rules/domain/messaging.md` updated with BR-018/BR-019 documenting both behaviors, plus a correction to the previously-inaccurate "audio/video are supported" claim in §8.

Closes #46

## Test plan
- [x] `tests/Unit/Helpers/TelegramHelperTest.php` — new type-detection helpers, all 7 unsupported types
- [x] `tests/Unit/Modules/Telegram/Services/Tg/TgMessageServiceTest.php` — unsupported-type notice for video/poll
- [x] `tests/Feature/Jobs/SendTelegramMessageJobIncomingMediaTest.php`, `tests/Unit/Modules/Telegram/Jobs/SendTelegramMessageJobTest.php` — text/caption fallback in `saveMessage()`
- [x] `tests/Feature/Modules/Telegram/IncomingMessagePersistenceTest.php` — group-OFF persistence path
- [x] `tests/Unit/Modules/Telegram/Controllers/TelegramBotControllerTest.php` — unresolved-sender logging (constructed directly, bypassing HTTP kernel/middleware)
- [x] `tests/Unit/Modules/Telegram/Services/TgEmail/TgEmailMessageServiceTest.php` — unsupported Email reply types notify the manager, no `messages` row created
- [x] Full suite: 1115 tests / 2939 assertions passing; PHPStan level 6 clean; Pint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)