### PR TITLE
Show a distinct message when Telegram verification times out

### DIFF
--- a/app/Modules/Admin/Services/WebhookRegistrationService.php
+++ b/app/Modules/Admin/Services/WebhookRegistrationService.php
@@ -7,6 +7,7 @@ namespace App\Modules\Admin\Services;
 use App\Modules\Telegram\Api\TelegramMethods;
 use App\Modules\Vk\Api\VkMethods;
 use App\Services\Settings\SettingsService;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
@@ -23,9 +24,31 @@ use Illuminate\Support\Facades\Log;
  */
 class WebhookRegistrationService
 {
+    private const TIMEOUT_MESSAGE = 'Не удалось подключиться к Telegram API: превышено время ожидания соединения. Проверьте доступность api.telegram.org с сервера (см. настройку TELEGRAM_FORCE_IPV4).';
+
     public function __construct(
         private readonly SettingsService $settings,
     ) {
+    }
+
+    /**
+     * Detect whether a raw failure payload from TelegramMethods::sendQueryTelegram()
+     * represents a connection timeout rather than a Telegram API error response.
+     *
+     * ParserMethods::postQuery() catches transport-level exceptions (including
+     * Illuminate\Http\Client\ConnectionException on timeout) and puts the
+     * exception message into the `result` field, so a string there — instead
+     * of the usual array — signals a transport failure.
+     *
+     * @param mixed $rawResult The `result` field from TelegramAnswerDto::$rawData.
+     */
+    private function isConnectionTimeout(mixed $rawResult): bool
+    {
+        if (! is_string($rawResult) || $rawResult === '') {
+            return false;
+        }
+
+        return str_contains($rawResult, 'cURL error 28') || stripos($rawResult, 'timed out') !== false;
     }
 
     /**
@@ -52,13 +75,18 @@ class WebhookRegistrationService
             $result = TelegramMethods::sendQueryTelegram('getMe', [], $token);
 
             if ($result->ok !== true) {
+                $isTimeout = $this->isConnectionTimeout($result->rawData['result'] ?? null);
+
                 Log::channel('app')->error('WebhookRegistrationService: Telegram token verification failed (getMe)', [
                     'response_code' => $result->response_code,
                     'type_error' => $result->type_error,
                     'description' => $result->rawData['description'] ?? null,
+                    'is_timeout' => $isTimeout,
                 ]);
 
-                return ['success' => false, 'message' => 'Неверный токен Telegram.', 'botId' => null, 'botUsername' => null];
+                $message = $isTimeout ? self::TIMEOUT_MESSAGE : 'Неверный токен Telegram.';
+
+                return ['success' => false, 'message' => $message, 'botId' => null, 'botUsername' => null];
             }
 
             $me = $result->rawData['result'] ?? [];
@@ -69,15 +97,22 @@ class WebhookRegistrationService
 
                 if ($chat->ok !== true) {
                     $desc = (string) ($chat->rawData['description'] ?? '');
-                    $message = 'Неверный ID группы или бот не добавлен в группу.';
-                    if ($desc !== '') {
-                        $message .= ' Ответ Telegram: ' . $desc;
+                    $isTimeout = $this->isConnectionTimeout($chat->rawData['result'] ?? null);
+
+                    if ($isTimeout) {
+                        $message = self::TIMEOUT_MESSAGE;
+                    } else {
+                        $message = 'Неверный ID группы или бот не добавлен в группу.';
+                        if ($desc !== '') {
+                            $message .= ' Ответ Telegram: ' . $desc;
+                        }
                     }
 
                     Log::channel('app')->error('WebhookRegistrationService: Telegram token verification failed (getChat)', [
                         'group_id' => $groupId,
                         'response_code' => $chat->response_code,
                         'description' => $desc !== '' ? $desc : null,
+                        'is_timeout' => $isTimeout,
                     ]);
 
                     return ['success' => false, 'message' => $message, 'botId' => null, 'botUsername' => null];
@@ -110,12 +145,17 @@ class WebhookRegistrationService
                 'botUsername' => isset($me['username']) ? (string) $me['username'] : null,
             ];
         } catch (\Throwable $e) {
+            $isTimeout = $e instanceof ConnectionException || $this->isConnectionTimeout($e->getMessage());
+
             Log::channel('app')->error('WebhookRegistrationService: Telegram token verification threw an exception', [
                 'exception_class' => get_class($e),
                 'exception_message' => $e->getMessage(),
+                'is_timeout' => $isTimeout,
             ]);
 
-            return ['success' => false, 'message' => 'Не удалось связаться с API платформы.', 'botId' => null, 'botUsername' => null];
+            $message = $isTimeout ? self::TIMEOUT_MESSAGE : 'Не удалось связаться с API платформы.';
+
+            return ['success' => false, 'message' => $message, 'botId' => null, 'botUsername' => null];
         }
     }
 

--- a/tests/Unit/Modules/Admin/Services/WebhookRegistrationServiceTest.php
+++ b/tests/Unit/Modules/Admin/Services/WebhookRegistrationServiceTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit\Modules\Admin\Services;
 
 use App\Modules\Admin\Services\WebhookRegistrationService;
 use App\Services\Settings\SettingsService;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Mockery;
@@ -266,6 +267,44 @@ class WebhookRegistrationServiceTest extends TestCase
         $service = new WebhookRegistrationService($settings);
 
         $service->verifyTelegram('bad_token');
+    }
+
+    public function test_verify_telegram_returns_timeout_message_on_connection_timeout(): void
+    {
+        Http::fake(fn () => throw new ConnectionException(
+            'cURL error 28: Connection timed out after 10002 milliseconds (see https://curl.se/libcurl/c/libcurl-errors.html) for https://api.telegram.org/bot123:validtoken/getMe'
+        ));
+
+        $settings = $this->makeSettings([]);
+        $service = new WebhookRegistrationService($settings);
+
+        $result = $service->verifyTelegram('bot123:validtoken');
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('превышено время ожидания', $result['message']);
+    }
+
+    public function test_verify_telegram_logs_is_timeout_true_on_connection_timeout(): void
+    {
+        Http::fake(fn () => throw new ConnectionException(
+            'cURL error 28: Connection timed out after 10002 milliseconds (see https://curl.se/libcurl/c/libcurl-errors.html) for https://api.telegram.org/bot123:validtoken/getMe'
+        ));
+
+        Log::shouldReceive('channel')->with('app')->andReturnSelf();
+        // ParserMethods::postQuery logs the raw transport exception via Log::log()
+        // before WebhookRegistrationService gets a chance to inspect the result.
+        Log::shouldReceive('log')->andReturnNull();
+        Log::shouldReceive('error')
+            ->once()
+            ->withArgs(function (string $message, array $context) {
+                return str_contains($message, 'getMe')
+                    && ($context['is_timeout'] ?? null) === true;
+            });
+
+        $settings = $this->makeSettings([]);
+        $service = new WebhookRegistrationService($settings);
+
+        $service->verifyTelegram('bot123:validtoken');
     }
 
     public function test_verify_telegram_returns_error_when_group_inaccessible(): void


### PR DESCRIPTION
## Summary

Distinguishes a Telegram API connection timeout from a genuinely invalid token/group when verifying credentials on `/admin/settings/integrations/telegram`: `WebhookRegistrationService::verifyTelegram()` now detects transport-level timeouts (curl error 28 / "timed out") in the `getMe`/`getChat` failure paths and surfaces a dedicated, actionable message instead of "Неверный токен Telegram."

## Linked issues

(no linked issue — this branch's original issue, #236, was already closed by the earlier merged PR #240; this change is unrelated to Web Push)

## Checklist

- [ ] Tests pass locally
- [ ] Docs / CHANGELOG updated if behavior changed
- [ ] No leftover debug code, prints, or stale TODOs
- [ ] Breaking changes flagged in the summary

## Notes for reviewer

Builds on the logging added in #240. No behavior change for non-timeout failures; the token itself is still never logged.

---

_The task was generated using the MCP server — [prog-time/mcp-github-issues](https://github.com/prog-time/mcp-github-issues)._
