### PR TITLE
Log Telegram token verification failures and exceptions

### DIFF
--- a/app/Modules/Admin/Services/WebhookRegistrationService.php
+++ b/app/Modules/Admin/Services/WebhookRegistrationService.php
@@ -52,27 +52,33 @@ class WebhookRegistrationService
             $result = TelegramMethods::sendQueryTelegram('getMe', [], $token);
 
             if ($result->ok !== true) {
+                Log::channel('app')->error('WebhookRegistrationService: Telegram token verification failed (getMe)', [
+                    'response_code' => $result->response_code,
+                    'type_error' => $result->type_error,
+                    'description' => $result->rawData['description'] ?? null,
+                ]);
+
                 return ['success' => false, 'message' => 'Неверный токен Telegram.', 'botId' => null, 'botUsername' => null];
             }
 
-            // Identity captured from getMe (used for the admin check below and to
-            // auto-store the AI bot id/username).
             $me = $result->rawData['result'] ?? [];
             $botId = isset($me['id']) ? (int) $me['id'] : null;
 
-            // When a group is provided, verify (1) the bot can access the chat and
-            // (2) the bot is an administrator in it.
             if ($groupId !== null && $groupId !== '') {
                 $chat = TelegramMethods::sendQueryTelegram('getChat', ['chat_id' => $groupId], $token);
 
                 if ($chat->ok !== true) {
-                    // Surface Telegram's own reason so a correct-looking ID that still
-                    // fails (bot not added, wrong -100 prefix, chat_id empty, …) is diagnosable.
                     $desc = (string) ($chat->rawData['description'] ?? '');
                     $message = 'Неверный ID группы или бот не добавлен в группу.';
                     if ($desc !== '') {
                         $message .= ' Ответ Telegram: ' . $desc;
                     }
+
+                    Log::channel('app')->error('WebhookRegistrationService: Telegram token verification failed (getChat)', [
+                        'group_id' => $groupId,
+                        'response_code' => $chat->response_code,
+                        'description' => $desc !== '' ? $desc : null,
+                    ]);
 
                     return ['success' => false, 'message' => $message, 'botId' => null, 'botUsername' => null];
                 }
@@ -86,6 +92,12 @@ class WebhookRegistrationService
                     $status = $member->rawData['result']['status'] ?? null;
 
                     if (! in_array($status, ['administrator', 'creator'], true)) {
+                        Log::channel('app')->warning('WebhookRegistrationService: Telegram token verification failed (bot not admin)', [
+                            'group_id' => $groupId,
+                            'bot_id' => $botId,
+                            'status' => $status,
+                        ]);
+
                         return ['success' => false, 'message' => 'Бот добавлен в группу, но без прав администратора.', 'botId' => null, 'botUsername' => null];
                     }
                 }
@@ -97,7 +109,12 @@ class WebhookRegistrationService
                 'botId' => $botId,
                 'botUsername' => isset($me['username']) ? (string) $me['username'] : null,
             ];
-        } catch (\Throwable) {
+        } catch (\Throwable $e) {
+            Log::channel('app')->error('WebhookRegistrationService: Telegram token verification threw an exception', [
+                'exception_class' => get_class($e),
+                'exception_message' => $e->getMessage(),
+            ]);
+
             return ['success' => false, 'message' => 'Не удалось связаться с API платформы.', 'botId' => null, 'botUsername' => null];
         }
     }
@@ -235,7 +252,6 @@ class WebhookRegistrationService
             return ['success' => false, 'message' => 'Токен VK не задан.'];
         }
 
-        // Verify connectivity: call groups.getById — returns group info on success.
         $result = VkMethods::sendQueryVk('groups.getById', []);
 
         if ($result->response_code !== 500 && empty($result->error_message)) {
@@ -257,7 +273,9 @@ class WebhookRegistrationService
      * Register the MAX bot webhook via the Max platform API.
      *
      * Max uses a REST endpoint: POST /subscriptions with {"url": "..."}
-     * authenticated via the bot token in Authorization header.
+     * authenticated via the bot token in Authorization header. The secret is
+     * sent so MAX echoes it back in the `X-Max-Bot-Api-Secret` header on every
+     * webhook — without it, MaxQuery middleware rejects incoming webhooks with 403.
      *
      * @return array{success: bool, message: string}
      */
@@ -269,9 +287,6 @@ class WebhookRegistrationService
             return ['success' => false, 'message' => 'Токен MAX не задан.'];
         }
 
-        // The secret is echoed back by MAX in the `X-Max-Bot-Api-Secret` header on
-        // every webhook; MaxQuery middleware checks it against `max.secret_key`.
-        // Without sending it here, incoming webhooks are rejected with 403.
         $secret = (string) $this->settings->get('max.secret_key');
 
         $appUrl = config('app.url');

--- a/tests/Unit/Modules/Admin/Services/WebhookRegistrationServiceTest.php
+++ b/tests/Unit/Modules/Admin/Services/WebhookRegistrationServiceTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit\Modules\Admin\Services;
 use App\Modules\Admin\Services\WebhookRegistrationService;
 use App\Services\Settings\SettingsService;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 use Mockery;
 use Tests\TestCase;
 
@@ -243,6 +244,30 @@ class WebhookRegistrationServiceTest extends TestCase
         $this->assertStringContainsString('Неверный токен Telegram', $result['message']);
     }
 
+    public function test_verify_telegram_logs_error_when_get_me_fails(): void
+    {
+        Http::fake([
+            'https://api.telegram.org/*' => Http::response([
+                'ok' => false,
+                'description' => 'Unauthorized',
+                'error_code' => 401,
+            ], 401),
+        ]);
+
+        Log::shouldReceive('channel')->with('app')->andReturnSelf();
+        Log::shouldReceive('error')
+            ->once()
+            ->withArgs(function (string $message, array $context) {
+                return str_contains($message, 'getMe')
+                    && ($context['description'] ?? null) === 'Unauthorized';
+            });
+
+        $settings = $this->makeSettings([]);
+        $service = new WebhookRegistrationService($settings);
+
+        $service->verifyTelegram('bad_token');
+    }
+
     public function test_verify_telegram_returns_error_when_group_inaccessible(): void
     {
         Http::fake([
@@ -257,6 +282,49 @@ class WebhookRegistrationServiceTest extends TestCase
 
         $this->assertFalse($result['success']);
         $this->assertStringContainsString('группы', $result['message']);
+    }
+
+    public function test_verify_telegram_logs_error_when_group_inaccessible(): void
+    {
+        Http::fake([
+            'https://api.telegram.org/*/getMe' => Http::response(['ok' => true, 'result' => ['id' => 1, 'is_bot' => true]], 200),
+            'https://api.telegram.org/*/getChat' => Http::response(['ok' => false, 'description' => 'chat not found', 'error_code' => 400], 400),
+        ]);
+
+        Log::shouldReceive('channel')->with('app')->andReturnSelf();
+        Log::shouldReceive('error')
+            ->once()
+            ->withArgs(function (string $message, array $context) {
+                return str_contains($message, 'getChat')
+                    && ($context['group_id'] ?? null) === '-100999999';
+            });
+
+        $settings = $this->makeSettings([]);
+        $service = new WebhookRegistrationService($settings);
+
+        $service->verifyTelegram('bot123:validtoken', '-100999999');
+    }
+
+    public function test_verify_telegram_logs_warning_when_bot_not_admin_in_group(): void
+    {
+        Http::fake([
+            'https://api.telegram.org/*/getMe' => Http::response(['ok' => true, 'result' => ['id' => 1, 'is_bot' => true]], 200),
+            'https://api.telegram.org/*/getChat' => Http::response(['ok' => true, 'result' => ['id' => -1001234567890, 'type' => 'supergroup']], 200),
+            'https://api.telegram.org/*/getChatMember' => Http::response(['ok' => true, 'result' => ['status' => 'member']], 200),
+        ]);
+
+        Log::shouldReceive('channel')->with('app')->andReturnSelf();
+        Log::shouldReceive('warning')
+            ->once()
+            ->withArgs(function (string $message, array $context) {
+                return str_contains($message, 'not admin')
+                    && ($context['status'] ?? null) === 'member';
+            });
+
+        $settings = $this->makeSettings([]);
+        $service = new WebhookRegistrationService($settings);
+
+        $service->verifyTelegram('bot123:validtoken', '-1001234567890');
     }
 
     public function test_verify_telegram_returns_success_with_valid_group(): void


### PR DESCRIPTION
## Summary

Adds structured logging to `WebhookRegistrationService::verifyTelegram()` so every failed Telegram token check (invalid token, inaccessible group, bot not an administrator) and any thrown exception is recorded to the `app` log channel, replacing several silent failure paths at the token-verification step on `/admin/settings/integrations/telegram`.

## Linked issues

Closes #236

## Checklist

- [ ] Tests pass locally
- [ ] Docs / CHANGELOG updated if behavior changed
- [ ] No leftover debug code, prints, or stale TODOs
- [ ] Breaking changes flagged in the summary

## Notes for reviewer

The token itself is never logged — only response codes/descriptions from Telegram, per `rules/process/security.md`. Also removed pre-existing inline `//` comments from the touched file to satisfy the repo's whole-file `no-inline-comments` pre-commit check; one genuinely useful note was preserved by moving it into the existing PHPDoc block on `registerMax()`.

---

_The task was generated using the MCP server — [prog-time/mcp-github-issues](https://github.com/prog-time/mcp-github-issues)._
