### PR TITLE
Fix VAPID setup failure in start.sh first-time install

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -76,12 +76,11 @@ run_step "docker compose exec app bash -c 'composer update'" "Обновлени
 # Миграции базы данных
 run_step "docker compose exec app bash -c 'php artisan migrate'" "Применение миграций базы данных"
 
-# Генерация ключа Laravel
-run_step "docker compose exec app bash -c 'php artisan key:generate'" "Генерация ключа приложения Laravel"
+# --force: без него key:generate не перезапишет плейсхолдер APP_KEY при APP_ENV=production.
+run_step "docker compose exec app bash -c 'php artisan key:generate --force'" "Генерация ключа приложения Laravel"
 
-# Генерация VAPID-ключей для Web Push (PWA-уведомления) — как и APP_KEY, поля
-# для них в админке нет, ключи хранятся в settings и создаются только этой командой
-run_step "docker compose exec app bash -c 'php artisan webpush:generate-vapid-keys'" "Генерация VAPID-ключей для Web Push"
+# --force: первичная установка, подписчиков на push ещё нет.
+run_step "docker compose exec app bash -c 'php artisan webpush:generate-vapid-keys --force'" "Генерация VAPID-ключей для Web Push"
 
 # Очистка кэша приложения (в т.ч. закэшированных настроек/интеграций из settings)
 run_step "docker compose exec app bash -c 'php artisan cache:clear'" "Очистка кэша приложения"

--- a/start.sh
+++ b/start.sh
@@ -68,7 +68,7 @@ run_step "sudo certbot certonly --standalone -d $MAIN_DOMAIN" "Выпуск се
 run_step "sed 's|__MAIN_DOMAIN__|$MAIN_DOMAIN|g' docker/nginx/default.conf.template > docker/nginx/default.conf" "Создание конфигурации Nginx"
 
 # Запуск Docker Compose
-run_step "docker-compose up -d --build" "Запуск Docker Compose"
+run_step "docker compose up -d --build" "Запуск Docker Compose"
 
 # Обновление зависимостей Composer
 run_step "docker compose exec app bash -c 'composer update'" "Обновление зависимостей PHP через Composer"


### PR DESCRIPTION
## Summary

`start.sh` (first-time Docker Compose setup) ran `key:generate` and `webpush:generate-vapid-keys` without `--force`. Since `.env.example` ships a non-empty `APP_KEY` placeholder, `key:generate` silently skips on `APP_ENV=production` when run non-interactively (exits 0 without actually writing a key), which then made `webpush:generate-vapid-keys` crash with a Crypt "Unsupported cipher or incorrect key length" error. Both commands now pass `--force`, safe at this fresh-install stage since no real key/subscribers exist yet.

## Linked issues

Closes #238

## Checklist

- [ ] Tests pass locally
- [ ] Docs / CHANGELOG updated if behavior changed
- [ ] No leftover debug code, prints, or stale TODOs
- [ ] Breaking changes flagged in the summary

## Notes for reviewer

If a deployment already hit this and ended up with a half-written VAPID keypair (public key set, private key missing), recovery is a manual one-time run: `docker compose exec app bash -c 'php artisan webpush:generate-vapid-keys --force'`.

---

_The task was generated using the MCP server — [prog-time/mcp-github-issues](https://github.com/prog-time/mcp-github-issues)._
